### PR TITLE
Simplify mpsbuild plugin dependency

### DIFF
--- a/metamodel-export-mps/build.gradle.kts
+++ b/metamodel-export-mps/build.gradle.kts
@@ -1,20 +1,9 @@
 import org.modelix.gradle.mpsbuild.MPSBuildSettings
 
-buildscript {
-    repositories {
-        mavenLocal()
-        maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
-    }
-    dependencies {
-        classpath("org.modelix.mpsbuild:gradle-mpsbuild-plugin:1.0.8")
-    }
-}
-
 plugins {
     base
+    id("org.modelix.mpsbuild") version "1.0.8"
 }
-
-apply(plugin = "modelix-gradle-mpsbuild-plugin")
 
 val generatorLibs by configurations.creating
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,12 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'modelix.core'
 
 include 'authorization'
@@ -12,3 +21,4 @@ include 'model-client'
 include 'model-server'
 include 'model-server-api'
 include 'ts-model-api'
+


### PR DESCRIPTION
Uses the `plugins {}` DSL to declare the mpsbuild plugin dependency.
In order to make repositories apart from the default `gradlePluginPortal()` available, they have to specified in the pluginManagement inside of `settings.gradle`.
closes #46 