### PR TITLE
Use metamodel gradle plugin without MPS

### DIFF
--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.blTypes.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.blTypes.json
@@ -1,0 +1,47 @@
+{
+    "uid": "ed6d7656-532c-4bc2-81d1-af945aeb8280",
+    "name": "jetbrains.mps.baseLanguage.blTypes",
+    "concepts": [
+        {
+            "uid": "mps:ed6d7656-532c-4bc2-81d1-af945aeb8280/1159268590033",
+            "name": "PrimitiveTypeDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ed6d7656-532c-4bc2-81d1-af945aeb8280/1159268590033/1159268590032",
+                    "name": "extends",
+                    "type": "jetbrains.mps.baseLanguage.blTypes.PrimitiveTypeRef",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.IType"
+            ]
+        },
+        {
+            "uid": "mps:ed6d7656-532c-4bc2-81d1-af945aeb8280/1159268661480",
+            "name": "PrimitiveTypeRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ed6d7656-532c-4bc2-81d1-af945aeb8280/1159268661480/1159268661479",
+                    "name": "descriptor",
+                    "type": "jetbrains.mps.baseLanguage.blTypes.PrimitiveTypeDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.builders.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.builders.json
@@ -1,0 +1,518 @@
+{
+    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a",
+    "name": "jetbrains.mps.baseLanguage.builders",
+    "concepts": [
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7057666463730155275",
+            "name": "Builder",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7057666463730155278",
+            "name": "BuilderCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator",
+                "jetbrains.mps.baseLanguage.builders.BuilderContainer",
+                "jetbrains.mps.baseLanguage.IControlFlowInterrupter"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7057666463730155299",
+            "name": "BuilderStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.builders.BuilderContainer"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792292064",
+            "name": "ResultExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374843",
+            "name": "SimpleBuilders",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374843/7288041816792374845",
+                    "name": "builder",
+                    "type": "jetbrains.mps.baseLanguage.builders.BaseSimpleBuilderDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374843/5199967550912384274",
+                    "name": "extendsBuilder",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilders"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792577338",
+            "name": "SimpleBuilderChild",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792577338/7288041816792607835",
+                    "name": "attachStatement",
+                    "type": "jetbrains.mps.baseLanguage.Statement",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792577338/7288041816792577339",
+                    "name": "child",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792577340",
+            "name": "SimpleBuilderParentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.SimpleBuilderExpression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792577342",
+            "name": "SimpleBuilderChildExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.SimpleBuilderExpression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792577344",
+            "name": "SimpleBuilderExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840",
+            "name": "SimpleBuilderDeclaration",
+            "properties": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/7288041816792489431",
+                    "name": "root",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/7288041816793407210",
+                    "name": "leaf",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/3816167865390639747",
+                    "name": "isAbstract",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/5425713840853683089",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderParameter",
+                    "multiple": true
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/3816167865390455307",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/7288041816793525038",
+                    "name": "creator",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/7288041816792733124",
+                    "name": "child",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderChild",
+                    "multiple": true
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/5389689214217081351",
+                    "name": "property",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderProperty",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816792374840/3816167865390363701",
+                    "name": "extends",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.BaseSimpleBuilderDeclaration",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816793071802",
+            "name": "SimpleBuilder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816793071802/4315270135340629600",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7288041816793071802/7288041816793071803",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.Builder"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5425713840853682520",
+            "name": "SimpleBuilderParameter",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5425713840853682520/5425713840853682521",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5425713840853785828",
+            "name": "SimpleBuilderParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5425713840853785828/5425713840853785829",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7802271442981707292",
+            "name": "AsBuilderStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7802271442981707292/7802271442981707295",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IContainsStatementList",
+                "jetbrains.mps.baseLanguage.builders.BuilderContainer"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7802271442981792228",
+            "name": "BuilderContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7802271442981792228/4797501453850567416",
+                    "name": "builder",
+                    "type": "jetbrains.mps.baseLanguage.builders.Builder",
+                    "optional": false
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/7802271442981792228/4797501453849924252",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/2679357232283750087",
+            "name": "BeanPropertyBuilder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/2679357232283750087/2679357232283750106",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/2679357232283750087/2679357232283750088",
+                    "name": "setter",
+                    "type": "jetbrains.mps.baseLanguage.InstanceMethodDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.Builder"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/6666322667909540799",
+            "name": "BeanBuilder",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.Builder",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214216557332",
+            "name": "AsTypeBuilder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214216557332/5389689214216557333",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.Builder"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214216990954",
+            "name": "SimpleBuilderProperty",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214216990954/5389689214216997399",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214216990954/5389689214217175694",
+                    "name": "set",
+                    "type": "jetbrains.mps.baseLanguage.Statement",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214217242850",
+            "name": "SimpleBuilderPropertyExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214217248368",
+            "name": "SimpleBuilderPropertyParent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.SimpleBuilderPropertyExpression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214217248394",
+            "name": "SimpleBuilderPropertyValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.SimpleBuilderPropertyExpression"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214217404511",
+            "name": "SimpleBuilderPropertyBuilder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214217404511/5389689214217404512",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/5389689214217404511/5389689214217404513",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderProperty",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.Builder"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/6254726786820421041",
+            "name": "BaseSimpleBuilderDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:132aa4d8-a3f7-441c-a7eb-3fce23492c6a/6254726786820459251",
+            "name": "SimpleBuilderExtensionDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/6254726786820459251/6254726786820459252",
+                    "name": "child",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderChild",
+                    "multiple": true
+                },
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/6254726786820459251/6254726786820459253",
+                    "name": "property",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderProperty",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "132aa4d8-a3f7-441c-a7eb-3fce23492c6a/6254726786820459251/6254726786820459254",
+                    "name": "extended",
+                    "type": "jetbrains.mps.baseLanguage.builders.SimpleBuilderDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.builders.BaseSimpleBuilderDeclaration"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.checkedDots.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.checkedDots.json
@@ -1,0 +1,19 @@
+{
+    "uid": "774bf8a0-62e5-41e1-af63-f4812e60e48b",
+    "name": "jetbrains.mps.baseLanguage.checkedDots",
+    "concepts": [
+        {
+            "uid": "mps:774bf8a0-62e5-41e1-af63-f4812e60e48b/4079382982702596667",
+            "name": "CheckedDotExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.DotExpression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.classifiers.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.classifiers.json
@@ -1,0 +1,222 @@
+{
+    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e",
+    "name": "jetbrains.mps.baseLanguage.classifiers",
+    "concepts": [
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205751982837",
+            "name": "IClassifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IExtractMethodAvailable"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752032448",
+            "name": "IMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752174734",
+            "name": "IClassifierPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752633985",
+            "name": "ThisClassifierExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752633985/1218736638915",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.IClassifier"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IThisExpression"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752813637",
+            "name": "BaseClassifierType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752906494",
+            "name": "DefaultClassifierType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205752906494/1205752917136",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.IClassifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205756064662",
+            "name": "IMemberOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205756064662/1205756909548",
+                    "name": "member",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.IMember",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205769003971",
+            "name": "DefaultClassifierMethodDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.baseLanguage.classifiers.IMember",
+                "jetbrains.mps.baseLanguage.IVisible"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205769149993",
+            "name": "DefaultClassifierMethodCallOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1205769149993/1205770614681",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1213999088275",
+            "name": "DefaultClassifierFieldDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.FieldDeclaration",
+                "jetbrains.mps.baseLanguage.classifiers.IMember"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1213999117680",
+            "name": "DefaultClassifierFieldAccessOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1217433449852",
+            "name": "SuperClassifierExpresson",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1029302639053433191",
+            "name": "DefaultClassifier",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1029302639053433191/1029302639053435660",
+                    "name": "field",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierFieldDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "443f4c36-fcf5-4eb6-9500-8d06ed259e3e/1029302639053433191/1029302639053435661",
+                    "name": "method",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierMethodDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.closures.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.closures.json
@@ -1,0 +1,379 @@
+{
+    "uid": "fd392034-7849-419d-9071-12563d152375",
+    "name": "jetbrains.mps.baseLanguage.closures",
+    "concepts": [
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1199542442495",
+            "name": "FunctionType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199542442495/1199542501692",
+                    "name": "parameterType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199542442495/1199542457201",
+                    "name": "resultType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199542442495/1214831762486",
+                    "name": "throwsType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199542442495/100821637069096425",
+                    "name": "runtimeIface",
+                    "type": "jetbrains.mps.baseLanguage.Interface"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1199547238293",
+            "name": "InvokeFunctionExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199547238293/1199547267289",
+                    "name": "function",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199547238293/1199548008404",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.IDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1199569711397",
+            "name": "ClosureLiteral",
+            "properties": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199569711397/890797661671409019",
+                    "name": "forceMultiLine",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199569711397/1199569906740",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.ParameterDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199569711397/1199569916463",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.baseLanguage.IContainsStatementList",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.baseLanguage.IFinalWrapper",
+                "jetbrains.mps.baseLanguage.IControlFlowInterrupter",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1199711271002",
+            "name": "InvokeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1199711271002/1199711344856",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1200830824066",
+            "name": "YieldStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1200830824066/1200830928149",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1203252195462",
+            "name": "UnboundClosureParameterDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ParameterDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1214952349786",
+            "name": "PairOfInts",
+            "properties": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1214952349786/1214952413127",
+                    "name": "first",
+                    "type": "INT"
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1214952349786/1214952416967",
+                    "name": "second",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1214952607239",
+            "name": "StringPropertyHolder",
+            "properties": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1214952607239/1214952630977",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1225797177491",
+            "name": "InvokeFunctionOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1225797177491/1225797361612",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1228997946467",
+            "name": "YieldAllStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1228997946467/1228997959377",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1229599750256",
+            "name": "ControlAbstractionContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1229599750256/1229600801065",
+                    "name": "controlAbstraction",
+                    "type": "jetbrains.mps.baseLanguage.closures.ControlAbstractionDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Classifier"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1229599834263",
+            "name": "ControlAbstractionDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1229599834263/1229600064117",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.ParameterDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1229599834263/1229600049315",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.GenericDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.HasAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1235746970280",
+            "name": "CompactInvokeFunctionExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1235746970280/1235746996653",
+                    "name": "function",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/1235746970280/1235747002942",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/4816492477345855364",
+            "name": "FunctionMethodDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.InstanceMethodDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/5612111951671407997",
+            "name": "AbstractFunctionType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/5612111951671407997/5612111951671407998",
+                    "name": "parameterType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                },
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/5612111951671407997/5612111951671407999",
+                    "name": "resultType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/6206193564530254535",
+            "name": "ClosureArgReference",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fd392034-7849-419d-9071-12563d152375/6206193564530254535/6206193564530254610",
+                    "name": "original",
+                    "type": "jetbrains.mps.baseLanguage.VariableReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:fd392034-7849-419d-9071-12563d152375/1046929382682558545",
+            "name": "ClosureLiteralType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.closures.FunctionType",
+                "jetbrains.mps.baseLanguage.IInternalType"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.collections.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.collections.json
@@ -1,0 +1,2876 @@
+{
+    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f",
+    "name": "jetbrains.mps.baseLanguage.collections",
+    "concepts": [
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1151688443754",
+            "name": "ListType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1151688443754/1151688676805",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1151689724996",
+            "name": "SequenceType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1151689724996/1151689745422",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1151701983961",
+            "name": "SequenceOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1151702311717",
+            "name": "ToListOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1153943597977",
+            "name": "ForEachStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1153943597977/1153944400369",
+                    "name": "variable",
+                    "type": "jetbrains.mps.baseLanguage.collections.ForEachVariable",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1153943597977/1153944424730",
+                    "name": "inputSequence",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractLoopStatement"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1153944233411",
+            "name": "ForEachVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1153944233411/1153944258490",
+                    "name": "variable",
+                    "type": "jetbrains.mps.baseLanguage.collections.ForEachVariable",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IVariableReference"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1160600644654",
+            "name": "ListCreatorWithInit",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1160612413312",
+            "name": "AddElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1160666733551",
+            "name": "AddAllElementsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1162934736510",
+            "name": "GetElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1162935959151",
+            "name": "GetSizeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1165525191778",
+            "name": "GetFirstOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1165530316231",
+            "name": "IsEmptyOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1165595910856",
+            "name": "GetLastOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1167380149909",
+            "name": "RemoveElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1171391069720",
+            "name": "GetIndexOfOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1172254888721",
+            "name": "ContainsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1172650591544",
+            "name": "SkipOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1172650591544/1172658456740",
+                    "name": "elementsToSkip",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1172664342967",
+            "name": "TakeOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1172664342967/1172664372046",
+                    "name": "elementsToTake",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1172667724288",
+            "name": "PageOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1172667724288/1172667737868",
+                    "name": "fromElement",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1172667724288/1172667748353",
+                    "name": "toElement",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1173946412755",
+            "name": "RemoveAllElementsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1175845471038",
+            "name": "ReverseOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1176501494711",
+            "name": "IsNotEmptyOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1176903168877",
+            "name": "UnionOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1176906603202",
+            "name": "BinaryOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1176906603202/1176906787974",
+                    "name": "rightExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1176921879268",
+            "name": "IntersectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1176923520476",
+            "name": "ExcludeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1178286324487",
+            "name": "SortDirection",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BooleanConstant"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1178894719932",
+            "name": "DistinctOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1180964022718",
+            "name": "ConcatOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1184963466173",
+            "name": "ToArrayOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1197683403723",
+            "name": "MapType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197683403723/1197683466920",
+                    "name": "keyType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197683403723/1197683475734",
+                    "name": "valueType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1197686869805",
+            "name": "HashMapCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197686869805/1197687026896",
+                    "name": "keyType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197686869805/1197687035757",
+                    "name": "valueType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197686869805/1206655950512",
+                    "name": "initializer",
+                    "type": "jetbrains.mps.baseLanguage.collections.MapInitializer"
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197686869805/1562299158921034623",
+                    "name": "initSize",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1197932370469",
+            "name": "MapElement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197932370469/1197932505799",
+                    "name": "map",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1197932370469/1197932525128",
+                    "name": "key",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1201216218329",
+            "name": "MapOperationExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1201216218329/1201216278566",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1201216218329/1201225916438",
+                    "name": "mapOperation",
+                    "type": "jetbrains.mps.baseLanguage.collections.MapOperation",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1201225890326",
+            "name": "MapOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1201306600024",
+            "name": "ContainsKeyOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1201306600024/1201654602639",
+                    "name": "key",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1201872418428",
+            "name": "GetKeysOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1206655653991",
+            "name": "MapInitializer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1206655653991/1206655902276",
+                    "name": "entries",
+                    "type": "jetbrains.mps.baseLanguage.collections.MapEntry",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1206655735055",
+            "name": "MapEntry",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1206655735055/1206655844556",
+                    "name": "key",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1206655735055/1206655853135",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1207233427108",
+            "name": "MapRemoveOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1207233427108/1207233489861",
+                    "name": "key",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1207236100912",
+            "name": "ToIteratorOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1208542034276",
+            "name": "MapClearOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1201792049884",
+            "name": "TranslateOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1202120902084",
+            "name": "WhereOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1202128969694",
+            "name": "SelectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1203518072036",
+            "name": "SmartClosureParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.closures.UnboundClosureParameterDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1204796164442",
+            "name": "InternalSequenceOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1204796164442/1204796294226",
+                    "name": "closure",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1204980550705",
+            "name": "VisitAllOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1205598340672",
+            "name": "DisjunctOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1205679737078",
+            "name": "SortOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1205679737078/1205679832066",
+                    "name": "ascending",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1205753243362",
+            "name": "ChunkOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1205753243362/1205753261887",
+                    "name": "length",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1205753590798",
+            "name": "CutOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.ChunkOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1205753630278",
+            "name": "TailOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.ChunkOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1209727891789",
+            "name": "ComparatorSortOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1209727891789/1209727996925",
+                    "name": "ascending",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1224414427926",
+            "name": "SequenceCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1224414427926/1224414456414",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1224414427926/1224414466839",
+                    "name": "initializer",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1224446583770",
+            "name": "SkipStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1224451845108",
+            "name": "StopStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1225621920911",
+            "name": "InsertElementOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1225621920911/1225621960341",
+                    "name": "index",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1225621920911/1225621943565",
+                    "name": "element",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1225645868993",
+            "name": "SetElementOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1225645868993/1225645893896",
+                    "name": "index",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1225645868993/1225645893898",
+                    "name": "element",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1225711141656",
+            "name": "ListElementAccessExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1225711141656/1225711182005",
+                    "name": "list",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1225711141656/1225711191269",
+                    "name": "index",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1225727723840",
+            "name": "FindFirstOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1225730411176",
+            "name": "FindLastOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226511727824",
+            "name": "SetType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1226511727824/1226511765987",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226516258405",
+            "name": "HashSetCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226566831166",
+            "name": "AbstractSetOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226566855640",
+            "name": "AddSetElementOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1226566855640/1226567214363",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226591481394",
+            "name": "RemoveSetElementOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1226591481394/1226591501988",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226592602759",
+            "name": "AddAllSetElementsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1226592602759/1226592623721",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226593880804",
+            "name": "RemoveAllSetElementsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1226593880804/1226593903142",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1226934395923",
+            "name": "ClearSetOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227008614712",
+            "name": "LinkedListCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227022159410",
+            "name": "AddFirstElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IDequeOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227022179634",
+            "name": "AddLastElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227022196108",
+            "name": "RemoveAtElementOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1227022196108/1227022274197",
+                    "name": "index",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227022210526",
+            "name": "ClearAllElementsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227026082377",
+            "name": "RemoveFirstElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1227026094155",
+            "name": "RemoveLastElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IDequeOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToDeque"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1228228912534",
+            "name": "DowncastExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1228228912534/1228228959951",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1235566554328",
+            "name": "AnyOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1235566831861",
+            "name": "AllOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1235573135402",
+            "name": "SingletonSequenceCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1235573135402/1235573175711",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1235573135402/1235573187520",
+                    "name": "singletonValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237467461002",
+            "name": "GetIteratorOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237467705688",
+            "name": "IteratorType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237467705688/1237467730343",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237470736245",
+            "name": "AbstractIteratorOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237470895604",
+            "name": "HasNextOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractIteratorOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237471031357",
+            "name": "GetNextOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractIteratorOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237471080820",
+            "name": "GetCurrentOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractEnumeratorOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237471163346",
+            "name": "MoveNextOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractEnumeratorOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237496250641",
+            "name": "EnumeratorType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237496250641/1237496250642",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237497044713",
+            "name": "AbstractEnumeratorOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237549269949",
+            "name": "GetEnumeratorOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237721394592",
+            "name": "AbstractContainerCreator",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237721394592/1237721435807",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237721394592/1237721435808",
+                    "name": "initValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237721394592/1237731803878",
+                    "name": "copyFrom",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237721394592/1562299158920737514",
+                    "name": "initSize",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237783176940",
+            "name": "AllConstant",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IntegerLiteral"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237907129112",
+            "name": "ContainsValueOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1237907129112/1237907150183",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1237909114519",
+            "name": "GetValuesOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240151247486",
+            "name": "ContainerIteratorType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IteratorType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240151544672",
+            "name": "RemoveOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractIteratorOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240216724530",
+            "name": "LinkedHashMapCreator",
+            "properties": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240216724530/1240219919705",
+                    "name": "order"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.HashMapCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240217271293",
+            "name": "LinkedHashSetCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.HashSetCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240239337991",
+            "name": "SortedMapType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240239494010",
+            "name": "TreeMapCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.HashMapCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240239309184",
+            "name": "SortedMapOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240239379525",
+            "name": "HeadMapOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240239379525/1240239942969",
+                    "name": "toKey",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortedMapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240240127120",
+            "name": "TailMapOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240240127120/1240240145771",
+                    "name": "fromKey",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortedMapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240240201186",
+            "name": "SubMapOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240240201186/1240240285641",
+                    "name": "fromKey",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240240201186/1240240291802",
+                    "name": "toKey",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortedMapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240247491866",
+            "name": "SortedSetType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SetType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240247536947",
+            "name": "TreeSetCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240247536947/2261417478148778174",
+                    "name": "comparator",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.HashSetCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251169236",
+            "name": "SortedSetOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251356173",
+            "name": "HeadSetOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251356173/1240251368364",
+                    "name": "toElement",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortedSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251565326",
+            "name": "TailSetOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251565326/1240251577131",
+                    "name": "fromElement",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortedSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251665173",
+            "name": "SubSetOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251665173/1240251672874",
+                    "name": "fromElement",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240251665173/1240251680059",
+                    "name": "toElement",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortedSetOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240325842691",
+            "name": "AsSequenceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240424373525",
+            "name": "MappingType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240424373525/1240424397093",
+                    "name": "keyType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240424373525/1240424402756",
+                    "name": "valueType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240687580870",
+            "name": "JoinOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240687580870/1240687658305",
+                    "name": "delimiter",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240824716764",
+            "name": "AbstractMappingOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240824834947",
+            "name": "ValueAccessOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractMappingOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240825616499",
+            "name": "KeyAccessOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractMappingOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240854379201",
+            "name": "MappingsSetOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1240906768633",
+            "name": "PutAllOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1240906768633/1240906921264",
+                    "name": "map",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.MapOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5686963296372475025",
+            "name": "QueueType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5686963296372573083",
+            "name": "AbstractContainerType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/5686963296372573083/5686963296372573084",
+                    "name": "elementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/3357971920378033937",
+            "name": "DequeType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.QueueType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/2141797557972817928",
+            "name": "IContainerOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/2141797557973018607",
+            "name": "IListOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.ICollectionOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/497032923610827734",
+            "name": "IQueueOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IContainerOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6801639034384703212",
+            "name": "StackType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6801639034384909353",
+            "name": "IDequeOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6801639034384909355",
+            "name": "IStackOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IContainerOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/3358009230508699637",
+            "name": "PopOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IDequeOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/3358009230508699932",
+            "name": "PushOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IDequeOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/3358009230509514604",
+            "name": "PriorityQueueCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/3358009230509553641",
+            "name": "LinkedListType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.ListType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/540871147943773365",
+            "name": "SingleArgumentSequenceOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/540871147943773365/540871147943773366",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/540871147943782829",
+            "name": "NoArgumentsSequenceOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/3055999550620853964",
+            "name": "RemoveWhereOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IQueueOperation",
+                "jetbrains.mps.baseLanguage.collections.IDequeOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToQueue"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/599357942184015200",
+            "name": "AlsoSortOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SortOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6126991172893676625",
+            "name": "ContainsAllOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5633809102336885303",
+            "name": "SubListOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/5633809102336885303/5633809102336885320",
+                    "name": "fromIndex",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/5633809102336885303/5633809102336885321",
+                    "name": "upToIndex",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5784983078884872741",
+            "name": "PeekOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IStackOperation",
+                "jetbrains.mps.baseLanguage.collections.IDequeOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToStack"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5232196642625574978",
+            "name": "HeadListOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/5232196642625574978/5232196642625574980",
+                    "name": "upToIndex",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5232196642625575054",
+            "name": "TailListOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/5232196642625575054/5232196642625575056",
+                    "name": "fromIndex",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6099516049394485216",
+            "name": "CustomContainerDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/6099516049394485216/6099516049394485311",
+                    "name": "containerType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/6099516049394485216/6099516049394485312",
+                    "name": "runtimeType",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/6099516049394485216/1279588871814993944",
+                    "name": "factory",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.GenericDeclaration",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IVisible"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6099516049394485324",
+            "name": "CustomContainers",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/6099516049394485324/6099516049394485326",
+                    "name": "containerDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.collections.CustomContainerDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1331913329176106419",
+            "name": "CustomContainerCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1331913329176106419/1331913329176106420",
+                    "name": "containerDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.collections.CustomContainerDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1576845966386891367",
+            "name": "CustomMapCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1576845966386891367/1576845966386891370",
+                    "name": "containerDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.collections.CustomContainerDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.HashMapCreator"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1153944193378",
+            "name": "ForEachVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.IVariableDeclaration",
+                "jetbrains.mps.lang.core.IResolveInfo"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1522217801069359738",
+            "name": "ReduceLeftOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1522217801069396403",
+            "name": "ReduceRightOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1522217801069396578",
+            "name": "FoldLeftOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1522217801069396578/1522217801069421796",
+                    "name": "seed",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/1522217801069421831",
+            "name": "FoldRightOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/1522217801069421831/1522217801069421833",
+                    "name": "seed",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.InternalSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/4020503625588385966",
+            "name": "GetLastIndexOfOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/9042586985346099698",
+            "name": "MultiForEachStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/9042586985346099698/9042586985346099734",
+                    "name": "forEach",
+                    "type": "jetbrains.mps.baseLanguage.collections.MultiForEachPair",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractLoopStatement"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/9042586985346099733",
+            "name": "MultiForEachPair",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/9042586985346099733/9042586985346099778",
+                    "name": "variable",
+                    "type": "jetbrains.mps.baseLanguage.collections.MultiForEachVariable",
+                    "optional": false
+                },
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/9042586985346099733/9042586985346099735",
+                    "name": "input",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/9042586985346099736",
+            "name": "MultiForEachVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.IVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/8293956702609956630",
+            "name": "MultiForEachVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/8293956702609956630/8293956702609966325",
+                    "name": "variable",
+                    "type": "jetbrains.mps.baseLanguage.collections.MultiForEachVariable",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/7125221305512719026",
+            "name": "CollectionType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.AbstractContainerType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/4327124999333572296",
+            "name": "ICollectionOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IContainerOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/2526372162255441536",
+            "name": "AsUnmodifiableOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.ICollectionOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/4611582986551020933",
+            "name": "AsSynchronizedOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.ICollectionOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/4611582986551314327",
+            "name": "OfTypeOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/4611582986551314327/4611582986551314344",
+                    "name": "requestedType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5699792037748043353",
+            "name": "TestAddElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/4073682006117732261",
+            "name": "TestRemoveElementOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SingleArgumentSequenceOperation",
+                "jetbrains.mps.baseLanguage.collections.IListOperation",
+                "jetbrains.mps.baseLanguage.collections.IApplicableToCollection"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5994574781936691958",
+            "name": "IApplicableToNothing",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5994574781936692983",
+            "name": "IApplicableToCollection",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IApplicableToList"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5994574781936692984",
+            "name": "IApplicableToList",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IApplicableToNothing"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5994574781936692987",
+            "name": "IApplicableToDeque",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IApplicableToNothing"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5994574781936692988",
+            "name": "IApplicableToQueue",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IApplicableToDeque"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/5994574781936692989",
+            "name": "IApplicableToStack",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.IApplicableToDeque"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/6481445890964205296",
+            "name": "MapAsSequenceVarRef",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "83888646-71ce-4f1c-9c53-c54016f6ad4f/6481445890964205296/6481445890964252459",
+                    "name": "original",
+                    "type": "jetbrains.mps.baseLanguage.VariableReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:83888646-71ce-4f1c-9c53-c54016f6ad4f/31378964227347002",
+            "name": "SelectNotNullOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.NoArgumentsSequenceOperation"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.constructors.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.constructors.json
@@ -1,0 +1,210 @@
+{
+    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393",
+    "name": "jetbrains.mps.baseLanguage.constructors",
+    "concepts": [
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701953",
+            "name": "CustomConstructorContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701953/3041831561922340678",
+                    "name": "constructors",
+                    "type": "jetbrains.mps.baseLanguage.constructors.CustomConstructor",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954",
+            "name": "CustomConstructor",
+            "properties": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954/3330196687714050062",
+                    "name": "description"
+                },
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954/3330196687714050063",
+                    "name": "separator"
+                },
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954/3330196687714050064",
+                    "name": "leftParenthesis"
+                },
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954/3330196687714050065",
+                    "name": "rightParenthesis"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954/3330196687714050067",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/526936149311701954/5379647004618201111",
+                    "name": "arguments",
+                    "type": "jetbrains.mps.baseLanguage.constructors.ArgumentClause",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/6820702584719416486",
+            "name": "CustomConstructorUsage",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/6820702584719416486/6820702584719569344",
+                    "name": "element",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/6820702584719416486/6820702584719569331",
+                    "name": "customConstructor",
+                    "type": "jetbrains.mps.baseLanguage.constructors.CustomConstructor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618176183",
+            "name": "ArgumentClause",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618176185",
+            "name": "ListArgumentsClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618176185/4739047193854398652",
+                    "name": "list",
+                    "type": "jetbrains.mps.baseLanguage.constructors.ListCustomParameter",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.constructors.ArgumentClause"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618176186",
+            "name": "CustomArgumentClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618176186/5379647004618201121",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.constructors.CustomConstructorParameter",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.constructors.ArgumentClause"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618201113",
+            "name": "CustomConstructorParameter",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618201113/5379647004618207272",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618378852",
+            "name": "CustomConstructorParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "0ae47ad3-5abd-486c-ac0f-298884f39393/5379647004618378852/5379647004618378853",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.constructors.CustomConstructorParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/4739047193854255783",
+            "name": "ListParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.constructors.CustomConstructorParameterReference"
+            ]
+        },
+        {
+            "uid": "mps:0ae47ad3-5abd-486c-ac0f-298884f39393/4739047193854376699",
+            "name": "ListCustomParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.constructors.CustomConstructorParameter"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.doubleDispatch.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.doubleDispatch.json
@@ -1,0 +1,19 @@
+{
+    "uid": "7db4447f-913e-4b81-bd75-c9a473319ac6",
+    "name": "jetbrains.mps.baseLanguage.doubleDispatch",
+    "concepts": [
+        {
+            "uid": "mps:7db4447f-913e-4b81-bd75-c9a473319ac6/2403002034744698617",
+            "name": "DispatchModifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Modifier"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.extensionMethods.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.extensionMethods.json
@@ -1,0 +1,152 @@
+{
+    "uid": "5dc5fc0d-37ef-4782-8192-8b5ce1f69f80",
+    "name": "jetbrains.mps.baseLanguage.extensionMethods",
+    "concepts": [
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1894531970723270160",
+            "name": "TypeExtension",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1894531970723270160/1894531970723323134",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.extensionMethods.BaseExtensionMethodContainer"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1550313277221324859",
+            "name": "ExtensionMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1550313277222152185",
+            "name": "ExtensionMethodDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1550313277222152185/8022092943109605394",
+                    "name": "extendedType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMember"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/3316739663067157299",
+            "name": "ThisExtensionExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/8022092943109322131",
+            "name": "SimpleExtensionMethodsContainer",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.extensionMethods.BaseExtensionMethodContainer"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/8022092943110829337",
+            "name": "BaseExtensionMethodContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/8022092943110829337/8022092943110829339",
+                    "name": "methods",
+                    "type": "jetbrains.mps.baseLanguage.extensionMethods.ExtensionMethodDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/8022092943110829337/1973189701690661983",
+                    "name": "staticFields",
+                    "type": "jetbrains.mps.baseLanguage.extensionMethods.ExtensionStaticFieldDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.GenericDeclaration",
+                "jetbrains.mps.baseLanguage.IVisible",
+                "jetbrains.mps.baseLanguage.IMemberContainer"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1973189701690850247",
+            "name": "ExtensionStaticFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/1973189701691027447",
+            "name": "ExtensionStaticFieldDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:5dc5fc0d-37ef-4782-8192-8b5ce1f69f80/7685333756920172912",
+            "name": "LocalExtendedMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodCall"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.javadoc.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.javadoc.json
@@ -1,0 +1,653 @@
+{
+    "uid": "f2801650-65d5-424e-bb1b-463a8781b786",
+    "name": "jetbrains.mps.baseLanguage.javadoc",
+    "concepts": [
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395",
+            "name": "BaseDocComment",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/8465538089690331502",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.CommentLine",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/5383422241790532083",
+                    "name": "tags",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/5349172909345532722",
+                    "name": "author",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.AuthorBlockDocTag",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/8465538089690331490",
+                    "name": "since",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.SinceBlockDocTag",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/8465538089690331491",
+                    "name": "version",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.VersionBlockDocTag",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/8465538089690331499",
+                    "name": "deprecated",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.DeprecatedBlockDocTag"
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345501395/2217234381367277533",
+                    "name": "see",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.SeeBlockDocTag",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.IDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5349172909345530173",
+            "name": "BaseBlockDocTag",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5349172909345530174",
+            "name": "AuthorBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345530174/5349172909345532826",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5349172909345532724",
+            "name": "MethodDocComment",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345532724/8465538089690917625",
+                    "name": "param",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.ParameterBlockDocTag",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345532724/5858074156537516428",
+                    "name": "throwsTag",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.ThrowsBlockDocTag",
+                    "multiple": true
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5349172909345532724/5858074156537516440",
+                    "name": "return",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.ReturnBlockDocTag"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseDocComment"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8465538089690324384",
+            "name": "VersionBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8465538089690324384/8465538089690324385",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8465538089690324397",
+            "name": "SinceBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8465538089690324397/8465538089690324399",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8465538089690331492",
+            "name": "DeprecatedBlockDocTag",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8465538089690331492/2667874559098216723",
+                    "name": "text",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.CommentLine",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8465538089690331500",
+            "name": "CommentLine",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8465538089690331500/8970989240999019149",
+                    "name": "part",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.CommentLinePart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8465538089690881930",
+            "name": "ParameterBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8465538089690881930/8465538089690881934",
+                    "name": "text"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8465538089690881930/6832197706140518123",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.BaseParameterReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5858074156537397872",
+            "name": "ThrowsBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5858074156537397872/5858074156537397874",
+                    "name": "text"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5858074156537397872/6832197706140448505",
+                    "name": "exceptionType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5858074156537516430",
+            "name": "ReturnBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5858074156537516430/5858074156537516431",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6832197706140518103",
+            "name": "BaseParameterReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/6832197706140518103/6832197706140518108",
+                    "name": "param",
+                    "type": "jetbrains.mps.baseLanguage.IValidIdentifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6832197706140518104",
+            "name": "DocMethodParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseParameterReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6832197706140518107",
+            "name": "DocTypeParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseParameterReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6832197706140896242",
+            "name": "FieldDocComment",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseDocComment"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2068944020170241612",
+            "name": "ClassifierDocComment",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2068944020170241612/2068944020170241614",
+                    "name": "param",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.ParameterBlockDocTag",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseDocComment"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8970989240999019142",
+            "name": "CommentLinePart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8970989240999019143",
+            "name": "TextCommentLinePart",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8970989240999019143/8970989240999019144",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.CommentLinePart"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/8970989240999019145",
+            "name": "InlineTagCommentLinePart",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/8970989240999019145/6962838954693749192",
+                    "name": "tag",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.BaseInlineDocTag",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.CommentLinePart"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6962838954693748792",
+            "name": "BaseInlineDocTag",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6962838954693748795",
+            "name": "ValueInlineDocTag",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/6962838954693748795/2565027568480644422",
+                    "name": "variableReference",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.BaseVariableDocReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseInlineDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2217234381367049075",
+            "name": "CodeInlineDocTag",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2217234381367049075/3106559687488741665",
+                    "name": "line",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.CommentLine",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseInlineDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2217234381367188006",
+            "name": "BaseDocReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2217234381367188008",
+            "name": "FieldDocReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseVariableDocReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2217234381367190443",
+            "name": "SeeBlockDocTag",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2217234381367190443/2217234381367190444",
+                    "name": "text"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2217234381367190443/2217234381367190458",
+                    "name": "reference",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.BaseDocReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2217234381367530195",
+            "name": "MethodDocReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2217234381367530195/2217234381367530196",
+                    "name": "methodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseDocReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2217234381367530212",
+            "name": "ClassifierDocReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2217234381367530212/2217234381367530213",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseDocReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2546654756694997551",
+            "name": "LinkInlineDocTag",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2546654756694997551/3106559687488913694",
+                    "name": "line",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.CommentLine",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2546654756694997551/2546654756694997556",
+                    "name": "reference",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.BaseDocReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseInlineDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/2565027568480805887",
+            "name": "CodeSnippet",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/2565027568480805887/2565027568480905697",
+                    "name": "statement",
+                    "type": "jetbrains.mps.baseLanguage.Statement",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.CommentLine"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/4730661099054379103",
+            "name": "InheritDocInlineDocTag",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseInlineDocTag"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/5562345046718956738",
+            "name": "BaseVariableDocReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/5562345046718956738/5562345046718956740",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.baseLanguage.BaseVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseDocReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6501140109493894267",
+            "name": "StaticFieldDocReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseVariableDocReference"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/6612597108003615641",
+            "name": "HTMLElement",
+            "properties": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/6612597108003615641/6612597108003615642",
+                    "name": "name"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f2801650-65d5-424e-bb1b-463a8781b786/6612597108003615641/6612597108003615643",
+                    "name": "line",
+                    "type": "jetbrains.mps.baseLanguage.javadoc.CommentLine",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.CommentLinePart"
+            ]
+        },
+        {
+            "uid": "mps:f2801650-65d5-424e-bb1b-463a8781b786/4948473272651335344",
+            "name": "EmptyBlockDocTag",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.javadoc.BaseBlockDocTag"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.jdk7.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.jdk7.json
@@ -1,0 +1,19 @@
+{
+    "uid": "96ee7a94-411d-4cf8-9b94-96cad7e52411",
+    "name": "jetbrains.mps.baseLanguage.jdk7",
+    "concepts": [
+        {
+            "uid": "mps:96ee7a94-411d-4cf8-9b94-96cad7e52411/400642802549924137",
+            "name": "StringSwitchStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.SwitchStatement"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.jdk8.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.jdk8.json
@@ -1,0 +1,37 @@
+{
+    "uid": "fdcdc48f-bfd8-4831-aa76-5abac2ffa010",
+    "name": "jetbrains.mps.baseLanguage.jdk8",
+    "concepts": [
+        {
+            "uid": "mps:fdcdc48f-bfd8-4831-aa76-5abac2ffa010/1719162360409810393",
+            "name": "SuperInterfaceMethodCall_old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "fdcdc48f-bfd8-4831-aa76-5abac2ffa010/1719162360409810393/1719162360409958622",
+                    "name": "classifier_old",
+                    "type": "jetbrains.mps.baseLanguage.Classifier"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.SuperMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:fdcdc48f-bfd8-4831-aa76-5abac2ffa010/4678410916365116210",
+            "name": "DefaultModifier_old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.JavaModifier"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.json
@@ -1,0 +1,5552 @@
+{
+    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816",
+    "name": "jetbrains.mps.baseLanguage",
+    "concepts": [
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886294",
+            "name": "AssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseAssignmentExpression",
+                "jetbrains.mps.baseLanguage.TypeDerivable"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068499141036",
+            "name": "BaseMethodCall",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068431790191",
+            "name": "Expression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198",
+            "name": "ClassConcept",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1075300953594",
+                    "name": "abstractClass",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1221565133444",
+                    "name": "isFinal",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/4980874121082273661",
+                    "name": "isStatic",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1068390468199",
+                    "name": "field",
+                    "type": "jetbrains.mps.baseLanguage.FieldDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1068390468201",
+                    "name": "constructor",
+                    "type": "jetbrains.mps.baseLanguage.ConstructorDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1070462273904",
+                    "name": "staticMethod",
+                    "type": "jetbrains.mps.baseLanguage.StaticMethodDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1165602531693",
+                    "name": "superclass",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1095933932569",
+                    "name": "implementedInterface",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1206629658424",
+                    "name": "instanceInitializer",
+                    "type": "jetbrains.mps.baseLanguage.InstanceInitializer"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1221737886778",
+                    "name": "classInitializer",
+                    "type": "jetbrains.mps.baseLanguage.StaticInitializer"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1171626359898",
+                    "name": "staticInitializer",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468198/1201374247313",
+                    "name": "property",
+                    "type": "jetbrains.mps.baseLanguage.Property",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Classifier",
+                "jetbrains.mps.baseLanguage.IBLDeprecatable",
+                "jetbrains.mps.lang.traceable.UnitConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886292",
+            "name": "ParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.IVariableAssignment",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068431790189",
+            "name": "Type",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.IType",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132",
+            "name": "BaseMethodDeclaration",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132/1181808852946",
+                    "name": "isFinal",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132/4276006055363816570",
+                    "name": "isSynchronized",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132/1068580123133",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132/1068580123134",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.ParameterDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132/1068580123135",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123132/1164879685961",
+                    "name": "throwsItem",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.GenericDeclaration",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.HasAnnotation",
+                "jetbrains.mps.baseLanguage.IBLDeprecatable",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.lang.core.IContainer",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.baseLanguage.TypeAnnotable",
+                "jetbrains.mps.lang.traceable.TraceableConcept",
+                "jetbrains.mps.lang.traceable.ScopeConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.baseLanguage.ITypeApplicable",
+                "jetbrains.mps.baseLanguage.IHasModifiers",
+                "jetbrains.mps.lang.core.ImplementationContainer"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136",
+            "name": "StatementList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665",
+                    "name": "statement",
+                    "type": "jetbrains.mps.baseLanguage.Statement",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.IContainer",
+                "jetbrains.mps.baseLanguage.ILocalVariableElementList",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart",
+                "jetbrains.mps.lang.traceable.ScopeConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.ScopeFacade"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123152",
+            "name": "EqualsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123155",
+            "name": "ExpressionStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123155/1068580123156",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.IWrapper"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123157",
+            "name": "Statement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ILocalVariableElement",
+                "jetbrains.mps.lang.traceable.TraceableConcept",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159",
+            "name": "IfStatement",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159/4467513934994662256",
+                    "name": "forceOneLine",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159/4467513934994662257",
+                    "name": "forceMultiLine",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159/1068580123160",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159/1082485599094",
+                    "name": "ifFalseStatement",
+                    "type": "jetbrains.mps.baseLanguage.Statement"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159/1068580123161",
+                    "name": "ifTrue",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159/1206060520071",
+                    "name": "elsifClauses",
+                    "type": "jetbrains.mps.baseLanguage.ElsifClause",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IContainsStatementList",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123165",
+            "name": "InstanceMethodDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123165/1178608670077",
+                    "name": "isAbstract",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.MethodDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMethodMember",
+                "jetbrains.mps.baseLanguage.ITypeApplicable",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020",
+            "name": "IntegerConstant",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020/1068580320021",
+                    "name": "value",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IntegerLiteral"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242863",
+            "name": "LocalVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.IVariableAssignment",
+                "jetbrains.mps.baseLanguage.IVariableDeclaration",
+                "jetbrains.mps.baseLanguage.ILocalDeclaration",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242864",
+            "name": "LocalVariableDeclarationStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242864/1068581242865",
+                    "name": "localVariableDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.LocalVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.IWrapper"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242867",
+            "name": "LongType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242869",
+            "name": "MinusExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242875",
+            "name": "PlusExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242878",
+            "name": "ReturnStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242878/1068581517676",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.TypeDerivable"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581517677",
+            "name": "VoidType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070462154015",
+            "name": "StaticFieldDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070462154015/6468716278899126575",
+                    "name": "isVolatile",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070462154015/6468716278899125786",
+                    "name": "isTransient",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.StaticKind",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.IBLDeprecatable",
+                "jetbrains.mps.lang.traceable.TraceableConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070475587102",
+            "name": "SuperConstructorInvocation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConstructorInvocationStatement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800",
+            "name": "StringLiteral",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070533707846",
+            "name": "StaticFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070533707846/1144433057691",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference",
+                "jetbrains.mps.baseLanguage.QualifiedReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070533982221",
+            "name": "ShortType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534058343",
+            "name": "NullLiteral",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534370425",
+            "name": "IntegerType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534436861",
+            "name": "FloatType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534513062",
+            "name": "DoubleType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534555686",
+            "name": "CharType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534604311",
+            "name": "ByteType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534644030",
+            "name": "BooleanType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534760951",
+            "name": "ArrayType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070534760951/1070534760952",
+                    "name": "componentType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070534934090",
+            "name": "CastExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070534934090/1070534934091",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070534934090/1070534934092",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1073063089578",
+            "name": "SuperMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1073239437375",
+            "name": "NotEqualsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1076505808687",
+            "name": "WhileStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1076505808687/1076505808688",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractLoopStatement",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1079359253375",
+            "name": "ParenthesizedExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1079359253375/1079359253376",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1080120340718",
+            "name": "AndExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1080223426719",
+            "name": "OrExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081236700937",
+            "name": "StaticMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081236700937/1144433194310",
+                    "name": "classConcept",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodCall",
+                "jetbrains.mps.baseLanguage.QualifiedReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081236700938",
+            "name": "StaticMethodDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.MethodDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMethodMember",
+                "jetbrains.mps.baseLanguage.StaticKind",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081256982272",
+            "name": "InstanceOfExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081256982272/1081256993304",
+                    "name": "leftExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081256982272/1081256993305",
+                    "name": "classType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081516740877",
+            "name": "NotExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081516740877/1081516765348",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081855346303",
+            "name": "BreakStatement",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081855346303/1199466066648",
+                    "name": "label"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081855346303/9056323058805176516",
+                    "name": "loopLabelReference",
+                    "type": "jetbrains.mps.baseLanguage.LoopLabelReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081773326031",
+            "name": "BinaryOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081773326031/1081773367579",
+                    "name": "rightExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1081773326031/1081773367580",
+                    "name": "leftExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1082113931046",
+            "name": "ContinueStatement",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1082113931046/1199470060942",
+                    "name": "label"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1082113931046/9056323058805226429",
+                    "name": "loopLabelReference",
+                    "type": "jetbrains.mps.baseLanguage.LoopLabelReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1082485599095",
+            "name": "BlockStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1082485599095/1082485599096",
+                    "name": "statements",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125",
+            "name": "EnumClass",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125/1083245396908",
+                    "name": "enumConstant",
+                    "type": "jetbrains.mps.baseLanguage.EnumConstantDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245299891",
+            "name": "EnumConstantDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1083245299891/492581319488141108",
+                    "name": "method",
+                    "type": "jetbrains.mps.baseLanguage.InstanceMethodDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.HasAnnotation",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.IMethodCall",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.baseLanguage.IMemberContainer",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083260308424",
+            "name": "EnumConstantReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1083260308424/1144432896254",
+                    "name": "enumClass",
+                    "type": "jetbrains.mps.baseLanguage.EnumClass",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1083260308424/1083260308426",
+                    "name": "enumConstantDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.EnumConstantDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.QualifiedReference",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1092119917967",
+            "name": "MulExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1095950406618",
+            "name": "DivExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1107135704075",
+            "name": "ConceptFunctionParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IParameter"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800",
+            "name": "Classifier",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/1211504562189",
+                    "name": "nestedName"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/2791683072064593257",
+                    "name": "packageName"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/1223633619771",
+                    "name": "isDeprecated",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/521412098689998745",
+                    "name": "nonStatic",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/5375687026011219971",
+                    "name": "member",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierMember",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/1128555889557",
+                    "name": "staticField",
+                    "type": "jetbrains.mps.baseLanguage.StaticFieldDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/1107880067339",
+                    "name": "method",
+                    "type": "jetbrains.mps.baseLanguage.InstanceMethodDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107461130800/1178616825527",
+                    "name": "staticInnerClassifiers",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.GenericDeclaration",
+                "jetbrains.mps.baseLanguage.IClassifier",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.HasAnnotation",
+                "jetbrains.mps.baseLanguage.IMemberContainer",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.IVisible",
+                "jetbrains.mps.lang.core.IContainer",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.ISmartReferent"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1107535904670",
+            "name": "ClassifierType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107535904670/1109201940907",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107535904670/1107535924139",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IClassifierType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1107796713796",
+            "name": "Interface",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1107796713796/1107797138135",
+                    "name": "extendedInterface",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Classifier",
+                "jetbrains.mps.baseLanguage.IBLDeprecatable",
+                "jetbrains.mps.lang.traceable.UnitConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1109279763828",
+            "name": "TypeVariableDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1109279763828/1214996933829",
+                    "name": "extends",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1109279763828/1214996921760",
+                    "name": "bound",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1109279763828/1215091156086",
+                    "name": "auxBounds",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.core.IResolveInfo"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1109279851642",
+            "name": "GenericDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1109279851642/1109279881614",
+                    "name": "typeVariableDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.TypeVariableDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1109283449304",
+            "name": "TypeVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1109283449304/1109283546497",
+                    "name": "typeVariableDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.TypeVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1116615150612",
+            "name": "ClassifierClassExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1116615150612/1116615189566",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.QualifiedReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1137021947720",
+            "name": "ConceptFunction",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1137021947720/1137022507850",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.lang.core.ImplementationContainer",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1144226303539",
+            "name": "ForeachStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1144226303539/1144226360166",
+                    "name": "iterable",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractForStatement",
+                "jetbrains.mps.lang.traceable.ScopeConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1144230876926",
+            "name": "AbstractForStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1144230876926/1144230900587",
+                    "name": "variable",
+                    "type": "jetbrains.mps.baseLanguage.LocalVariableDeclaration"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractLoopStatement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1144231330558",
+            "name": "ForStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1144231330558/1144231399730",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1144231330558/1144231408325",
+                    "name": "iteration",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1144231330558/1032195626824963089",
+                    "name": "additionalVar",
+                    "type": "jetbrains.mps.baseLanguage.AdditionalForLoopVariable",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractForStatement",
+                "jetbrains.mps.lang.traceable.ScopeConcept",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1145552809883",
+            "name": "AbstractCreator",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1145552977093",
+            "name": "GenericNewExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1145552977093/1145553007750",
+                    "name": "creator",
+                    "type": "jetbrains.mps.baseLanguage.AbstractCreator",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1146644584814",
+            "name": "Visibility",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1146644602865",
+            "name": "PublicVisibility",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Visibility"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1146644623116",
+            "name": "PrivateVisibility",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Visibility"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1146644641414",
+            "name": "ProtectedVisibility",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Visibility"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1152728232947",
+            "name": "Closure",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.baseLanguage.Closureoid",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1153179527848",
+            "name": "ClosureParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.IResolveInfo"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1153179560115",
+            "name": "ClosureParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1153179560115/1153179615652",
+                    "name": "closureParameter",
+                    "type": "jetbrains.mps.baseLanguage.ClosureParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1153952380246",
+            "name": "TryFinallyStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1153952380246/1153952416686",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1153952380246/1153952429843",
+                    "name": "finallyBody",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1153952380246/1164903700860",
+                    "name": "catchClause",
+                    "type": "jetbrains.mps.baseLanguage.CatchClause",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IContainsStatementList",
+                "jetbrains.mps.baseLanguage.ITryCatchStatement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1154032098014",
+            "name": "AbstractLoopStatement",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1154032098014/1199465379613",
+                    "name": "label"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1154032098014/1154032183016",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1154032098014/363746191845183793",
+                    "name": "loopLabel",
+                    "type": "jetbrains.mps.baseLanguage.LoopLabel"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.IContainer",
+                "jetbrains.mps.baseLanguage.IContainsStatementList",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1154542696413",
+            "name": "ArrayCreatorWithInitializer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1154542696413/1154542793668",
+                    "name": "componentType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1154542696413/1154542803372",
+                    "name": "initValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1160998861373",
+            "name": "AssertStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1160998861373/1160998896846",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1160998861373/1160998916832",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1070475354124",
+            "name": "ThisExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1070475354124/1182955020723",
+                    "name": "classConcept",
+                    "type": "jetbrains.mps.baseLanguage.Classifier"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IThisExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1163668896201",
+            "name": "TernaryOperatorExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163668896201/1163668914799",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163668896201/1163668922816",
+                    "name": "ifTrue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163668896201/1163668934364",
+                    "name": "ifFalse",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1163670490218",
+            "name": "SwitchStatement",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670490218/1201381395355",
+                    "name": "label"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670490218/1163670766145",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670490218/1163670772911",
+                    "name": "case",
+                    "type": "jetbrains.mps.baseLanguage.SwitchCase",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670490218/1163670592366",
+                    "name": "defaultBlock",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670490218/4652593672361747214",
+                    "name": "switchLabel",
+                    "type": "jetbrains.mps.baseLanguage.LoopLabel"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1163670641947",
+            "name": "SwitchCase",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670641947/1163670677455",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1163670641947/1163670683720",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1164118113764",
+            "name": "PrimitiveType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1164879751025",
+            "name": "TryCatchStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1164879751025/1164879758292",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1164879751025/1164903496223",
+                    "name": "catchClause",
+                    "type": "jetbrains.mps.baseLanguage.CatchClause",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IContainsStatementList",
+                "jetbrains.mps.baseLanguage.ITryCatchStatement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1164903280175",
+            "name": "CatchClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1164903280175/1164903359217",
+                    "name": "throwable",
+                    "type": "jetbrains.mps.baseLanguage.LocalVariableDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1164903280175/1164903359218",
+                    "name": "catchBody",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCatchClause",
+                "jetbrains.mps.lang.traceable.ScopeConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1164991038168",
+            "name": "ThrowStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1164991038168/1164991057263",
+                    "name": "throwable",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1168622733562",
+            "name": "RemarkStatement",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1168622733562/1168623065899",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1170075670744",
+            "name": "SynchronizedStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1170075670744/1170075728144",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1170075670744/1170075736412",
+                    "name": "block",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1170345865475",
+            "name": "AnonymousClass",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1170345865475/1170346101385",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1170345865475/1201186121363",
+                    "name": "typeParameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1170345865475/1170346070688",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.IMethodCall",
+                "jetbrains.mps.baseLanguage.IAnonymousClass",
+                "jetbrains.mps.baseLanguage.IControlFlowInterrupter",
+                "jetbrains.mps.lang.traceable.UnitConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1171903607971",
+            "name": "WildCardType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1171903862077",
+            "name": "LowerBoundType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1171903862077/1171903869531",
+                    "name": "bound",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1171903916106",
+            "name": "UpperBoundType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1171903916106/1171903916107",
+                    "name": "bound",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1172058436953",
+            "name": "LocalStaticMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.LocalMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1173175405605",
+            "name": "ArrayAccessExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1173175405605/1173175590490",
+                    "name": "array",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1173175405605/1173175577737",
+                    "name": "index",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1177666668936",
+            "name": "DoWhileStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1177666668936/1177666688034",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractLoopStatement",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1178285077437",
+            "name": "ClassifierMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IVisible",
+                "jetbrains.mps.baseLanguage.IClassifierMember",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1178893518978",
+            "name": "ThisConstructorInvocation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConstructorInvocationStatement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1179362310214",
+            "name": "IntegerLiteral",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1182160077978",
+            "name": "AnonymousClassCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1182160077978/1182160096073",
+                    "name": "cls",
+                    "type": "jetbrains.mps.baseLanguage.AnonymousClass",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1184950988562",
+            "name": "ArrayCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1184950988562/1184951007469",
+                    "name": "componentType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1184950988562/1184952969026",
+                    "name": "dimensionExpression",
+                    "type": "jetbrains.mps.baseLanguage.DimensionExpression",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1184952934362",
+            "name": "DimensionExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1184952934362/1184953288404",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188206331916",
+            "name": "Annotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Interface"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188206574119",
+            "name": "AnnotationMethodDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188206574119/5790076564176875336",
+                    "name": "defaultValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.InstanceMethodDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188207840427",
+            "name": "AnnotationInstance",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188207840427/1188214630783",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.AnnotationInstanceValue",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188207840427/1188208074048",
+                    "name": "annotation",
+                    "type": "jetbrains.mps.baseLanguage.Annotation",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188214482800",
+            "name": "AnnotationInstanceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188214482800/1188214506790",
+                    "name": "annotationInstance",
+                    "type": "jetbrains.mps.baseLanguage.AnnotationInstance",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188214545140",
+            "name": "AnnotationInstanceValue",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188214545140/1188214607812",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188214545140/1188214555875",
+                    "name": "key",
+                    "type": "jetbrains.mps.baseLanguage.AnnotationMethodDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188220165133",
+            "name": "ArrayLiteral",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188220165133/1188220173759",
+                    "name": "item",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1194952169813",
+            "name": "IMemberContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1197027756228",
+            "name": "DotExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1197027756228/1197027771414",
+                    "name": "operand",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1197027756228/1197027833540",
+                    "name": "operation",
+                    "type": "jetbrains.mps.baseLanguage.IOperation",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1197027803184",
+            "name": "IOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1197029447546",
+            "name": "FieldReferenceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1197029447546/1197029500499",
+                    "name": "fieldDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.FieldDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1199653749349",
+            "name": "IStatementListContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201183863028",
+            "name": "TypeDerivable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201370618622",
+            "name": "Property",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201370618622/1201371481316",
+                    "name": "propertyName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201370618622/1201371521209",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201370618622/1201372378714",
+                    "name": "propertyImplementation",
+                    "type": "jetbrains.mps.baseLanguage.PropertyImplementation",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201372346056",
+            "name": "PropertyImplementation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201372606839",
+            "name": "DefaultPropertyImplementation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201372606839/1202065356069",
+                    "name": "defaultGetAccessor",
+                    "type": "jetbrains.mps.baseLanguage.DefaultGetAccessor",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201372606839/1202078082794",
+                    "name": "defaultSetAccessor",
+                    "type": "jetbrains.mps.baseLanguage.DefaultSetAccessor",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PropertyImplementation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201385106094",
+            "name": "PropertyReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201385106094/1201385237847",
+                    "name": "property",
+                    "type": "jetbrains.mps.baseLanguage.Property",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201398722958",
+            "name": "CustomPropertyImplementation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201398722958/1201402259264",
+                    "name": "getAccessor",
+                    "type": "jetbrains.mps.baseLanguage.GetAccessor",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201398722958/1201476937466",
+                    "name": "setAccessor",
+                    "type": "jetbrains.mps.baseLanguage.SetAccessor"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PropertyImplementation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201402044357",
+            "name": "GetAccessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201402044357/1202593363480",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.baseLanguage.IStatementListContainer"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1201476912089",
+            "name": "SetAccessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1201476912089/1202593336291",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.baseLanguage.IStatementListContainer"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1202003934320",
+            "name": "ValueParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1202065242027",
+            "name": "DefaultGetAccessor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1202077725299",
+            "name": "DefaultSetAccessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1202077725299/1202077744034",
+                    "name": "visibility",
+                    "type": "jetbrains.mps.baseLanguage.Visibility"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1202948039474",
+            "name": "InstanceMethodCallOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946",
+            "name": "IMethodCall",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141038",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/4972241301747169160",
+                    "name": "typeArgument",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037",
+                    "name": "baseMethodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.TypeDerivable",
+                "jetbrains.mps.baseLanguage.TypeAnnotable"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1204200696010",
+            "name": "NullType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PrimitiveType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1206036041805",
+            "name": "IInternalType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1206060495898",
+            "name": "ElsifClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1206060495898/1206060619838",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1206060495898/1206060644605",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IConditional"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1206629501431",
+            "name": "InstanceInitializer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1206629501431/1206629521979",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1207665819089",
+            "name": "Closureoid",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1208623485264",
+            "name": "AbstractOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1208890769693",
+            "name": "ArrayLengthOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1212170275853",
+            "name": "IValidIdentifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1212685548494",
+            "name": "ClassCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1212685548494/1212687122400",
+                    "name": "typeParameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1214918800624",
+            "name": "PostfixIncrementExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractUnaryNumberOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1214918975462",
+            "name": "PostfixDecrementExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractUnaryNumberOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1215693861676",
+            "name": "BaseAssignmentExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1215693861676/1068498886295",
+                    "name": "lValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1215693861676/1068498886297",
+                    "name": "rValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1215695189714",
+            "name": "PlusAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1215695201514",
+            "name": "MinusAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1219920932475",
+            "name": "VariableArityType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1219920932475/1219921048460",
+                    "name": "componentType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1221393582612",
+            "name": "IExtractMethodAvailable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1221737317277",
+            "name": "StaticInitializer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1221737317277/1221737317278",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1222174328436",
+            "name": "IStaticContainerForMethods",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1223985693348",
+            "name": "IVariableAssignment",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224071154655",
+            "name": "AsExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224071154655/1224071154656",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224071154655/1224071154657",
+                    "name": "classifierType",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224071180699",
+            "name": "UsingStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224071180699/1224071180701",
+                    "name": "resource",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224071180699/1224071180702",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224573963862",
+            "name": "EnumValuesExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224573963862/1224573974191",
+                    "name": "enumClass",
+                    "type": "jetbrains.mps.baseLanguage.EnumClass",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.QualifiedReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224500799915",
+            "name": "BitwiseXorExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryBitwiseOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224575136086",
+            "name": "EnumValueOfExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224575136086/1224575157853",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224575136086/1224575174120",
+                    "name": "enumClass",
+                    "type": "jetbrains.mps.baseLanguage.EnumClass",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.QualifiedReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224500579375",
+            "name": "BinaryBitwiseOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224500790866",
+            "name": "BitwiseOrExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryBitwiseOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224500764161",
+            "name": "BitwiseAndExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryBitwiseOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224609861009",
+            "name": "IThisExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1224848483129",
+            "name": "IBLDeprecatable",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1224848483129/1224848525476",
+                    "name": "isDeprecated",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.IDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271177708",
+            "name": "StringType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271221393",
+            "name": "NPENotEqualsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271283259",
+            "name": "NPEEqualsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271315873",
+            "name": "BaseStringOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271369338",
+            "name": "IsEmptyOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.StringBooleanOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271408483",
+            "name": "IsNotEmptyOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.StringBooleanOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271443097",
+            "name": "StringBooleanOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseStringOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271484915",
+            "name": "SubstringExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1225271484915/1225271484916",
+                    "name": "operand",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1225271484915/1225271484917",
+                    "name": "startIndex",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1225271484915/1225271484918",
+                    "name": "endIndex",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225271546410",
+            "name": "TrimOperation",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1225271546410/1225271546413",
+                    "name": "trimKind"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseStringOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225280593310",
+            "name": "IParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225894555487",
+            "name": "BitwiseNotExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1225894555487/1225894555490",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1232461062092",
+            "name": "CommentedStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1232461062092/1232461075566",
+                    "name": "statement",
+                    "type": "jetbrains.mps.baseLanguage.Statement"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1233920926773",
+            "name": "TypeAnnotable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1237545921771",
+            "name": "IContainsStatementList",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1238803202705",
+            "name": "ILocalVariableElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1238805530342",
+            "name": "ILocalVariableElementList",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1239354281271",
+            "name": "IMethodLike",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1239448985469",
+            "name": "BinaryCompareOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1239709250944",
+            "name": "PrefixIncrementExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractUnaryNumberOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1239709577448",
+            "name": "PrefixDecrementExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractUnaryNumberOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1239714755177",
+            "name": "AbstractUnaryNumberOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1239714755177/1239714902950",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1241450588333",
+            "name": "BLBottomType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1241540912639",
+            "name": "ConstructorInvocationStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4972933694980447171",
+            "name": "BaseVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/4972933694980447171/5680397130376446158",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5497648299878491908",
+            "name": "BaseVariableReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5497648299878491908/5497648299878491909",
+                    "name": "baseVariableDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.BaseVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/363746191845175146",
+            "name": "LoopLabel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.LocalToMethodKind",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/363746191845183785",
+            "name": "LoopLabelReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/363746191845183785/363746191845183786",
+                    "name": "loopLabel",
+                    "type": "jetbrains.mps.baseLanguage.LoopLabel",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104955",
+            "name": "CommentPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304495340",
+            "name": "MulAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501412",
+            "name": "DivAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501414",
+            "name": "RemAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501416",
+            "name": "OrAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501418",
+            "name": "AndAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501420",
+            "name": "XorAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501422",
+            "name": "LeftShiftAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7024111702304501424",
+            "name": "RightShiftAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1830039279190439966",
+            "name": "AdditionalForLoopVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.LocalVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7812779912047922391",
+            "name": "AbstractClassifierReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/7812779912047922391/7812779912047934386",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2580416627845338977",
+            "name": "ImplicitAnnotationInstanceValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AnnotationInstanceValue"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4564374268190696673",
+            "name": "PrimitiveClassExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/4564374268190696673/4564374268190696674",
+                    "name": "primitiveType",
+                    "type": "jetbrains.mps.baseLanguage.PrimitiveType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5432666129547687712",
+            "name": "IVariableDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3718132079121388578",
+            "name": "ITryCatchStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3066917033203108594",
+            "name": "LocalInstanceMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.LocalMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3262277503800813724",
+            "name": "ILocalDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3262277503800813725",
+            "name": "ILocalReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5205855332950442198",
+            "name": "ArrayCloneOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2948164764175055168",
+            "name": "UnresolvedNameReference",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2948164764175055168/2948164764175055169",
+                    "name": "resolveName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5293379017992965193",
+            "name": "StubStatementList",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.StatementList",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.IStubForAnotherConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4957392803029437192",
+            "name": "OperationAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8972672481958095232",
+            "name": "IControlFlowInterrupter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4609636120081351393",
+            "name": "IWillBeClassifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1461424660015405635",
+            "name": "EscapeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseStringOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4836112446988635817",
+            "name": "UndefinedType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5620135147607645642",
+            "name": "IFinalWrapper",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3425520165286454670",
+            "name": "IAnonymousClass",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/320030840061612167",
+            "name": "UnsignedRightShiftAssignmentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.OperationAssignmentExpression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1023687332192347378",
+            "name": "IVariableReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8412076637103718467",
+            "name": "ISkipsReturn",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5862977038373003187",
+            "name": "LocalPropertyReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5862977038373003187/5862977038373003188",
+                    "name": "property",
+                    "type": "jetbrains.mps.baseLanguage.Property",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/229277139747537782",
+            "name": "ContextClassifierKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6694311595176645018",
+            "name": "ImplicitAnnotationMethodKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6617045035157661092",
+            "name": "SuperMethodKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4790782560812794334",
+            "name": "StaticKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2406048883599831972",
+            "name": "ThisConstructorKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/501006281268604400",
+            "name": "LocalToMethodKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2406048883599609633",
+            "name": "SuperConstructorKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1251851371723515367",
+            "name": "ArrayClassExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1251851371723515367/1251851371723515368",
+                    "name": "arrayType",
+                    "type": "jetbrains.mps.baseLanguage.ArrayType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7405920559687209277",
+            "name": "IClassifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7405920559687209278",
+            "name": "IClassifierMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7405920559687237502",
+            "name": "IClassifierType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468200",
+            "name": "FieldDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468200/1240249534625",
+                    "name": "isVolatile",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468200/8606350594693632173",
+                    "name": "isTransient",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.IBLDeprecatable",
+                "jetbrains.mps.lang.traceable.TraceableConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123140",
+            "name": "ConstructorDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123140/1211505677611",
+                    "name": "nestedName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1172008963197",
+            "name": "LocalStaticFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1188208481402",
+            "name": "HasAnnotation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1188208481402/1188208488637",
+                    "name": "annotation",
+                    "type": "jetbrains.mps.baseLanguage.AnnotationInstance",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1178549954367",
+            "name": "IVisible",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1178549954367/1178549979242",
+                    "name": "visibility",
+                    "type": "jetbrains.mps.baseLanguage.Visibility"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104957",
+            "name": "TextCommentPart",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104957/6329021646629104958",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.CommentPart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629175143",
+            "name": "StatementCommentPart",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629175143/6329021646629175144",
+                    "name": "commentedStatement",
+                    "type": "jetbrains.mps.baseLanguage.Statement",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.CommentPart"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104954",
+            "name": "SingleLineComment",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104954/6329021646629175155",
+                    "name": "commentPart",
+                    "type": "jetbrains.mps.baseLanguage.CommentPart",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104954/1350122676458893092",
+                    "name": "text",
+                    "type": "jetbrains.mps.lang.text.Line",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6329021646629104954/8356039341262087992",
+                    "name": "line",
+                    "type": "jetbrains.mps.lang.text.Line"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.baseLanguage.IComment",
+                "jetbrains.mps.lang.core.IOldCommentContainer"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7785501532031639928",
+            "name": "LocalInstanceFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225892208569",
+            "name": "ShiftLeftExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryBitwiseOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1225892319711",
+            "name": "ShiftRightExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryBitwiseOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/320030840061144153",
+            "name": "ShiftRightUnsignedExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryBitwiseOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1153422105332",
+            "name": "RemExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081506773034",
+            "name": "LessThanExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryCompareOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1153422305557",
+            "name": "LessThanOrEqualsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryCompareOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1153417849900",
+            "name": "GreaterThanOrEqualsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryCompareOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1081506762703",
+            "name": "GreaterThanExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryCompareOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8064396509828172209",
+            "name": "UnaryMinus",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractUnaryNumberOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1179360813171",
+            "name": "HexIntegerLiteral",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1179360813171/1179360856892",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IntegerLiteral"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4269842503726207156",
+            "name": "LongLiteral",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/4269842503726207156/4269842503726207157",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5279705229678483897",
+            "name": "FloatingPointFloatConstant",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5279705229678483897/5279705229678483899",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1111509017652",
+            "name": "FloatingPointConstant",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1111509017652/1113006610751",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137",
+            "name": "BooleanConstant",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138",
+                    "name": "value",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1200397529627",
+            "name": "CharConstant",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1200397529627/1200397540847",
+                    "name": "charConstant"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1157103807699",
+            "name": "Number",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068431474542",
+            "name": "VariableDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068431474542/1176718929932",
+                    "name": "isFinal",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068431474542/1068431790190",
+                    "name": "initializer",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableDeclaration",
+                "jetbrains.mps.baseLanguage.HasAnnotation",
+                "jetbrains.mps.baseLanguage.TypeDerivable",
+                "jetbrains.mps.baseLanguage.TypeAnnotable",
+                "jetbrains.mps.baseLanguage.IVariableDeclaration",
+                "jetbrains.mps.lang.core.IResolveInfo"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296",
+            "name": "VariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1068498886296/1068581517664",
+                    "name": "variableDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.VariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.TypeAnnotable",
+                "jetbrains.mps.baseLanguage.IVariableReference",
+                "jetbrains.mps.baseLanguage.ILocalReference"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8136348407761606757",
+            "name": "IYetUnresolved",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7812454656619025416",
+            "name": "MethodDeclaration",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/7812454656619025416/8355037393041754995",
+                    "name": "isNative",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.lang.core.IResolveInfo"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8277080359323839091",
+            "name": "ITypeApplicable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7812454656619025412",
+            "name": "LocalMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3304084122476667220",
+            "name": "UnknownNew",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3304084122476667220/3304084122476721463",
+                    "name": "className"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IMethodCall",
+                "jetbrains.mps.baseLanguage.IYetUnresolved"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8473865358220097975",
+            "name": "UnknownNameRef",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.Tokens",
+                "jetbrains.mps.baseLanguage.IYetUnresolved"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4107091686347010317",
+            "name": "IGenericType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6823176311001356881",
+            "name": "StringToken",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6823176311001356881/6823176311001356882",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/9100188248702352244",
+            "name": "UnknownConsCall",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/9100188248702352244/9100188248702352610",
+                    "name": "isSuper",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IMethodCall",
+                "jetbrains.mps.baseLanguage.IYetUnresolved"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2621000434129552854",
+            "name": "UnknownLocalCall",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2621000434129552854/2621000434129552880",
+                    "name": "callee"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IMethodCall",
+                "jetbrains.mps.baseLanguage.IYetUnresolved"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2621000434129553333",
+            "name": "UnknownDotCall",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2621000434129553333/4872723285943177972",
+                    "name": "callee"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.UnknownNameRef",
+                "jetbrains.mps.baseLanguage.IMethodCall",
+                "jetbrains.mps.baseLanguage.IYetUnresolved"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2403002034744051110",
+            "name": "Modifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2323553266850475941",
+            "name": "IHasModifiers",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2323553266850475941/2323553266850475953",
+                    "name": "modifiers",
+                    "type": "jetbrains.mps.baseLanguage.Modifier",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1465982738277781862",
+            "name": "PlaceholderMember",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6050519299856556786",
+            "name": "JavaImports",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6050519299856556786/28358707492429991",
+                    "name": "entries",
+                    "type": "jetbrains.mps.baseLanguage.JavaImport",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6528213125912070246",
+            "name": "Tokens",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6528213125912070246/1843920760191311250",
+                    "name": "tokens"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2820489544401957797",
+            "name": "DefaultClassCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2820489544401957797/2820489544402271667",
+                    "name": "typeParameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2820489544401957797/2820489544401957798",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/28358707492436943",
+            "name": "JavaImport",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/28358707492436943/28358707492436944",
+                    "name": "onDemand",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/28358707492436943/5574384225470059890",
+                    "name": "static",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.Tokens"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441",
+            "name": "IncompleteMemberDeclaration",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/3609453419506282388",
+                    "name": "static",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/3609453419506282390",
+                    "name": "final",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/3609453419506282393",
+                    "name": "abstract",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/3609453419506283925",
+                    "name": "synchronized",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/3609453419506286246",
+                    "name": "volatile",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/6348240317717564887",
+                    "name": "transient",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/8355037393080469281",
+                    "name": "native",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3609453419506221441/3609453419535151784",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.IHasModifiers"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2622108313324567541",
+            "name": "PropertyValueReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/2622108313324567541/2622108313342889969",
+                    "name": "owningProperty",
+                    "type": "jetbrains.mps.baseLanguage.Property",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4285773203949551198",
+            "name": "CustomSetterPropertyImplementation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/4285773203949551198/4285773203949552004",
+                    "name": "getAccessor",
+                    "type": "jetbrains.mps.baseLanguage.DefaultGetAccessor",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/4285773203949551198/4285773203949552005",
+                    "name": "setAccessor",
+                    "type": "jetbrains.mps.baseLanguage.SetAccessor"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.PropertyImplementation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7251340091268481742",
+            "name": "IncompleteLeftParen",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.baseLanguage.IIncompleteParen"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/2329139813954029793",
+            "name": "IncompleteRightParen",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.baseLanguage.IIncompleteParen"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1742226163722651198",
+            "name": "IBinaryLike",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1071364028384826861",
+            "name": "IIncompleteParen",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1071364028384826861/1071364028384826862",
+                    "name": "count",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8287904403586151262",
+            "name": "SuperInerfaceKind",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4235809288648185282",
+            "name": "IConditional",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4032730095448229738",
+            "name": "QualifiedSuperMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/4032730095448229738/4032730095448229757",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.SuperMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7282214966977214052",
+            "name": "NestedNewExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.GenericNewExpression",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1164142520228671896",
+            "name": "JavaModifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Modifier"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6038287468700811827",
+            "name": "GenericLValueExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6038287468700811827/8230959874503203826",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6038287468700811827/6900020712833426234",
+                    "name": "referenceExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6038287468700811827/6038287468700812034",
+                    "name": "getValueExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6038287468700811827/9101202990845387125",
+                    "name": "assignValueExression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6038287468700812090",
+            "name": "ValueRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6900020712833426154",
+            "name": "PassByRefExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/6900020712833426154/6900020712833426231",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/559597157502843494",
+            "name": "ClassifierMethodMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassifierMember"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1190966837021918474",
+            "name": "BinaryIntegerLiteral",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1190966837021918474/1179360856892",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IntegerLiteral"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/6643422257213699484",
+            "name": "StubInitializer",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.IStubForAnotherConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1045393269083384056",
+            "name": "OctalIntegerLiteral",
+            "properties": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1045393269083384056/1179360856892",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IntegerLiteral"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3093926081418224065",
+            "name": "AbstractCatchClause",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/9079830899491039969",
+            "name": "QualifiedReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1732176556423009631",
+            "name": "MultiLineComment",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1732176556423009631/1732176556423038857",
+                    "name": "lines",
+                    "type": "jetbrains.mps.lang.text.Line",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.baseLanguage.IComment"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8118189177080264853",
+            "name": "AlternativeType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/8118189177080264853/8118189177080264854",
+                    "name": "alternative",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.UndefinedType"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4952749571008284462",
+            "name": "CatchVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.LocalVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3093926081414150598",
+            "name": "MultipleCatchClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3093926081414150598/8276990574895933172",
+                    "name": "throwable",
+                    "type": "jetbrains.mps.baseLanguage.CatchVariable",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/3093926081414150598/8276990574895933173",
+                    "name": "catchBody",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCatchClause",
+                "jetbrains.mps.lang.traceable.ScopeConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5351203823916832286",
+            "name": "ResourceVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.LocalVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5351203823916750322",
+            "name": "TryUniversalStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5351203823916750322/5351203823916750334",
+                    "name": "resource",
+                    "type": "jetbrains.mps.baseLanguage.ResourceVariable",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5351203823916750322/8276990574886367508",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5351203823916750322/8276990574886367510",
+                    "name": "catchClause",
+                    "type": "jetbrains.mps.baseLanguage.MultipleCatchClause",
+                    "multiple": true
+                },
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/5351203823916750322/8276990574886367509",
+                    "name": "finallyClause",
+                    "type": "jetbrains.mps.baseLanguage.FinallyClause"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.baseLanguage.ITryCatchStatement",
+                "jetbrains.mps.baseLanguage.IContainsStatementList"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/4678410916365116210",
+            "name": "DefaultModifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.JavaModifier"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1719162360409810393",
+            "name": "SuperInterfaceMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/1719162360409810393/1719162360409958622",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.SuperMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/8276990574909231788",
+            "name": "FinallyClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/8276990574909231788/8276990574909234106",
+                    "name": "finallyBody",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/281208147558998637",
+            "name": "IComment",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.IHoldLines"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7427431040809561508",
+            "name": "IThrowCheckedExceptions",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/7877620156201500108",
+            "name": "SwitchCaseExtension",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f3061a53-9226-4cc5-a443-f952ceaf5816/7877620156201500108/7877620156201500109",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/3870108946630849399",
+            "name": "StaticFieldReferenceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:f3061a53-9226-4cc5-a443-f952ceaf5816/5763944538902644732",
+            "name": "StaticMethodCallOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.lightweightdsl.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.lightweightdsl.json
@@ -1,0 +1,515 @@
+{
+    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67",
+    "name": "jetbrains.mps.baseLanguage.lightweightdsl",
+    "concepts": [
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767060",
+            "name": "MethodInstance",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767060/19209059688387895",
+                    "name": "decl",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.MethodDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.InstanceMethodDeclaration",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767068",
+            "name": "DependentTypeDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767068/3751132065236767069",
+                    "name": "getter",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767072",
+            "name": "DSLDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767072/1825613483881472526",
+                    "name": "initializer",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+                },
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767072/8264762413010642120",
+                    "name": "classLikeMember",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.DSLClassMember",
+                    "multiple": true
+                },
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767072/4507527286374037522",
+                    "name": "implModel",
+                    "type": "jetbrains.mps.lang.modelapi.ModelIdentity"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767072/1825613483881131410",
+                    "name": "preferredConcept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767076",
+            "name": "ParameterDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767076/3751132065236767078",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767076/2049012130657165289",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767079",
+            "name": "MethodDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767079/3751132065236767080",
+                    "name": "param",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.ParameterDescriptor",
+                    "multiple": true
+                },
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767079/3751132065236767081",
+                    "name": "retType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.lightweightdsl.DSLClassMember"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767083",
+            "name": "DependentTypeInstance",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767083/3751132065236767084",
+                    "name": "decl",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.DependentTypeDescriptor",
+                    "optional": false
+                },
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3751132065236767083/9097849371505568270",
+                    "name": "point",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3571587574961713354",
+            "name": "DSLAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3571587574961713354/3571587574961717879",
+                    "name": "descriptor",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.DSLDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3402736933911578110",
+            "name": "MemberModifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3402736933911578134",
+            "name": "RequiredModifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberModifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010631473",
+            "name": "PropertyDescriptor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010631473/5155329496663029311",
+                    "name": "type",
+                    "type": "jetbrains.mps.lang.structure.PrimitiveDataTypeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.lightweightdsl.DSLClassMember"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010642119",
+            "name": "DSLClassMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010642119/3402736933911577960",
+                    "name": "modifier",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.MemberModifier",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010669353",
+            "name": "PlaceholderModifier",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010669353/8264762413010669653",
+                    "name": "caption"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberModifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010673052",
+            "name": "CustomMemberDescriptor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8264762413010673052/8264762413010673055",
+                    "name": "cncpt",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.DSLClassMember",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308703666",
+            "name": "MemberPlaceholder",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308703666/6478870542308703667",
+                    "name": "caption"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308703666/6478870542308703669",
+                    "name": "decl",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.DSLClassMember",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance",
+                "jetbrains.mps.baseLanguage.ClassifierMember"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308708689",
+            "name": "PropertyInstance",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308708689/8585153554445465961",
+                    "name": "decl",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.PropertyDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.FieldDeclaration",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308708729",
+            "name": "MemberInstance",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308871428",
+            "name": "StringPropertyInstance",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308871428/6478870542308871429",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.lightweightdsl.PropertyInstance"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308871875",
+            "name": "BooleanPropertyInstance",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308871875/6478870542308871876",
+                    "name": "value",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.lightweightdsl.PropertyInstance"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308871877",
+            "name": "IntegerPropertyInstance",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/6478870542308871877/6478870542308871878",
+                    "name": "value",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.lightweightdsl.PropertyInstance"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/5820409521797720671",
+            "name": "EmptyMemberDescriptor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.DSLClassMember"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3682791316837141912",
+            "name": "GenerateModifier",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/3682791316837141912/3855110916776619768",
+                    "name": "name"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberModifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/2141245758541615598",
+            "name": "MultipleModifier",
+            "properties": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/2141245758541615598/2141245758541615599",
+                    "name": "name"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberModifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/1055884086724924397",
+            "name": "AutoInitDSLClass",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8880393040217246788",
+            "name": "MethodParameterInstance",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8880393040217246788/8880393040217294897",
+                    "name": "decl",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.ParameterDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ParameterDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8823436878019095465",
+            "name": "DefaultModifier",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/8823436878019095465/8823436878019096888",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.PropertyInstance",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberModifier"
+            ]
+        },
+        {
+            "uid": "mps:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/4507527286374294556",
+            "name": "ImplementationCode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c7d5b9dd-a05f-4be2-bc73-f2e16994cc67/4507527286374294556/4507527286374294559",
+                    "name": "descriptor",
+                    "type": "jetbrains.mps.baseLanguage.lightweightdsl.DSLDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.logging.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.logging.json
@@ -1,0 +1,101 @@
+{
+    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3",
+    "name": "jetbrains.mps.baseLanguage.logging",
+    "concepts": [
+        {
+            "uid": "mps:760a0a8c-eabb-4521-8bfd-65db761a9ba3/1168401810208",
+            "name": "PrintStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/1168401810208/1168401864803",
+                    "name": "textExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:760a0a8c-eabb-4521-8bfd-65db761a9ba3/2034914114981261497",
+            "name": "LogLowLevelStatement",
+            "properties": [
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/2034914114981261497/2034914114981261751",
+                    "name": "severity"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/2034914114981261497/2034914114981261753",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/2034914114981261497/2034914114981261755",
+                    "name": "throwable",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.logging.IMessage"
+            ]
+        },
+        {
+            "uid": "mps:760a0a8c-eabb-4521-8bfd-65db761a9ba3/6332851714983831325",
+            "name": "MsgStatement",
+            "properties": [
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/6332851714983831325/6332851714983843871",
+                    "name": "severity"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/6332851714983831325/5721587534047265374",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/6332851714983831325/5721587534047265375",
+                    "name": "throwable",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "760a0a8c-eabb-4521-8bfd-65db761a9ba3/6332851714983831325/5721587534047265560",
+                    "name": "project",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.logging.IMessage"
+            ]
+        },
+        {
+            "uid": "mps:760a0a8c-eabb-4521-8bfd-65db761a9ba3/6332851714983849654",
+            "name": "IMessage",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.overloadedOperators.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.overloadedOperators.json
@@ -1,0 +1,205 @@
+{
+    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc",
+    "name": "jetbrains.mps.baseLanguage.overloadedOperators",
+    "concepts": [
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470132813",
+            "name": "OverloadedBinaryOperator",
+            "properties": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470132813/2673276898228709090",
+                    "name": "commutative",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470132813/6677452554237917709",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470132813/6677452554239170993",
+                    "name": "leftType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470132813/6677452554239170994",
+                    "name": "rightType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470132813/2838654975957155510",
+                    "name": "operator",
+                    "type": "jetbrains.mps.baseLanguage.overloadedOperators.Operator",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470139399",
+            "name": "OverloadedOperatorContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470139399/483844232470139400",
+                    "name": "operators",
+                    "type": "jetbrains.mps.baseLanguage.overloadedOperators.OverloadedBinaryOperator",
+                    "multiple": true
+                },
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470139399/2838654975956759196",
+                    "name": "customOperators",
+                    "type": "jetbrains.mps.baseLanguage.overloadedOperators.CustomOperatorDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/483844232470668960",
+            "name": "LeftOperand",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/7789383629180756961",
+            "name": "RightOperand",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/2838654975957036198",
+            "name": "Operator",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/2838654975957155508",
+            "name": "BinaryOperationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/2838654975957155508/2838654975957155509",
+                    "name": "binaryOperation",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.overloadedOperators.Operator"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/2838654975957402167",
+            "name": "CustomOperator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/2838654975957402167/2838654975957402169",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.baseLanguage.overloadedOperators.CustomOperatorDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.overloadedOperators.Operator"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/1569627462441399919",
+            "name": "CustomOperatorUsage",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/1569627462441399919/1569627462441399920",
+                    "name": "operator",
+                    "type": "jetbrains.mps.baseLanguage.overloadedOperators.CustomOperatorDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/1569627462442419521",
+            "name": "CustomOperatorDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:fc8d557e-5de6-4dd8-b749-aab2fb23aefc/7363434029342207049",
+            "name": "ContainerImport",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "fc8d557e-5de6-4dd8-b749-aab2fb23aefc/7363434029342207049/7363434029342207301",
+                    "name": "container",
+                    "type": "jetbrains.mps.baseLanguage.overloadedOperators.OverloadedOperatorContainer",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.regexp.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.regexp.json
@@ -1,0 +1,1120 @@
+{
+    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0",
+    "name": "jetbrains.mps.baseLanguage.regexp",
+    "concepts": [
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174482743037",
+            "name": "Regexp",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174482753837",
+            "name": "StringLiteralRegexp",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174482753837/1174482761807",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174482769792",
+            "name": "OrRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.BinaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174482804200",
+            "name": "PlusRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174482808826",
+            "name": "StarRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174483125581",
+            "name": "RegexpDeclaration",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174483125581/1174662978120",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174483125581/1174483133849",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174484562151",
+            "name": "SeqRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.BinaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174485167097",
+            "name": "BinaryRegexp",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174485167097/1174485176897",
+                    "name": "left",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174485167097/1174485181039",
+                    "name": "right",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174485235885",
+            "name": "UnaryRegexp",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174485235885/1174485243418",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174491169200",
+            "name": "ParensRegexp",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174491169200/1174491174779",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174510540317",
+            "name": "InlineRegexpExpression",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174510540317/1175158902584",
+                    "name": "dotAll",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174510540317/1175158906851",
+                    "name": "multiLine",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174510540317/1175159132192",
+                    "name": "caseInsensitive",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174510540317/1174510571016",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.RegexpExpression"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174512414484",
+            "name": "MatchRegexpStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174512414484/1174512427594",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174512414484/1174512569438",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174552240608",
+            "name": "QuestionRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554186090",
+            "name": "SymbolClassRegexp",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554186090/1174557628217",
+                    "name": "part",
+                    "type": "jetbrains.mps.baseLanguage.regexp.SymbolClassPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp",
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassRegexpAndPart"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554211468",
+            "name": "PositiveSymbolClassRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554238051",
+            "name": "NegativeSymbolClassRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554386384",
+            "name": "PredefinedSymbolClassDeclaration",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554386384/1174554540628",
+                    "name": "description"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554406855",
+            "name": "PredefinedSymbolClasses",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174554406855/1174554418919",
+                    "name": "symbolClass",
+                    "type": "jetbrains.mps.baseLanguage.regexp.PredefinedSymbolClassDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174555732504",
+            "name": "PredefinedSymbolClassRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174555732504/1174555843709",
+                    "name": "symbolClass",
+                    "type": "jetbrains.mps.baseLanguage.regexp.PredefinedSymbolClassDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174556813606",
+            "name": "DotRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174557861378",
+            "name": "SymbolClassPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassRegexpAndPart"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174557878319",
+            "name": "CharacterSymbolClassPart",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174557878319/1174557887320",
+                    "name": "character"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassPart"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174558301835",
+            "name": "IntervalSymbolClassPart",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174558301835/1174558315290",
+                    "name": "start"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174558301835/1174558317822",
+                    "name": "end"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassPart"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174558792178",
+            "name": "PredefinedSymbolClassSymbolClassPart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174558792178/1174558819022",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.baseLanguage.regexp.PredefinedSymbolClassDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassPart"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174564062919",
+            "name": "MatchParensRegexp",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174564062919/1174564160889",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IVariableAssignment"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174565027678",
+            "name": "MatchVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174565027678/1174565035929",
+                    "name": "match",
+                    "type": "jetbrains.mps.baseLanguage.regexp.MatchParensRegexp",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174653354106",
+            "name": "RegexpUsingConstruction",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174653354106/1174653387388",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.RegexpExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174655989549",
+            "name": "ReplaceWithRegexpExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174655989549/1174656103019",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174655989549/1174656339468",
+                    "name": "replaceBlock",
+                    "type": "jetbrains.mps.baseLanguage.regexp.ReplaceBlock",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174656254036",
+            "name": "ReplaceBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Closure"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174660461415",
+            "name": "LazyStarRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174660505718",
+            "name": "LazyPlusRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174660533095",
+            "name": "LazyQuestionRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174662351725",
+            "name": "Regexps",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174662351725/1174662369010",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.RegexpDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174662605354",
+            "name": "RegexpDeclarationReferenceRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174662605354/1174662628918",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.RegexpDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904166999",
+            "name": "NTimesRegexp",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904166999/1174904184877",
+                    "name": "n",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904442594",
+            "name": "AtLeastNTimesRegexp",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904442594/1174904477749",
+                    "name": "n",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904605806",
+            "name": "FromNToMTimesRegexp",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904605806/1174904618869",
+                    "name": "n",
+                    "type": "INT"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174904605806/1174904621683",
+                    "name": "m",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.UnaryRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174906321267",
+            "name": "PositiveLookAheadRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.LookRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174906468661",
+            "name": "NegativeLookAheadRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.LookRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174906544517",
+            "name": "LookRegexp",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174906544517/1174906566584",
+                    "name": "regexp",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174906762287",
+            "name": "PositiveLookBehindRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.LookRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174906790902",
+            "name": "NegativeLookBehindRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.LookRegexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174909099093",
+            "name": "MatchVariableReferenceRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174909099093/1174909113141",
+                    "name": "match",
+                    "type": "jetbrains.mps.baseLanguage.regexp.MatchParensRegexp",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1174919147781",
+            "name": "RegexpExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175154849582",
+            "name": "ForEachMatchStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175154849582/1175154880428",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175154849582/1175154946790",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175161264766",
+            "name": "LineStartRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175161300324",
+            "name": "LineEndRegexp",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175164405556",
+            "name": "SplitExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175164405556/1175164443297",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175169009571",
+            "name": "FindMatchStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175169009571/1175169023932",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1175169009571/1175169154112",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1179357154354",
+            "name": "MatchRegexpExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1179357154354/1179357286898",
+                    "name": "inputExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1203415418648",
+            "name": "UnicodeCharacterRegexp",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1203415418648/1203415499835",
+                    "name": "code"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Regexp"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1220021842985",
+            "name": "IntersectionSymbolClassPart",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1220021842985/1220356033934",
+                    "name": "left",
+                    "type": "jetbrains.mps.baseLanguage.regexp.SymbolClassRegexpAndPart",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1220021842985/1220356007276",
+                    "name": "right",
+                    "type": "jetbrains.mps.baseLanguage.regexp.SymbolClassRegexpAndPart",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.SymbolClassPart"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1220356640633",
+            "name": "SymbolClassRegexpAndPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1222256539755",
+            "name": "SplitOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1222260469397",
+            "name": "MatchRegexpOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/1222260556146",
+            "name": "ReplaceWithRegexpOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/1222260556146/1222261033031",
+                    "name": "replaceBlock",
+                    "type": "jetbrains.mps.baseLanguage.regexp.ReplaceBlock",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/6129327962763158517",
+            "name": "FindMatchExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/6129327962763158517/6129327962763255289",
+                    "name": "inputExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.regexp.RegexpUsingConstruction"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346",
+            "name": "ReplaceRegexpOperation",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346/3796137614137159270",
+                    "name": "dotAll",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346/3796137614137159271",
+                    "name": "multiLine",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346/3796137614137159272",
+                    "name": "caseInsensitive",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346/3796137614137159273",
+                    "name": "globalReplace",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346/3796137614137159227",
+                    "name": "search",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Regexp",
+                    "optional": false
+                },
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137086346/3796137614137086347",
+                    "name": "replacement",
+                    "type": "jetbrains.mps.baseLanguage.regexp.Replacement",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137538892",
+            "name": "LiteralReplacement",
+            "properties": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137538892/3796137614137565243",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Replacement"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137538894",
+            "name": "MatchVariableReferenceReplacement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137538894/3796137614137539525",
+                    "name": "match",
+                    "type": "jetbrains.mps.baseLanguage.regexp.MatchParensRegexp",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.regexp.Replacement"
+            ]
+        },
+        {
+            "uid": "mps:daafa647-f1f7-4b0b-b096-69cd7c8408c0/3796137614137538898",
+            "name": "Replacement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.tuples.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.tuples.json
@@ -1,0 +1,214 @@
+{
+    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a",
+    "name": "jetbrains.mps.baseLanguage.tuples",
+    "concepts": [
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1238852151516",
+            "name": "IndexedTupleType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1238852151516/1238852204892",
+                    "name": "componentType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1238853782547",
+            "name": "IndexedTupleLiteral",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1238853782547/1238853845806",
+                    "name": "component",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1238857743184",
+            "name": "IndexedTupleMemberAccessExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1238857743184/1238857764950",
+                    "name": "tuple",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1238857743184/1238857834412",
+                    "name": "index",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1239360506533",
+            "name": "NamedTupleDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239360506533/1239529553065",
+                    "name": "component",
+                    "type": "jetbrains.mps.baseLanguage.tuples.NamedTupleComponentDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239360506533/322547369016009796",
+                    "name": "extended",
+                    "type": "jetbrains.mps.baseLanguage.tuples.NamedTupleType"
+                },
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239360506533/2423993921025641700",
+                    "name": "implements",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Classifier",
+                "jetbrains.mps.baseLanguage.IBLDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1239462176079",
+            "name": "NamedTupleComponentDeclaration",
+            "properties": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239462176079/1240400839614",
+                    "name": "final",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239462176079/1239462974287",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.HasAnnotation",
+                "jetbrains.mps.baseLanguage.TypeDerivable",
+                "jetbrains.mps.baseLanguage.TypeAnnotable",
+                "jetbrains.mps.lang.core.IResolveInfo"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1239531918181",
+            "name": "NamedTupleType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassifierType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1239559992092",
+            "name": "NamedTupleLiteral",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239559992092/1239560910577",
+                    "name": "componentRef",
+                    "type": "jetbrains.mps.baseLanguage.tuples.NamedTupleComponentReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239559992092/1239560008022",
+                    "name": "tupleDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.tuples.NamedTupleDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1239560581441",
+            "name": "NamedTupleComponentReference",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239560581441/1239560837729",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239560581441/1239560595302",
+                    "name": "componentDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.tuples.NamedTupleComponentDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:a247e09e-2435-45ba-b8d2-07e93feba96a/1239576519914",
+            "name": "NamedTupleComponentAccessOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "a247e09e-2435-45ba-b8d2-07e93feba96a/1239576519914/1239576542472",
+                    "name": "component",
+                    "type": "jetbrains.mps.baseLanguage.tuples.NamedTupleComponentDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.unitTest.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.unitTest.json
@@ -1,0 +1,374 @@
+{
+    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6",
+    "name": "jetbrains.mps.baseLanguage.unitTest",
+    "concepts": [
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171931690126",
+            "name": "TestMethod",
+            "properties": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171931690126/1171931690128",
+                    "name": "methodName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.InstanceMethodDeclaration",
+                "jetbrains.mps.baseLanguage.unitTest.ITestMethod"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171931851043",
+            "name": "BTestCase",
+            "properties": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171931851043/1171931851045",
+                    "name": "testCaseName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171931851043/1171931851044",
+                    "name": "testMethodList",
+                    "type": "jetbrains.mps.baseLanguage.unitTest.TestMethodList",
+                    "optional": false
+                },
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171931851043/8243879142738613219",
+                    "name": "beforeTest",
+                    "type": "jetbrains.mps.baseLanguage.unitTest.BeforeTest"
+                },
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171931851043/8243879142738613220",
+                    "name": "afterTest",
+                    "type": "jetbrains.mps.baseLanguage.unitTest.AfterTest"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.unitTest.ITestCase",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171931858461",
+            "name": "TestMethodList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171931858461/1171931858462",
+                    "name": "testMethod",
+                    "type": "jetbrains.mps.baseLanguage.unitTest.TestMethod",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171978097730",
+            "name": "AssertEquals",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.BinaryAssert"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171981022339",
+            "name": "AssertTrue",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171981022339/1171981057159",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171983834376",
+            "name": "AssertFalse",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1171983834376/1171983854940",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1171985735491",
+            "name": "AssertSame",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.BinaryAssert"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1172017222794",
+            "name": "Fail",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1172028177041",
+            "name": "AssertIsNull",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1172028177041/1172028236559",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1172069869612",
+            "name": "AssertThrows",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1172069869612/1172070029086",
+                    "name": "statement",
+                    "type": "jetbrains.mps.baseLanguage.Statement",
+                    "optional": false
+                },
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1172069869612/1172070532815",
+                    "name": "exceptionType",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1172073500303",
+            "name": "Message",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1172073500303/1172073511101",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1172075514136",
+            "name": "MessageHolder",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1172075514136/1172075534298",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.unitTest.Message"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1215620452633",
+            "name": "ITestable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1216130694486",
+            "name": "ITestCase",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/1216130694486/6427619394892729757",
+                    "name": "canNotRunInProcess",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.ITestable",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/1216134482493",
+            "name": "ITestMethod",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.ITestable"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/7080278351417106679",
+            "name": "AssertIsNotNull",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/7080278351417106679/7080278351417106681",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/8427750732757990717",
+            "name": "BinaryAssert",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/8427750732757990717/8427750732757990724",
+                    "name": "expected",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "f61473f9-130f-42f6-b98d-6c438812c2f6/8427750732757990717/8427750732757990725",
+                    "name": "actual",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/8243879142738608185",
+            "name": "BeforeTest",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.PrepareMethod"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/8243879142738613213",
+            "name": "AfterTest",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.PrepareMethod"
+            ]
+        },
+        {
+            "uid": "mps:f61473f9-130f-42f6-b98d-6c438812c2f6/8243879142738615226",
+            "name": "PrepareMethod",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.varVariable.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguage.varVariable.json
@@ -1,0 +1,33 @@
+{
+    "uid": "515552c7-fcc0-4ab4-9789-2f3c49344e85",
+    "name": "jetbrains.mps.baseLanguage.varVariable",
+    "concepts": [
+        {
+            "uid": "mps:515552c7-fcc0-4ab4-9789-2f3c49344e85/1236693300889",
+            "name": "VarVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.LocalVariableDeclaration",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:515552c7-fcc0-4ab4-9789-2f3c49344e85/1177714083117",
+            "name": "VarType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.UndefinedType"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguageInternal.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.baseLanguageInternal.json
@@ -1,0 +1,668 @@
+{
+    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88",
+    "name": "jetbrains.mps.baseLanguageInternal",
+    "concepts": [
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1173990517731",
+            "name": "InternalStaticMethodCall",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173990517731/1173992483054",
+                    "name": "fqClassName"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173990517731/1173992444083",
+                    "name": "methodName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173990517731/1175794062018",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173990517731/1200499032583",
+                    "name": "typeParameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173990517731/319021450862604085",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1173995204289",
+            "name": "InternalStaticFieldReference",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173995204289/1173995448817",
+                    "name": "fqClassName"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173995204289/1173995466678",
+                    "name": "fieldName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1173996401517",
+            "name": "InternalNewExpression",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173996401517/1173996588177",
+                    "name": "fqClassName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173996401517/1179332974947",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173996401517/1240934738108",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1173996401517/319021450862590135",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1174294166120",
+            "name": "InternalPartialInstanceMethodCall",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1174294166120/1174294288199",
+                    "name": "methodName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1174294166120/1174313653259",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1174294166120/1174317636233",
+                    "name": "instance",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1174294166120/1174318197094",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1174478619261",
+            "name": "InternalClassExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1174478619261/1174478663778",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1174914042989",
+            "name": "InternalClassifierType",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1174914042989/1174914081067",
+                    "name": "fqClassName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1176743162354",
+            "name": "InternalVariableReference",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1176743162354/1176743296073",
+                    "name": "name"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1176743162354/1176743202636",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1177590007607",
+            "name": "InternalPartialFieldReference",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1177590007607/1177590059093",
+                    "name": "fieldName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1177590007607/1177590063781",
+                    "name": "fieldType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1177590007607/1177597912206",
+                    "name": "instanceType",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1177590007607/1177590086595",
+                    "name": "instance",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1199964756070",
+            "name": "TypeHintExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1199964756070/1199964762556",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1199964756070/1199964767385",
+                    "name": "typeHint",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1202838164916",
+            "name": "InternalThisExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1238251434034",
+            "name": "ExtractToConstantExpression",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1238251434034/1238251449050",
+                    "name": "fieldName"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1238251434034/8835849473318867199",
+                    "name": "makeUnique",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1238251434034/1238251454130",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3196918548952765095",
+            "name": "ExtractStatementListExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3196918548952765095/3196918548952767737",
+                    "name": "stmts",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3196918548952765095/3196918548952839504",
+                    "name": "innerExpr",
+                    "type": "jetbrains.mps.baseLanguageInternal.ExtractStatementListInnerExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.ILocalVariableElementList"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3196918548953109193",
+            "name": "ExtractStatementListInnerExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3196918548953109193/3196918548953109194",
+                    "name": "inner",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.ILocalVariableElement"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3585982959253588676",
+            "name": "ExtractStaticMethodExpression",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3585982959253588676/8733626498296603539",
+                    "name": "makeUnique",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3585982959253588676/3585982959253588678",
+                    "name": "method",
+                    "type": "jetbrains.mps.baseLanguage.StaticMethodDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3585982959253588676/3585982959253588677",
+                    "name": "inner",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3585982959253821850",
+            "name": "ExtractStaticMethod_CallExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/7738261905749564104",
+            "name": "ExtractStaticInnerClassExpression",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/7738261905749564104/7738261905749582054",
+                    "name": "makeUnique",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/7738261905749564104/4106700815269135333",
+                    "name": "nonStatic",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/7738261905749564104/7738261905749564105",
+                    "name": "innerClass",
+                    "type": "jetbrains.mps.baseLanguageInternal.ExtractStaticInnerClassConcept",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/7738261905749564104/7738261905749582030",
+                    "name": "inner",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/5822086619725599105",
+            "name": "ExtractStaticInnerClassCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassCreator"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/937236280924494202",
+            "name": "ExtractStaticInnerClassConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/99767819676010097",
+            "name": "ExtractToConstantRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/99767819676010097/99767819676010098",
+                    "name": "original",
+                    "type": "jetbrains.mps.baseLanguageInternal.ExtractToConstantExpression",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/8791205313600585946",
+            "name": "WeakClassReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/8791205313600585946/8791205313600585947",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559752",
+            "name": "InternalAnonymousClassCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559752/3421461530438560031",
+                    "name": "cls",
+                    "type": "jetbrains.mps.baseLanguageInternal.InternalAnonymousClass",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559753",
+            "name": "InternalAnonymousClass",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559753/3421461530438559973",
+                    "name": "fqClassName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559753/3421461530438559756",
+                    "name": "constructorArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559753/3421461530438559974",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3421461530438559753/3421461530438559757",
+                    "name": "typeParameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.IAnonymousClass",
+                "jetbrains.mps.baseLanguage.IControlFlowInterrupter"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1585405235656310154",
+            "name": "ConstantValue",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1585405235656310154/1585405235656310169",
+                    "name": "className"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1585405235656310154/1585405235656310155",
+                    "name": "constant",
+                    "type": "jetbrains.mps.baseLanguage.StaticFieldDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/3731567766880819155",
+            "name": "InternalSuperMethodCallOperation",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3731567766880819155/3731567766880819160",
+                    "name": "methodName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3731567766880819155/3731567766880819158",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/3731567766880819155/3731567766880819159",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/1100832983841311024",
+            "name": "InternalClassCreator",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1100832983841311024/1100832983841311026",
+                    "name": "fqClassName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1100832983841311024/1100832983841311029",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1100832983841311024/1100832983841311027",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "multiple": true
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/1100832983841311024/1100832983841311028",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/8228699960986551056",
+            "name": "InternalTypedStaticFieldReference",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/8228699960986551056/8228699960986556342",
+                    "name": "returnType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguageInternal.InternalStaticFieldReference"
+            ]
+        },
+        {
+            "uid": "mps:df345b11-b8c7-4213-ac66-48d2a9b75d88/4927083583736784422",
+            "name": "ExtractToSingleConstantExpression",
+            "properties": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/4927083583736784422/4927083583736815155",
+                    "name": "uniqueFieldName"
+                },
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/4927083583736784422/3566113306135792467",
+                    "name": "baseContainerName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "df345b11-b8c7-4213-ac66-48d2a9b75d88/4927083583736784422/4927083583736819744",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.core.properties.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.core.properties.json
@@ -1,0 +1,75 @@
+{
+    "uid": "58f98fef-90ad-4b72-a390-fad66ec7005a",
+    "name": "jetbrains.mps.core.properties",
+    "concepts": [
+        {
+            "uid": "mps:58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390517588",
+            "name": "PropertiesFile",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390517588/3961775458390522563",
+                    "name": "lines",
+                    "type": "jetbrains.mps.core.properties.PropertiesLine",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.traceable.UnitConcept"
+            ]
+        },
+        {
+            "uid": "mps:58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390522561",
+            "name": "PropertiesDeclaration",
+            "properties": [
+                {
+                    "uid": "58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390522561/3961775458390522596",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.properties.PropertiesLine",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390522562",
+            "name": "PropertiesLine",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390522585",
+            "name": "PropertiesComment",
+            "properties": [
+                {
+                    "uid": "58f98fef-90ad-4b72-a390-fad66ec7005a/3961775458390522585/3961775458390522586",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.properties.PropertiesLine"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.core.xml.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.core.xml.json
@@ -1,0 +1,511 @@
+{
+    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298",
+    "name": "jetbrains.mps.core.xml",
+    "concepts": [
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6786756355279841993",
+            "name": "XmlDocument",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6786756355279841993/6666499814681299060",
+                    "name": "prolog",
+                    "type": "jetbrains.mps.core.xml.XmlProlog"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6786756355279841993/6666499814681299055",
+                    "name": "rootElement",
+                    "type": "jetbrains.mps.core.xml.XmlBaseElement",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299051",
+            "name": "XmlContent",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.core.xml.XmlPart"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299053",
+            "name": "XmlBaseElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299057",
+            "name": "XmlProlog",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299057/7604553062773674214",
+                    "name": "elements",
+                    "type": "jetbrains.mps.core.xml.XmlPrologElement",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299061",
+            "name": "XmlProcessingInstruction",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299061/6666499814681299062",
+                    "name": "target"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299061/6666499814681299063",
+                    "name": "rawData"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent",
+                "jetbrains.mps.core.xml.XmlPrologElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299064",
+            "name": "XmlComment",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299064/1622293396949036151",
+                    "name": "lines",
+                    "type": "jetbrains.mps.core.xml.XmlCommentLine",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent",
+                "jetbrains.mps.core.xml.XmlPrologElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299066",
+            "name": "XmlCDATA",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681299066/1622293396948985395",
+                    "name": "content"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681415858",
+            "name": "XmlElement",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681415858/6666499814681415862",
+                    "name": "tagName"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681415858/6999033275467544021",
+                    "name": "shortEmptyNotation",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681415858/6666499814681415861",
+                    "name": "attributes",
+                    "type": "jetbrains.mps.core.xml.XmlBaseAttribute",
+                    "multiple": true
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681415858/1622293396948928802",
+                    "name": "content",
+                    "type": "jetbrains.mps.core.xml.XmlContent",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlBaseElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681415859",
+            "name": "XmlBaseAttribute",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681447923",
+            "name": "XmlAttribute",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681447923/6666499814681447926",
+                    "name": "attrName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681447923/6666499814681541918",
+                    "name": "value",
+                    "type": "jetbrains.mps.core.xml.XmlValuePart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlBaseAttribute"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681515200",
+            "name": "XmlFile",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681515200/7692057055172140539",
+                    "name": "fileExtension"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681515200/6666499814681515201",
+                    "name": "document",
+                    "type": "jetbrains.mps.core.xml.XmlDocument",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.traceable.UnitConcept"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541916",
+            "name": "XmlValuePart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919",
+            "name": "XmlTextValue",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlValuePart"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541921",
+            "name": "XmlEntityRefValue",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541921/6666499814681543256",
+                    "name": "entityName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlValuePart"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339",
+            "name": "XmlText",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396948952339/1622293396948953704",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396949036126",
+            "name": "XmlCommentLine",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396949036126/1622293396949036127",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396949069645",
+            "name": "XmlEntityRef",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/1622293396949069645/1622293396949069711",
+                    "name": "entityName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/3080189811177199750",
+            "name": "XmlCharRef",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/3080189811177199750/3080189811177199751",
+                    "name": "charCode"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlContent"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/3080189811177215998",
+            "name": "XmlCharRefValue",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/3080189811177215998/3080189811177216006",
+                    "name": "charCode"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlValuePart"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/3080189811177426492",
+            "name": "XmlNoSpaceValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlValuePart"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/7604553062773674213",
+            "name": "XmlPrologElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlPart"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/7604553062773750440",
+            "name": "XmlWhitespace",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/7604553062773750440/5228786488744844115",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlBasePrologElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/5228786488744996718",
+            "name": "XmlDeclaration",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/5228786488744996718/5491461270226117667",
+                    "name": "version"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/5228786488744996718/3374336260035925078",
+                    "name": "encoding"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/5228786488744996718/3374336260035925080",
+                    "name": "standalone"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlBasePrologElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044437631294",
+            "name": "XmlPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044437669768",
+            "name": "XmlBasePrologElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.core.xml.XmlPrologElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044437898907",
+            "name": "XmlDoctypeDeclaration",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044437898907/2133624044437898910",
+                    "name": "doctypeName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044437898907/2133624044438029120",
+                    "name": "externalId",
+                    "type": "jetbrains.mps.core.xml.XmlExternalId"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.XmlBasePrologElement"
+            ]
+        },
+        {
+            "uid": "mps:479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044438029119",
+            "name": "XmlExternalId",
+            "properties": [
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044438029119/2133624044438029123",
+                    "name": "publicId"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044438029119/2133624044438029124",
+                    "name": "systemId"
+                },
+                {
+                    "uid": "479c7a8c-02f9-43b5-9139-d910cb22f298/2133624044438029119/2133624044438029125",
+                    "name": "isPublic",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.core.xml.sax.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.core.xml.sax.json
@@ -1,0 +1,514 @@
+{
+    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63",
+    "name": "jetbrains.mps.core.xml.sax",
+    "concepts": [
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140353",
+            "name": "XMLSAXAttributeHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.sax.XMLSAXHandlerFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140361",
+            "name": "XMLSAXAttributeReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140361/2264311582634140362",
+                    "name": "attribute",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXAttributeRule",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140363",
+            "name": "XMLSAXAttributeRule",
+            "properties": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140363/2264311582634140364",
+                    "name": "isRequired",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140363/2264311582634140365",
+                    "name": "handler",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXAttributeHandler"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140367",
+            "name": "XMLSAXBreakStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140367/2264311582634140369",
+                    "name": "result",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140370",
+            "name": "XMLSAXChildHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.sax.XMLSAXHandlerFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140373",
+            "name": "XMLSAXChildHandler_childObject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376",
+            "name": "XMLSAXChildRule",
+            "properties": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376/2264311582634140378",
+                    "name": "tagName"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376/2264311582634140379",
+                    "name": "overrideTag",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376/4720003541470390117",
+                    "name": "condition",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXChildRuleCondition"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376/2264311582634140377",
+                    "name": "handler",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXChildHandler"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376/1068499141038",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140376/2264311582634140380",
+                    "name": "rule",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeRule",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140381",
+            "name": "XMLSAXFieldDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140381/2264311582634140382",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140384",
+            "name": "XMLSAXFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140384/2264311582634140385",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXFieldDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140387",
+            "name": "XMLSAXHandlerFunction",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140394",
+            "name": "XMLSAXHandler_resultObject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140397",
+            "name": "XMLSAXLocatorExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140399",
+            "name": "XMLSAXNodeCreator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402",
+            "name": "XMLSAXNodeRule",
+            "properties": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140409",
+                    "name": "tagName"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140410",
+                    "name": "isCompact",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140403",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/980633948634473186",
+                    "name": "params",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeRuleParam",
+                    "multiple": true
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140404",
+                    "name": "attrs",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXAttributeRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140405",
+                    "name": "children",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXChildRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/4250669309761816325",
+                    "name": "defaultChild",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXDefaultChildRule"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140406",
+                    "name": "text",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXTextRule"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140407",
+                    "name": "creator",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeCreator"
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140402/2264311582634140408",
+                    "name": "validator",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeValidator"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140412",
+            "name": "XMLSAXNodeValidator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.sax.XMLSAXHandlerFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140417",
+            "name": "XMLSAXParser",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140417/2264311582634140418",
+                    "name": "parameters",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXFieldDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140417/2264311582634140420",
+                    "name": "nodes",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140417/2264311582634140421",
+                    "name": "fields",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXFieldDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140417/2264311582634140422",
+                    "name": "globalText",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXTextRule"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140417/2264311582634140419",
+                    "name": "root",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeRule",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140424",
+            "name": "XMLSAXTextHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.sax.XMLSAXHandlerFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140432",
+            "name": "XMLSAXTextRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/2264311582634140432/2264311582634140433",
+                    "name": "handler",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXTextHandler"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/3465552206661906222",
+            "name": "XMLSAXAttributeHandler_value",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/3465552206661911172",
+            "name": "XMLSAXTextHandler_value",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/980633948634473453",
+            "name": "XMLSAXNodeRuleParam",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4720003541456852678",
+            "name": "XMLSAXNodeRuleParamRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4720003541456852678/4720003541456852960",
+                    "name": "param",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXNodeRuleParam",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4720003541470384741",
+            "name": "XMLSAXChildRuleCondition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4250669309761661311",
+            "name": "XMLSAXDefaultChildRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4250669309761661311/4250669309761661313",
+                    "name": "handler",
+                    "type": "jetbrains.mps.core.xml.sax.XMLSAXDefaultChildHandler"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4250669309761678855",
+            "name": "XMLSAXDefaultChildHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.core.xml.sax.XMLSAXHandlerFunction"
+            ]
+        },
+        {
+            "uid": "mps:dcb5a83a-19a8-44ff-a4cb-fc7d324ecc63/4250669309762245972",
+            "name": "XMLSAXDefaultChildHandler_tagName",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.execution.util.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.execution.util.json
@@ -1,0 +1,19 @@
+{
+    "uid": "4caf0310-491e-41f5-8a9b-2006b3a94898",
+    "name": "jetbrains.mps.execution.util",
+    "concepts": [
+        {
+            "uid": "mps:4caf0310-491e-41f5-8a9b-2006b3a94898/4666195181811081429",
+            "name": "IMainClass",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.access.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.access.json
@@ -1,0 +1,147 @@
+{
+    "uid": "63650c59-16c8-498a-99c8-005c7ee9515d",
+    "name": "jetbrains.mps.lang.access",
+    "concepts": [
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348170",
+            "name": "BaseExecuteCommandStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348170/8974276187400348171",
+                    "name": "commandClosureLiteral",
+                    "type": "jetbrains.mps.lang.access.CommandClosureLiteral",
+                    "optional": false
+                },
+                {
+                    "uid": "63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348170/1423104411234567454",
+                    "name": "repo",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348172",
+            "name": "BaseExecuteCommandStatementSync",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatement"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348173",
+            "name": "CommandClosureLiteral",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348174",
+            "name": "ExecuteCommandInEDTStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatement"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348177",
+            "name": "ExecuteCommandStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatementSync"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348179",
+            "name": "ExecuteEDTCommandStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatement"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348181",
+            "name": "ExecuteLightweightCommandStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatementSync"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348183",
+            "name": "ExecuteWriteActionStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatementSync"
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/8974276187400348185",
+            "name": "IExecuteCommandStatementSync",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:63650c59-16c8-498a-99c8-005c7ee9515d/5332677359380589431",
+            "name": "ExecuteTransparentCommandStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.access.BaseExecuteCommandStatementSync"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.actions.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.actions.json
@@ -1,0 +1,517 @@
+{
+    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd",
+    "name": "jetbrains.mps.lang.actions",
+    "concepts": [
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158700664498",
+            "name": "NodeFactories",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158700664498/1158700779049",
+                    "name": "nodeFactory",
+                    "type": "jetbrains.mps.lang.actions.NodeFactory",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158700725281",
+            "name": "NodeFactory",
+            "properties": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158700725281/1158952310477",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158700725281/1158701448518",
+                    "name": "setupFunction",
+                    "type": "jetbrains.mps.lang.actions.NodeSetupFunction",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158700725281/1158700943156",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1158701162220",
+            "name": "NodeSetupFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221135252814",
+            "name": "PasteWrappers",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221135252814/1221135321084",
+                    "name": "wrapper",
+                    "type": "jetbrains.mps.lang.actions.PasteWrapper",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221135315536",
+            "name": "PasteWrapper",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221135315536/1221137217490",
+                    "name": "wrapperFunction",
+                    "type": "jetbrains.mps.lang.actions.QueryFunction_PasteWrapper",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221135315536/1221135563864",
+                    "name": "sourceConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221135315536/1221137152191",
+                    "name": "targetConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221137268788",
+            "name": "ConceptFunctionParameter_nodeToPasteWrap",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/1221137293320",
+            "name": "QueryFunction_PasteWrapper",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/564335015825199468",
+            "name": "PastePostProcessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/564335015825199468/3887139083693416947",
+                    "name": "postProcessFunction",
+                    "type": "jetbrains.mps.lang.actions.PastePostProcessFunction",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/564335015825199468/6026743057587410043",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/6026743057587433039",
+            "name": "PastePostProcessFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/6026743057587447931",
+            "name": "ConceptFunctionParameter_nodeToPastePostProcess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682321734",
+            "name": "CopyPreProcessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682321734/5948027493682325465",
+                    "name": "preProcessFunction",
+                    "type": "jetbrains.mps.lang.actions.CopyPreProcessFunction",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682321734/5948027493682346893",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682346911",
+            "name": "CopyPreProcessFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682405428",
+            "name": "ConceptFunctionParameter_nodeToCopyPreProcess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682405480",
+            "name": "ConceptFunctionParameter_nodeToCopyPreProcessOriginal",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682789918",
+            "name": "CopyPasteHandlers",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682789918/5948027493682790174",
+                    "name": "postProcessor",
+                    "type": "jetbrains.mps.lang.actions.PastePostProcessor",
+                    "multiple": true
+                },
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5948027493682789918/5948027493682790175",
+                    "name": "preProcessor",
+                    "type": "jetbrains.mps.lang.actions.CopyPreProcessor",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5979988948250981289",
+            "name": "SNodeCreatorAndInitializer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5979988948250981289/3757480014665187678",
+                    "name": "prototype",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeCreator"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/7776141288922801652",
+            "name": "NF_Concept_NewInstance",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/7776141288922801652/3757480014665178932",
+                    "name": "prototype",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Concept_NewInstance"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5480835971642155304",
+            "name": "NF_Model_CreateNewNodeOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5480835971642155304/3757480014665175786",
+                    "name": "prototype",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Model_CreateNewNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5480835971642160908",
+            "name": "NF_Model_CreateNewRootNodeOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5480835971642160908/3757480014665175784",
+                    "name": "prototype",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Model_CreateNewRootNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/767145758118872824",
+            "name": "NF_Node_InsertNewNextSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Node_InsertNewNextSiblingOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/767145758118872826",
+            "name": "NF_Node_InsertNewPrevSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Node_InsertNewPrevSiblingOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/767145758118872828",
+            "name": "NF_Node_ReplaceWithNewOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Node_ReplaceWithNewOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/767145758118872830",
+            "name": "NF_Link_SetNewChildOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Link_SetNewChildOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/767145758118872833",
+            "name": "NF_LinkList_AddNewChildOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.LinkList_AddNewChildOperation"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5584396657084912703",
+            "name": "NodeSetupFunction_NewNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5584396657084920413",
+            "name": "NodeSetupFunction_SampleNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/5584396657084920670",
+            "name": "NodeSetupFunction_EnclosingNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/562388756457499018",
+            "name": "MigratedToAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/562388756457499018/562388756457499129",
+                    "name": "migratedTo",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/562388756457602485",
+            "name": "MigrateManuallyAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "aee9cad2-acd4-4608-aef2-0004f6a1cdbd/562388756457602485/562388756457602486",
+                    "name": "migrateTo",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:aee9cad2-acd4-4608-aef2-0004f6a1cdbd/8525549501910325545",
+            "name": "ICouldBeAnnotatedWithMigrateManually",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.aspect.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.aspect.json
@@ -1,0 +1,184 @@
+{
+    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af",
+    "name": "jetbrains.mps.lang.aspect",
+    "concepts": [
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/3274906159125934214",
+            "name": "LanguageAspectDescriptor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.AutoInitDSLClass"
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374",
+            "name": "SimpleLanguageAspectDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374/6106419185511570295",
+                    "name": "mainLanguages",
+                    "type": "jetbrains.mps.lang.smodel.LanguageIdentity",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374/6106419185511570301",
+                    "name": "additionalLanguages",
+                    "type": "jetbrains.mps.lang.smodel.LanguageIdentity",
+                    "multiple": true
+                },
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374/8222125370833980146",
+                    "name": "devkit",
+                    "type": "jetbrains.mps.lang.smodel.DevkitIdentity"
+                },
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374/3433054418425083029",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon"
+                },
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374/4726480899534753275",
+                    "name": "helpUrl",
+                    "type": "jetbrains.mps.lang.resources.HelpURL"
+                },
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/3433054418424672374/2343319097654255233",
+                    "name": "order",
+                    "type": "jetbrains.mps.lang.util.order.Order"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.util.order.OrderParticipant"
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/6641743975991294767",
+            "name": "GenerationDescriptor_Class",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/6641743975991294767/6422667311313188829",
+                    "name": "implTemplate",
+                    "type": "jetbrains.mps.baseLanguage.ClassConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.aspect.GenerationDescriptor"
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/6659466008484795896",
+            "name": "GenerationDescriptor",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/6659466008484795896/8999016044020882995",
+                    "name": "mainIntfcClass",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/5386558680326206123",
+            "name": "GenerationDescriptor_ByInterface",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/5386558680326206123/5386558680326206125",
+                    "name": "methods",
+                    "type": "jetbrains.mps.lang.aspect.AspectMethodDescriptor",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.aspect.GenerationDescriptor"
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/5386558680326206128",
+            "name": "AspectMethodDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/5386558680326206128/5386558680326206132",
+                    "name": "baseConceptFunc",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/5386558680326206128/5386558680326206129",
+                    "name": "method",
+                    "type": "jetbrains.mps.baseLanguage.MethodDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "f159adf4-3c93-40f9-9c5a-1f245a8697af/5386558680326206128/5386558680326206137",
+                    "name": "cncpt",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/8921494878338859209",
+            "name": "IAspectConcept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:f159adf4-3c93-40f9-9c5a-1f245a8697af/174635545557784815",
+            "name": "SimpleAspectOrderRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.util.order.OrderParticipantReference"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.behavior.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.behavior.json
@@ -1,0 +1,185 @@
+{
+    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1",
+    "name": "jetbrains.mps.lang.behavior",
+    "concepts": [
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194240794",
+            "name": "ConceptBehavior",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194240794/1225194240801",
+                    "name": "constructor",
+                    "type": "jetbrains.mps.lang.behavior.ConceptConstructorDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194240794/1225194240805",
+                    "name": "method",
+                    "type": "jetbrains.mps.lang.behavior.ConceptMethodDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194240794/1225194240799",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IMemberContainer",
+                "jetbrains.mps.baseLanguage.IExtractMethodAvailable",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194413805",
+            "name": "ConceptConstructorDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194472830",
+            "name": "ConceptMethodDeclaration",
+            "properties": [
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194472830/1225194472832",
+                    "name": "isVirtual",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194472830/1225194472833",
+                    "name": "isPrivate",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194472830/1225194472834",
+                    "name": "isAbstract",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194472830/5864038008284099149",
+                    "name": "isStatic",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194472830/1225194472831",
+                    "name": "overriddenMethod",
+                    "type": "jetbrains.mps.lang.behavior.ConceptMethodDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.baseLanguage.IVisible"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194628440",
+            "name": "SuperNodeExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194628440/5299096511375896640",
+                    "name": "superConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.behavior.SuperExpression"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/1225194691553",
+            "name": "ThisNodeExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IThisExpression"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/6496299201655527393",
+            "name": "LocalBehaviorMethodCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/1703835097132541506",
+            "name": "ThisConceptExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IThisExpression"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/7613853987897845671",
+            "name": "SuperConceptExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "af65afd8-f0dd-4942-87d9-63a55f2a9db1/7613853987897845671/7613853987897845672",
+                    "name": "superConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.behavior.SuperExpression"
+            ]
+        },
+        {
+            "uid": "mps:af65afd8-f0dd-4942-87d9-63a55f2a9db1/2668211767468819683",
+            "name": "SuperExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.checkedName.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.checkedName.json
@@ -1,0 +1,90 @@
+{
+    "uid": "fe9d76d7-5809-45c9-ae28-a40915b4d6ff",
+    "name": "jetbrains.mps.lang.checkedName",
+    "concepts": [
+        {
+            "uid": "mps:fe9d76d7-5809-45c9-ae28-a40915b4d6ff/4844813484172611384",
+            "name": "ICheckedNamePolicy",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:fe9d76d7-5809-45c9-ae28-a40915b4d6ff/4844813484172611385",
+            "name": "PropertyRefExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "fe9d76d7-5809-45c9-ae28-a40915b4d6ff/4844813484172611385/4844813484172611386",
+                    "name": "nodeExpr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "fe9d76d7-5809-45c9-ae28-a40915b4d6ff/4844813484172611385/4844813484172611387",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:fe9d76d7-5809-45c9-ae28-a40915b4d6ff/4844813484172611390",
+            "name": "PropertyRefType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:fe9d76d7-5809-45c9-ae28-a40915b4d6ff/8697758915834074539",
+            "name": "PropertyPointerValueOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:fe9d76d7-5809-45c9-ae28-a40915b4d6ff/8697758915834076725",
+            "name": "PropertyPointerType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "fe9d76d7-5809-45c9-ae28-a40915b4d6ff/8697758915834076725/3232030656012226095",
+                    "name": "dataType",
+                    "type": "jetbrains.mps.lang.structure.DataTypeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.json
@@ -1,0 +1,747 @@
+{
+    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1",
+    "name": "jetbrains.mps.lang.constraints",
+    "concepts": [
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147467115080",
+            "name": "NodePropertyConstraint",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147467115080/1147468630220",
+                    "name": "propertyGetter",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_PropertyGetter"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147467115080/1152963095733",
+                    "name": "propertySetter",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_PropertySetter"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147467115080/1212097481299",
+                    "name": "propertyValidator",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_PropertyValidator"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147467115080/1147467295099",
+                    "name": "applicableProperty",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147467790433",
+            "name": "ConstraintFunction_PropertyGetter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1147468365020",
+            "name": "ConstraintsFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148687176410",
+            "name": "NodeReferentConstraint",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148687176410/1148687345559",
+                    "name": "searchScopeFactory",
+                    "type": "jetbrains.mps.lang.constraints.NodeScopeFactory"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148687176410/3906442776579556548",
+                    "name": "presentation",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_ReferentSearchScope_Presentation"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148687176410/1163203787401",
+                    "name": "referentSetHandler",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_ReferentSetHandler"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148687176410/8830318409774605087",
+                    "name": "keepsReference",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_RefSetHandlerKeepsReference"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148687176410/1148687202698",
+                    "name": "applicableLink",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148934493876",
+            "name": "ConstraintFunction_ReferentSearchScope_AbstractBase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1148934636683",
+            "name": "ConceptParameter_ReferentSearchScope_enclosingNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1152959968041",
+            "name": "ConstraintFunction_PropertySetter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1159285995602",
+            "name": "NodeDefaultSearchScope",
+            "properties": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1159285995602/1159286099186",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1159285995602/1159286114227",
+                    "name": "searchScopeFactory",
+                    "type": "jetbrains.mps.lang.constraints.NodeScopeFactory",
+                    "optional": false
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1159285995602/3906442776579628834",
+                    "name": "presentation",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_ReferentSearchScope_Presentation"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1163200368514",
+            "name": "ConstraintFunction_ReferentSetHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1163200647017",
+            "name": "ConstraintFunctionParameter_referenceNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1163202640154",
+            "name": "ConstraintFunctionParameter_newReferentNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1163202694127",
+            "name": "ConstraintFunctionParameter_oldReferentNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1202989658459",
+            "name": "ConstraintFunctionParameter_parentNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1205764368223",
+            "name": "ConstraintFunctionParameter_linkTargetNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1153138554286",
+            "name": "ConstraintsFunctionParameter_propertyValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1212096972063",
+            "name": "ConstraintFunction_PropertyValidator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558",
+            "name": "ConceptConstraints",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1213098023997",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.constraints.NodePropertyConstraint",
+                    "multiple": true
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1213100494875",
+                    "name": "referent",
+                    "type": "jetbrains.mps.lang.constraints.NodeReferentConstraint",
+                    "multiple": true
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1213101058038",
+                    "name": "defaultScope",
+                    "type": "jetbrains.mps.lang.constraints.NodeDefaultSearchScope"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/6702802731807737306",
+                    "name": "canBeChild",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_CanBeAChild"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1227085062429",
+                    "name": "canBeRoot",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_CanBeARoot"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/6702802731807532712",
+                    "name": "canBeParent",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_CanBeAParent"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/6702802731807532730",
+                    "name": "canBeAncestor",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_CanBeAnAncestor"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/3754598629525415384",
+                    "name": "alternativeIcon",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_GetAlternativeIcon"
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1426851521646478396",
+                    "name": "instanceIcon",
+                    "type": "jetbrains.mps.lang.constraints.ConstraintFunction_GetInstanceIcon"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1213093996982",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1213093968558/1213106917431",
+                    "name": "defaultConcreteConcept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1227084988347",
+            "name": "ConstraintFunction_CanBeARoot",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/3906442776579549644",
+            "name": "ConstraintFunctionParameter_parameterNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/3906442776579556545",
+            "name": "ConstraintFunction_ReferentSearchScope_Presentation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.constraints.ConstraintFunction_ReferentSearchScope_AbstractBase"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6768994795311967732",
+            "name": "ConstraintFunctionParameter_visible",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6768994795311967741",
+            "name": "ConstraintFunctionParameter_smartReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4590747232508808445",
+            "name": "ConstraintFunctionParameter_inEditor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/3754598629525415375",
+            "name": "ConstraintFunction_GetAlternativeIcon",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/2990203945683059368",
+            "name": "ConstraintFunctionParameter_checkedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4962705936936018688",
+            "name": "ConstraintFunction_RefSetHandlerKeepsReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/2978993595262518683",
+            "name": "ConstraintFunctionParameter_containingLink",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/8401916545537438634",
+            "name": "NodeScopeFactory",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/8401916545537438642",
+            "name": "InheritedNodeScopeFactory",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/8401916545537438642/8401916545537438643",
+                    "name": "kind",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.constraints.NodeScopeFactory"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/8966504967485224688",
+            "name": "ConstraintFunctionParameter_contextNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4656991770397278586",
+            "name": "ConstraintFunctionParameter_contextRole",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4656991770397278593",
+            "name": "ConstraintFunctionParameter_exists",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4656991770397278600",
+            "name": "ConstraintFunctionParameter_position",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6738154313879680265",
+            "name": "ConstraintFunctionParameter_childNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1426851521646451314",
+            "name": "ConstraintFunction_GetInstanceIcon",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4303308395523096213",
+            "name": "ConstraintFunctionParameter_childConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6702802731807424858",
+            "name": "ConstraintFunction_CanBeAnAncestor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/4303308395523343364",
+            "name": "ConstraintFunctionParameter_link",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6702802731807351367",
+            "name": "ConstraintFunction_CanBeAChild",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/5564765827938108528",
+            "name": "ConstraintFunctionParameter_containmentLink",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/5564765827938091039",
+            "name": "ConstraintFunction_ReferentSearchScope_Scope",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.constraints.NodeScopeFactory"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6702802731807420587",
+            "name": "ConstraintFunction_CanBeAParent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/5564765827938191777",
+            "name": "ConstraintFunctionParameter_linkTarget",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/1957603573855863643",
+            "name": "ConstraintsMigration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6358186717179259582",
+            "name": "RefPresentationMigrated",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6358186717179259582/5753863164744094836",
+                    "name": "problems",
+                    "type": "jetbrains.mps.lang.constraints.RefPresentationMigratedProblem",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6358186717179259587",
+            "name": "RefPresentationMigratedProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1/6358186717179259587/6358186717179259588",
+                    "name": "editor",
+                    "type": "jetbrains.mps.lang.editor.BaseEditorComponent",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.msg.specification.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.msg.specification.json
@@ -1,0 +1,6 @@
+{
+    "uid": "e51810c5-7308-4642-bcb6-469e61b5dd18",
+    "name": "jetbrains.mps.lang.constraints.msg.specification",
+    "concepts": [
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.rules.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.rules.json
@@ -1,0 +1,157 @@
+{
+    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15",
+    "name": "jetbrains.mps.lang.constraints.rules",
+    "concepts": [
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/7291380803376279010",
+            "name": "Rule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/7291380803376279010/1328301445982561464",
+                    "name": "expr",
+                    "type": "jetbrains.mps.lang.constraints.rules.ExpressionWrapper",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.constraints.rules.skeleton.RuleBlockMember",
+                "jetbrains.mps.lang.constraints.rules.RuleIdHolder",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.constraints.rules.RuleBlockMemberWithApplicability"
+            ]
+        },
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/7291380803377228245",
+            "name": "DefForRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/7291380803377228245/5473446470512342703",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/7291380803377228245/1328301445982561451",
+                    "name": "expr",
+                    "type": "jetbrains.mps.lang.constraints.rules.ExpressionWrapper",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.constraints.rules.skeleton.RuleBlockMember",
+                "jetbrains.mps.lang.context.defs.TypedDef",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.constraints.rules.RuleBlockMemberWithApplicability"
+            ]
+        },
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/315923949160453290",
+            "name": "RuleIdHolder",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/315923949160453290/6714410169261853888",
+                    "name": "ruleId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/315923949160453290/315923949161043066",
+                    "name": "sourceNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/3562920471664315692",
+            "name": "ApplicableCondition",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/3562920471664315692/1328301445982552662",
+                    "name": "expr",
+                    "type": "jetbrains.mps.lang.constraints.rules.ExpressionWrapper",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/1328301445982517233",
+            "name": "ExpressionWrapper",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/1328301445982517233/1328301445982532877",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/4310380201428925514",
+            "name": "RuleBlockMemberWithApplicability",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/4310380201428925514/7932913038696094796",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.constraints.rules.ApplicableCondition"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.constraints.rules.skeleton.RuleBlockMember"
+            ]
+        },
+        {
+            "uid": "mps:47257bf3-78d3-470b-89d9-8c3261a61d15/6958325536051830060",
+            "name": "EditorListOfDefs",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "47257bf3-78d3-470b-89d9-8c3261a61d15/6958325536051830060/6958325536051830064",
+                    "name": "defs",
+                    "type": "jetbrains.mps.lang.context.defs.TypedDefReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.rules.kinds.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.rules.kinds.json
@@ -1,0 +1,27 @@
+{
+    "uid": "5dae8159-ab99-46bb-a40d-0cee30ee7018",
+    "name": "jetbrains.mps.lang.constraints.rules.kinds",
+    "concepts": [
+        {
+            "uid": "mps:5dae8159-ab99-46bb-a40d-0cee30ee7018/7291380803376071240",
+            "name": "RuleKind",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "5dae8159-ab99-46bb-a40d-0cee30ee7018/7291380803376071240/2949762704422496010",
+                    "name": "context",
+                    "type": "jetbrains.mps.lang.context.Context",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.rules.skeleton.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.constraints.rules.skeleton.json
@@ -1,0 +1,86 @@
+{
+    "uid": "134c38d4-e3af-4d9e-b069-1c7df0a4005d",
+    "name": "jetbrains.mps.lang.constraints.rules.skeleton",
+    "concepts": [
+        {
+            "uid": "mps:134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327984720090",
+            "name": "RulesConstraintsRoot",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327984720090/1867733327984720091",
+                    "name": "block",
+                    "type": "jetbrains.mps.lang.constraints.rules.skeleton.Block",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327984720090/1867733327984720094",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327984720096",
+            "name": "Block",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327985055562",
+            "name": "RulesBlock",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327985055562/1867733327985055563",
+                    "name": "members",
+                    "type": "jetbrains.mps.lang.constraints.rules.skeleton.RuleBlockMember",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327985055562/1867733327985055564",
+                    "name": "kind",
+                    "type": "jetbrains.mps.lang.constraints.rules.kinds.RuleKind",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.constraints.rules.skeleton.Block"
+            ]
+        },
+        {
+            "uid": "mps:134c38d4-e3af-4d9e-b069-1c7df0a4005d/1867733327985055568",
+            "name": "RuleBlockMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.context.defs.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.context.defs.json
@@ -1,0 +1,127 @@
+{
+    "uid": "ea3159bf-f48e-4720-bde2-86dba75f0d34",
+    "name": "jetbrains.mps.lang.context.defs",
+    "concepts": [
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/1328301445982536381",
+            "name": "NativeDef",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.context.defs.TypedDef"
+            ]
+        },
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/2740527090601018866",
+            "name": "NativeTypedConceptDef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ea3159bf-f48e-4720-bde2-86dba75f0d34/2740527090601018866/2740527090601018867",
+                    "name": "conceptParameter",
+                    "type": "jetbrains.mps.lang.context.defs.ContextConceptParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.context.defs.NativeDef"
+            ]
+        },
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/315923949159026769",
+            "name": "NativeTypedNodeDef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ea3159bf-f48e-4720-bde2-86dba75f0d34/315923949159026769/315923949159027763",
+                    "name": "conceptParameter",
+                    "type": "jetbrains.mps.lang.context.defs.ContextConceptParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.context.defs.NativeDef"
+            ]
+        },
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/7291380803377301036",
+            "name": "TypedDef",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/5473446470512342705",
+            "name": "TypedNativeDef",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ea3159bf-f48e-4720-bde2-86dba75f0d34/5473446470512342705/5473446470512342706",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.context.defs.NativeDef"
+            ]
+        },
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/5473446470512654133",
+            "name": "ContextConceptParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:ea3159bf-f48e-4720-bde2-86dba75f0d34/7291380803376202513",
+            "name": "TypedDefReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ea3159bf-f48e-4720-bde2-86dba75f0d34/7291380803376202513/7291380803376221790",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.context.defs.TypedDef",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.context.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.context.json
@@ -1,0 +1,32 @@
+{
+    "uid": "3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7",
+    "name": "jetbrains.mps.lang.context",
+    "concepts": [
+        {
+            "uid": "mps:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7/24399255755667773",
+            "name": "Context",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7/24399255755667773/7291380803376071326",
+                    "name": "defs",
+                    "type": "jetbrains.mps.lang.context.defs.NativeDef",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7/24399255755667773/8018723092206206171",
+                    "name": "conceptParameter",
+                    "type": "jetbrains.mps.lang.context.defs.ContextConceptParameter"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.core.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.core.json
@@ -1,0 +1,650 @@
+{
+    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c",
+    "name": "jetbrains.mps.lang.core",
+    "concepts": [
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626",
+            "name": "BaseConcept",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1156234966388",
+                    "name": "shortDescription"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1193676396447",
+                    "name": "virtualPackage"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/5169995583184591170",
+                    "name": "smodelAttribute",
+                    "type": "jetbrains.mps.lang.core.Attribute",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468",
+            "name": "INamedConcept",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001",
+                    "name": "name"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1196978630214",
+            "name": "IResolveInfo",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1196978630214/1196978656277",
+                    "name": "resolveInfo"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1221647093812",
+            "name": "IWrapper",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1224608834445",
+            "name": "IDeprecatable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1233160296597",
+            "name": "IContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1234971358450",
+            "name": "IType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/201537367881071930",
+            "name": "IMetaLevelChanger",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/5169995583184591161",
+            "name": "Attribute",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049745",
+            "name": "LinkAttribute",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049745/1757699476691236116",
+                    "name": "role_DebugInfo"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049745/1341860900488019036",
+                    "name": "linkId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.Attribute"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049748",
+            "name": "NodeAttribute",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.Attribute"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049750",
+            "name": "PropertyAttribute",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049750/1757699476691236117",
+                    "name": "name_DebugInfo"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049750/1341860900487648621",
+                    "name": "propertyId"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049750/1189424455254633007",
+                    "name": "enumUsageMigrated",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.Attribute"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3734116213129792499",
+            "name": "ScopeProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1047408822409601647",
+            "name": "IAntisuppressErrors",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3393165121846091586",
+            "name": "ICanSuppressErrors",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3393165121846091587",
+            "name": "ISuppressErrors",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/4222318806802425298",
+            "name": "SuppressErrorsAnnotation",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/4222318806802425298/2423417345669755629",
+                    "name": "filter"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/4222318806802425298/8575328350543493365",
+                    "name": "message"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/4222318806802425298/8575328350543493371",
+                    "name": "comment"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1835621062190663819",
+            "name": "IDontSubstituteByDefault",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3361475375157466558",
+            "name": "ScopeFacade",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1319728274783077719",
+            "name": "ImplementationPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ScopeFacade"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1319728274783151479",
+            "name": "ImplementationContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1319728274784973096",
+            "name": "InterfacePart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/6999738288738427190",
+            "name": "ImplementationWithStubPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/155087542027447621",
+            "name": "IStubForAnotherConcept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/779128492853369165",
+            "name": "SideTransformInfo",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/779128492853369165/779128492853699361",
+                    "name": "side"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/779128492853369165/779128492853934523",
+                    "name": "cellId"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/779128492853369165/779128492853935960",
+                    "name": "anchorTag"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/4452961908202556907",
+            "name": "BaseCommentAttribute",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/4452961908202556907/3078666699043039389",
+                    "name": "commentedNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ChildAttribute",
+                "jetbrains.mps.lang.core.ISkipConstraintsChecking",
+                "jetbrains.mps.lang.core.IDontApplyTypesystemRules",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/709746936026466394",
+            "name": "ChildAttribute",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/709746936026466394/709746936026609029",
+                    "name": "role_DebugInfo"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/709746936026466394/709746936026609031",
+                    "name": "linkId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.Attribute"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/5831887615299457091",
+            "name": "ISkipConstraintsChecking",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/2216760464199502422",
+            "name": "IDontApplyTypesystemRules",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/4123120730935488432",
+            "name": "IOldCommentContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/7094926192234036184",
+            "name": "ISmartReferent",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/2482611074346661065",
+            "name": "ReviewMigration_old",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/2482611074346661065/2482611074346661078",
+                    "name": "reasonShort"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/2482611074346661065/2482611074346661073",
+                    "name": "todo"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/2482611074346661065/2482611074347169514",
+                    "name": "readableId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.MigrationAnnotation_old"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/2482611074347614920",
+            "name": "MigrationAnnotation_old",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3717301156197626279",
+            "name": "BasePlaceholder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/3717301156197626279/3717301156197626301",
+                    "name": "content",
+                    "type": "jetbrains.mps.lang.core.IPlaceholderContent"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ChildAttribute"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/4058177569375150038",
+            "name": "IPlaceholderContent",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436978668945",
+            "name": "MigrationDataAnnotation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436978668945/6807933448470330574",
+                    "name": "dataNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.MigrationAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436979359251",
+            "name": "MigrationAnnotation",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436979359251/8703179436979359252",
+                    "name": "createdByScript"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.MigrationAnnotation_old"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436979359238",
+            "name": "ReviewMigration",
+            "properties": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436979359238/8703179436979359239",
+                    "name": "reasonShort"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436979359238/8703179436979359240",
+                    "name": "todo"
+                },
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/8703179436979359238/8703179436979359241",
+                    "name": "readableId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.MigrationAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/5259630923505770665",
+            "name": "TypeAnnotated",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ceab5195-25ea-4f22-9b92-103b95ca8c0c/5259630923505770665/5259630923505770666",
+                    "name": "annotation",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.dataFlow.analyzers.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.dataFlow.analyzers.json
@@ -1,0 +1,674 @@
+{
+    "uid": "97a52717-898f-4598-8150-573d9fd03868",
+    "name": "jetbrains.mps.lang.dataFlow.analyzers",
+    "concepts": [
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/6618572076229093257",
+            "name": "Analyzer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/4746038179140588765",
+                    "name": "initialFunction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.AnalyzerInitialFunction",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/4746038179140586188",
+                    "name": "mergeFunction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.AnalyzerMergeFunction",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/4746038179140588766",
+                    "name": "funFunction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.AnalyzerFunFunction",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/9177062368042220440",
+                    "name": "direction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.AnalysisDirection",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/9177062368042359739",
+                    "name": "latticeElementType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/3325264799421088056",
+                    "name": "instruction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Instruction",
+                    "multiple": true
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/3993089038373544707",
+                    "name": "constructorParameters",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.AnalyzerConstructorParameter",
+                    "multiple": true
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093257/8350235189170141188",
+                    "name": "usedContainers",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.CustomInstructionsContainerReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/6618572076229093258",
+            "name": "Instruction",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/6618572076229093258/3325264799421088068",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.InstructionParameter",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/6393434056522580745",
+            "name": "AnalyzerMergeFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4746038179140566716",
+            "name": "AnalyzerParameterProgram",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4746038179140566725",
+            "name": "AnalyzerMergeParameterInput",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4746038179140588744",
+            "name": "AnalyzerInitialFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4746038179140588745",
+            "name": "AnalyzerFunFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4746038179140588754",
+            "name": "AnalyzerFunParameterProgramState",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4746038179140588756",
+            "name": "AnalyzerFunParameterInput",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/9177062368042220422",
+            "name": "AnalysisDirection",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/9177062368042220424",
+            "name": "ForwardDirection",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.analyzers.AnalysisDirection"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/9177062368042220438",
+            "name": "BackwardDirection",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.analyzers.AnalysisDirection"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/9177062368042364839",
+            "name": "AnalyzerFunctionResultType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/430844094082168520",
+            "name": "Rule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/430844094082168520/4943044633101742986",
+                    "name": "actions",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/430844094082168520/3325264799421290838",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.ApplicableCondition",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/430844094082168520/7966224008969473787",
+                    "name": "modes",
+                    "type": "jetbrains.mps.lang.dataFlow.IBuilderMode",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/430844094082168520/4130591939054429248",
+                    "name": "analyzer",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Analyzer",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/430844094082202272",
+            "name": "InstructionParameter",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/430844094082202272/430844094082202274",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/3325264799421290200",
+            "name": "ApplicableCondition",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/3325264799421303651",
+            "name": "PatternCondition",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/3325264799421303651/3325264799421304898",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.analyzers.ApplicableCondition"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4217760266503579796",
+            "name": "EmitInstruction",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4217760266503579796/4217760266503650651",
+                    "name": "instructionRef",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.InstructionReference",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4217760266503579796/323410281720600578",
+                    "name": "target",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4217760266503579796/24089196731087404",
+                    "name": "position",
+                    "type": "jetbrains.mps.lang.pattern.InsertPosition",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.ActionStatement"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4217760266503638748",
+            "name": "InstructionReference",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4217760266503638748/4217760266503638749",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4217760266503638748/4217760266503638757",
+                    "name": "instruction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Instruction",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/752944717341640112",
+            "name": "RuleReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/752944717341640112/752944717341640113",
+                    "name": "rule",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Rule",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/2045671745393426211",
+            "name": "AnalyzerRunnerType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/95073643532950033",
+            "name": "AnalyzerRunnerAnalyzeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/95073643532950038",
+            "name": "AnalyzerRunnerCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/95073643532950038/178770917832625312",
+                    "name": "nodeToCheck",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/95073643532950038/3993089038374473158",
+                    "name": "parameters",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/95073643532950038/3364696741418270074",
+                    "name": "mode",
+                    "type": "jetbrains.mps.lang.dataFlow.IBuilderMode"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/95073643532950038/95073643532950039",
+                    "name": "analyzer",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Analyzer",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/7985661997283714146",
+            "name": "IsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/7985661997283714146/7985661997283737329",
+                    "name": "left",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/7985661997283714146/7985661997283714147",
+                    "name": "instruction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Instruction",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4943044633101449694",
+            "name": "ConceptCondition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4943044633101449694/4943044633101738901",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.analyzers.ApplicableCondition",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/4943044633102057744",
+            "name": "ApplicableNodeReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/4943044633102057744/4943044633102057745",
+                    "name": "applicableNode",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.ConceptCondition",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/8424563347437821087",
+            "name": "InsertBeforePosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/8424563347437829923",
+            "name": "InsertPosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/8424563347437829924",
+            "name": "InsertAfterPosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/1417545764634752447",
+            "name": "AnalyzerRunnerClassKeeper",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/1417545764634752447/4445029770708541867",
+                    "name": "member",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierMember",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/3993089038373626032",
+            "name": "AnalyzerConstructorParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/3993089038373626360",
+            "name": "AnalyzerConstructorParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableReference"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/9120988775422995278",
+            "name": "AnalyzerFunParameterStateValues",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/3727642986272245276",
+            "name": "ProgramParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/8350235189170059441",
+            "name": "CustomInstructionsContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/8350235189170059441/8350235189170065641",
+                    "name": "instruction",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.Instruction",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:97a52717-898f-4598-8150-573d9fd03868/8350235189170112408",
+            "name": "CustomInstructionsContainerReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "97a52717-898f-4598-8150-573d9fd03868/8350235189170112408/8350235189170112409",
+                    "name": "containter",
+                    "type": "jetbrains.mps.lang.dataFlow.analyzers.CustomInstructionsContainer",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.dataFlow.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.dataFlow.json
@@ -1,0 +1,551 @@
+{
+    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4",
+    "name": "jetbrains.mps.lang.dataFlow",
+    "concepts": [
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206442055221",
+            "name": "DataFlowBuilderDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206442055221/1206442812839",
+                    "name": "builderBlock",
+                    "type": "jetbrains.mps.lang.dataFlow.BuilderBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206442055221/7966224008969473787",
+                    "name": "modes",
+                    "type": "jetbrains.mps.lang.dataFlow.IBuilderMode",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206442055221/1206442096288",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206442659665",
+            "name": "BuilderBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206442747519",
+            "name": "NodeParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206443583064",
+            "name": "EmitStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206443583064/78261276407124230",
+                    "name": "position",
+                    "type": "jetbrains.mps.lang.dataFlow.InsertPosition"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206443660532",
+            "name": "EmitNopStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206443823146",
+            "name": "EmitReadStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BaseEmitVariableStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444349662",
+            "name": "EmitWriteStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444349662/1230468250683",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BaseEmitVariableStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444622344",
+            "name": "BaseEmitVariableStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444622344/1206444629799",
+                    "name": "variable",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444875712",
+            "name": "Position",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444910183",
+            "name": "RelativePosition",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206444910183/1206444923842",
+                    "name": "relativeTo",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.Position"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206445069217",
+            "name": "BeforePosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.RelativePosition"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206445082906",
+            "name": "AfterPosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.RelativePosition"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206445181593",
+            "name": "BaseEmitJumpStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206445181593/1206445193860",
+                    "name": "jumpTo",
+                    "type": "jetbrains.mps.lang.dataFlow.Position",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206445295557",
+            "name": "EmitIfJumpStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BaseEmitJumpStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206445310309",
+            "name": "EmitJumpStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BaseEmitJumpStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206454052847",
+            "name": "EmitCodeForStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206454052847/1206454079161",
+                    "name": "codeFor",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206462858103",
+            "name": "EmitRetStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206534235764",
+            "name": "EmitMayBeUnreachable",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206534235764/1206534244140",
+                    "name": "emitStatement",
+                    "type": "jetbrains.mps.lang.dataFlow.EmitStatement",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.Closureoid"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1206956528885",
+            "name": "EmitTryFinallyStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206956528885/1206956559912",
+                    "name": "tryPart",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1206956528885/1206956567220",
+                    "name": "finallyPart",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1207062474157",
+            "name": "EmitLabelStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.EmitStatement",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1207062697254",
+            "name": "LabelPosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/1207062697254/1207062703832",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.dataFlow.EmitLabelStatement",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.Position"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/8486807419021026914",
+            "name": "InsertAfter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.InsertPosition"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/8486807419021026916",
+            "name": "InsertBefore",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.InsertPosition"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/8486807419021026918",
+            "name": "InsertPosition",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/8486807419021026918/8486807419021026953",
+                    "name": "instruction",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/2959643274329928484",
+            "name": "GetCodeForExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7fa12e9c-b949-4976-b4fa-19accbc320b4/2959643274329928484/2959643274329928485",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/4969132436616196224",
+            "name": "InstructionType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1823319949748058980",
+            "name": "InstructionGetSourceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BaseInstructionOperation"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/1823319949748058981",
+            "name": "BaseInstructionOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/7180022869589052764",
+            "name": "InstructionIsNop",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BooleanInstructionOperation"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/7180022869589052765",
+            "name": "InstructionIsRet",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BooleanInstructionOperation"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/7180022869589052771",
+            "name": "BooleanInstructionOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BaseInstructionOperation"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/8754905177066994421",
+            "name": "InstructionIsJump",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.dataFlow.BooleanInstructionOperation"
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/7966224008969060052",
+            "name": "IBuilderMode",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7fa12e9c-b949-4976-b4fa-19accbc320b4/7966224008969060053",
+            "name": "IntraProcedural_BuilderMode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.dataFlow.IBuilderMode"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.descriptor.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.descriptor.json
@@ -1,0 +1,68 @@
+{
+    "uid": "f4ad079d-bc71-4ffb-9600-9328705cf998",
+    "name": "jetbrains.mps.lang.descriptor",
+    "concepts": [
+        {
+            "uid": "mps:f4ad079d-bc71-4ffb-9600-9328705cf998/9020561928507175845",
+            "name": "LanguageDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f4ad079d-bc71-4ffb-9600-9328705cf998/9020561928507175845/1698302279987270971",
+                    "name": "language",
+                    "type": "jetbrains.mps.lang.project.Language",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:f4ad079d-bc71-4ffb-9600-9328705cf998/5100536058472628033",
+            "name": "GeneratorInternal_Aspect",
+            "properties": [
+                {
+                    "uid": "f4ad079d-bc71-4ffb-9600-9328705cf998/5100536058472628033/5100536058472628079",
+                    "name": "implClass"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "f4ad079d-bc71-4ffb-9600-9328705cf998/5100536058472628033/5100536058472628070",
+                    "name": "interfaceClass",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:f4ad079d-bc71-4ffb-9600-9328705cf998/3919235298192590467",
+            "name": "GeneratorDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "f4ad079d-bc71-4ffb-9600-9328705cf998/3919235298192590467/7568285956000479292",
+                    "name": "generator",
+                    "type": "jetbrains.mps.lang.project.Generator"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.forms.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.forms.json
@@ -1,0 +1,98 @@
+{
+    "uid": "602c36ad-cc55-47ff-8c40-73d7f12f035c",
+    "name": "jetbrains.mps.lang.editor.forms",
+    "concepts": [
+        {
+            "uid": "mps:602c36ad-cc55-47ff-8c40-73d7f12f035c/312429380032619384",
+            "name": "CellModel_Checkbox",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "602c36ad-cc55-47ff-8c40-73d7f12f035c/312429380032619384/1340057216891284122",
+                    "name": "ui",
+                    "type": "jetbrains.mps.lang.editor.forms.AbstractCheckboxUI",
+                    "optional": false
+                },
+                {
+                    "uid": "602c36ad-cc55-47ff-8c40-73d7f12f035c/312429380032619384/8215612579904156902",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "602c36ad-cc55-47ff-8c40-73d7f12f035c/312429380032619384/3696012239575138271",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:602c36ad-cc55-47ff-8c40-73d7f12f035c/312429380032720646",
+            "name": "StubCellModel_Checkbox",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:602c36ad-cc55-47ff-8c40-73d7f12f035c/1340057216891283515",
+            "name": "CheckboxUI_Text",
+            "properties": [
+                {
+                    "uid": "602c36ad-cc55-47ff-8c40-73d7f12f035c/1340057216891283515/1340057216891283518",
+                    "name": "trueText"
+                },
+                {
+                    "uid": "602c36ad-cc55-47ff-8c40-73d7f12f035c/1340057216891283515/1340057216891283520",
+                    "name": "falseText"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.forms.AbstractCheckboxUI",
+                "jetbrains.mps.lang.editor.ICellStyle"
+            ]
+        },
+        {
+            "uid": "mps:602c36ad-cc55-47ff-8c40-73d7f12f035c/1801654740563842010",
+            "name": "AbstractCheckboxUI",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:602c36ad-cc55-47ff-8c40-73d7f12f035c/7024409093146622323",
+            "name": "CheckboxUI_Platform",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.forms.AbstractCheckboxUI"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.imageGen.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.imageGen.json
@@ -1,0 +1,41 @@
+{
+    "uid": "1839bec5-cea6-41df-b9e0-c405ff35c41e",
+    "name": "jetbrains.mps.lang.editor.imageGen",
+    "concepts": [
+        {
+            "uid": "mps:1839bec5-cea6-41df-b9e0-c405ff35c41e/2359976223559993484",
+            "name": "ImageGenerator",
+            "properties": [
+                {
+                    "uid": "1839bec5-cea6-41df-b9e0-c405ff35c41e/2359976223559993484/2359976223560030855",
+                    "name": "fileName"
+                },
+                {
+                    "uid": "1839bec5-cea6-41df-b9e0-c405ff35c41e/2359976223559993484/3245637733309852966",
+                    "name": "id"
+                },
+                {
+                    "uid": "1839bec5-cea6-41df-b9e0-c405ff35c41e/2359976223559993484/1380214350862969083",
+                    "name": "imageFormat"
+                },
+                {
+                    "uid": "1839bec5-cea6-41df-b9e0-c405ff35c41e/2359976223559993484/1380214350862971625",
+                    "name": "scale"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "1839bec5-cea6-41df-b9e0-c405ff35c41e/2359976223559993484/3245637733310277398",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.json
@@ -1,0 +1,7606 @@
+{
+    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba",
+    "name": "jetbrains.mps.lang.editor",
+    "concepts": [
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1071666914219",
+            "name": "ConceptEditorDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1071666914219/1078153129734",
+                    "name": "inspectedCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1071666914219/2597348684684069742",
+                    "name": "contextHints",
+                    "type": "jetbrains.mps.lang.editor.ConceptEditorHintDeclarationReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BaseEditorComponent",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265",
+            "name": "EditorCellModel",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/1130859485024",
+                    "name": "attractsFocus"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/1142887637401",
+                    "name": "renderingCondition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeCondition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/1164826688380",
+                    "name": "menuDescriptor",
+                    "type": "jetbrains.mps.lang.editor.CellMenuDescriptor"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/1198512004906",
+                    "name": "focusPolicyApplicable",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeCondition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/4323500428121274054",
+                    "name": "id",
+                    "type": "jetbrains.mps.lang.editor.EditorCellId"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/4202667662392416064",
+                    "name": "transformationMenu",
+                    "type": "jetbrains.mps.lang.editor.ITransformationMenuReference"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/1139959269582",
+                    "name": "actionMap",
+                    "type": "jetbrains.mps.lang.editor.CellActionMapDeclaration"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389214265/1081339532145",
+                    "name": "keyMap",
+                    "type": "jetbrains.mps.lang.editor.CellKeyMapDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.ICellStyle"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423",
+            "name": "CellModel_Collection",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/1073389446425",
+                    "name": "vertical",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/1073389446426",
+                    "name": "gridLayout",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/1139416841293",
+                    "name": "usesBraces",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/1160590353935",
+                    "name": "usesFolding",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/6240706158490734113",
+                    "name": "collapseByDefault",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/1073389446424",
+                    "name": "childCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel",
+                    "multiple": true
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/7723470090030138869",
+                    "name": "foldedCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/1106270802874",
+                    "name": "cellLayout",
+                    "type": "jetbrains.mps.lang.editor.CellLayout"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/8709572687796959088",
+                    "name": "usesFoldingCondition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeCondition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/6240706158490734121",
+                    "name": "collapseByDefaultCondition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeCondition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/4242538589862653897",
+                    "name": "addHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389446423/4242538589862654489",
+                    "name": "removeHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.editor.Synchronizeable",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart",
+                "jetbrains.mps.lang.editor.LayoutContainer"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389577006",
+            "name": "CellModel_Constant",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389577006/1073389577007",
+                    "name": "text"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389577006/1082639509531",
+                    "name": "nullText"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_AbstractLabel",
+                "jetbrains.mps.lang.editor.Synchronizeable",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389658414",
+            "name": "CellModel_Property",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_WithRole",
+                "jetbrains.mps.lang.editor.Synchronizeable",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389882823",
+            "name": "CellModel_RefNode",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389882823/16410578721444372",
+                    "name": "customizeEmptyCell",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389882823/5861024100072578575",
+                    "name": "addHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389882823/5861024100072578576",
+                    "name": "removeHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073389882823/16410578721629643",
+                    "name": "emptyCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_WithRole",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982",
+            "name": "CellModel_RefNodeList",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982/1145360728033",
+                    "name": "reverse",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982/1165347032372",
+                    "name": "elementMenuDescriptor",
+                    "type": "jetbrains.mps.lang.editor.CellMenuDescriptor"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982/1182233390675",
+                    "name": "filter",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeListFilter"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982/7279578193766667846",
+                    "name": "addHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982/7279578193766667847",
+                    "name": "removeHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1073390211982/1173177718857",
+                    "name": "elementActionMap",
+                    "type": "jetbrains.mps.lang.editor.CellActionMapDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_ListWithRole",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1074767920765",
+            "name": "CellModel_ModelAccess",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1074767920765/1082638248796",
+                    "name": "nullText"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1074767920765/1176718152741",
+                    "name": "modelAcessor",
+                    "type": "jetbrains.mps.lang.editor.ModelAccessor",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_AbstractLabel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1075375595203",
+            "name": "CellModel_Error",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1075375595203/1075375595204",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_AbstractLabel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078308402140",
+            "name": "CellModel_Custom",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078308402140/1176795024817",
+                    "name": "cellProvider",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_CellProvider",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078938745671",
+            "name": "EditorComponentDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078938745671/7033942394258392116",
+                    "name": "overridenEditorComponent",
+                    "type": "jetbrains.mps.lang.editor.EditorComponentDeclarationReference"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078938745671/7348800710862477686",
+                    "name": "contextHints",
+                    "type": "jetbrains.mps.lang.editor.ConceptEditorHintDeclarationReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BaseEditorComponent",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078939183254",
+            "name": "CellModel_Component",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1078939183254/1078939183255",
+                    "name": "editorComponent",
+                    "type": "jetbrains.mps.lang.editor.EditorComponentDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1079353555532",
+            "name": "CellModel_AbstractLabel",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1079353555532/1197893615481",
+                    "name": "defaultCaretPosition"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1080736578640",
+            "name": "BaseEditorComponent",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1080736578640/1080736633877",
+                    "name": "cellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractComponent",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1081293058843",
+            "name": "CellKeyMapDeclaration",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1081293058843/1149937560128",
+                    "name": "everyModel",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1081293058843/1136930944870",
+                    "name": "item",
+                    "type": "jetbrains.mps.lang.editor.CellKeyMapItem",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1081293058843/1139445935125",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088013125922",
+            "name": "CellModel_RefCell",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088013125922/1088186146602",
+                    "name": "editorComponent",
+                    "type": "jetbrains.mps.lang.editor.InlineEditorComponent",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_WithRole",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart",
+                "jetbrains.mps.lang.editor.IReferenceContextProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088185857835",
+            "name": "InlineEditorComponent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BaseEditorComponent"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088612959204",
+            "name": "CellModel_Alternation",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088612959204/1088613081987",
+                    "name": "vertical",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088612959204/1145918517974",
+                    "name": "alternationCondition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeCondition",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088612959204/1088612958265",
+                    "name": "ifTrueCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1088612959204/1088612973955",
+                    "name": "ifFalseCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1103016434866",
+            "name": "CellModel_JComponent",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1103016434866/1176475119347",
+                    "name": "componentProvider",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_JComponent",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1106270491082",
+            "name": "CellLayout",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1106270549637",
+            "name": "CellLayout_Horizontal",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1106270571710",
+            "name": "CellLayout_Vertical",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1106270637846",
+            "name": "CellLayout_Flow",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1134379236839",
+            "name": "CellModel_AttributedPropertyCell",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136564507907",
+            "name": "CellModel_AttributedLinkCell",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141",
+            "name": "CellKeyMapItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1136916941877",
+                    "name": "description"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1141091278922",
+                    "name": "caretPolicy"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1163507208434",
+                    "name": "showInPopup",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1184322083615",
+                    "name": "menuAlwaysShown",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1136916998332",
+                    "name": "keystroke",
+                    "type": "jetbrains.mps.lang.editor.CellKeyMapKeystroke",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1136917325338",
+                    "name": "isApplicableFunction",
+                    "type": "jetbrains.mps.lang.editor.CellKeyMap_IsApplicableFunction"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916919141/1136920925604",
+                    "name": "executeFunction",
+                    "type": "jetbrains.mps.lang.editor.CellKeyMap_ExecuteFunction",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916976737",
+            "name": "CellKeyMapKeystroke",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916976737/1136923970223",
+                    "name": "modifiers"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136916976737/1136923970224",
+                    "name": "keycode"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136917155755",
+            "name": "CellKeyMap_AbstractFunction",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136917249679",
+            "name": "CellKeyMap_IsApplicableFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellKeyMap_AbstractFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1136917288805",
+            "name": "CellKeyMap_ExecuteFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellKeyMap_AbstractFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535219966",
+            "name": "CellActionMapDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535219966/8528336319562672595",
+                    "name": "imports",
+                    "type": "jetbrains.mps.lang.editor.CellActionMapImport",
+                    "multiple": true
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535219966/1139535219969",
+                    "name": "item",
+                    "type": "jetbrains.mps.lang.editor.CellActionMapItem",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535219966/1139535219968",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535280617",
+            "name": "CellActionMapItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535280617/1139537298254",
+                    "name": "description"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535280617/1139535298778",
+                    "name": "actionId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535280617/1139535280620",
+                    "name": "executeFunction",
+                    "type": "jetbrains.mps.lang.editor.CellActionMap_ExecuteFunction",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535280617/3459162043708468028",
+                    "name": "canExecuteFunction",
+                    "type": "jetbrains.mps.lang.editor.CellActionMap_CanExecuteFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139535439104",
+            "name": "CellActionMap_ExecuteFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139744628335",
+            "name": "CellModel_Image",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139744628335/1139746504291",
+                    "name": "imageFile"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139744628335/1139858284555",
+                    "name": "descent",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139744628335/1176899909521",
+                    "name": "imagePathProvider",
+                    "type": "jetbrains.mps.lang.editor.ImagePathProvider"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139848536355",
+            "name": "CellModel_WithRole",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139848536355/1139852716018",
+                    "name": "noTargetText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139848536355/1214560368769",
+                    "name": "emptyNoTargetText",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139848536355/1140017977771",
+                    "name": "readOnly",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139848536355/1140114345053",
+                    "name": "allowEmptyText",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1139848536355/1140103550593",
+                    "name": "relationDeclaration",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_AbstractLabel",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322",
+            "name": "CellModel_ListWithRole",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1140524450554",
+                    "name": "vertical",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1140524450555",
+                    "name": "gridLayout",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1140524450556",
+                    "name": "usesBraces",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1160590307797",
+                    "name": "usesFolding",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1140524450557",
+                    "name": "separatorText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1156252885376",
+                    "name": "separatorLayoutConstraint"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1176897874615",
+                    "name": "nodeFactory",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeFactory"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1140524464359",
+                    "name": "emptyCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/6046489571270834038",
+                    "name": "foldedCellModel",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1140524464360",
+                    "name": "cellLayout",
+                    "type": "jetbrains.mps.lang.editor.CellLayout"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/1233141163694",
+                    "name": "separatorStyle",
+                    "type": "jetbrains.mps.lang.editor.InlineStyleDeclaration"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/928328222691832421",
+                    "name": "separatorTextQuery",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SeparatorText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1140524381322/4601216887035799527",
+                    "name": "usesFoldingCondition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_NodeCondition"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_WithRole",
+                "jetbrains.mps.lang.editor.LayoutContainer"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1142886221719",
+            "name": "QueryFunction_NodeCondition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1142886811589",
+            "name": "ConceptFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1149850725784",
+            "name": "CellModel_AttributedNodeCell",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1160493135005",
+            "name": "CellMenuPart_PropertyValues_GetValues",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1161622981231",
+            "name": "ConceptFunctionParameter_editorContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1162497113192",
+            "name": "CellMenuPart_ReplaceChild_currentChild",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1162498275506",
+            "name": "CellMenuPart_ReplaceChild_defaultConceptOfChild",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1163613035599",
+            "name": "CellMenuPart_AbstractGroup_Query",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1163613131943",
+            "name": "CellMenuPart_ReplaceNode_Group_Create",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1163613549566",
+            "name": "CellMenuPart_AbstractGroup_parameterObject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1163613822479",
+            "name": "CellMenuPart_Abstract_editedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164052439493",
+            "name": "CellMenuPart_AbstractGroup_MatchingText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164052588708",
+            "name": "CellMenuPart_AbstractGroup_DescriptionText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164824717996",
+            "name": "CellMenuDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164824717996/1164824815888",
+                    "name": "cellMenuPart",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_Abstract",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164824854750",
+            "name": "CellMenuPart_Abstract",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IReferenceContextProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164833692343",
+            "name": "CellMenuPart_PropertyValues",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164833692343/1164833692344",
+                    "name": "valuesFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_PropertyValues_GetValues",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164914519156",
+            "name": "CellMenuPart_ReplaceNode_CustomNodeConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164914519156/1164914727930",
+                    "name": "replacementConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164996492011",
+            "name": "CellMenuPart_ReferentPrimary",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164996492011/6918029743851332884",
+                    "name": "matchingText",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_RefPresentation"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1164996492011/6646996417796504278",
+                    "name": "visibleMatchingText",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_RefPresentation"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165004207520",
+            "name": "CellMenuPart_ReplaceNode_Group",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165004207520/1165004529292",
+                    "name": "parametersFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup_Query",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165004207520/1165004529293",
+                    "name": "createFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_ReplaceNode_Group_Create",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165253627126",
+            "name": "CellMenuPart_AbstractGroup",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165253627126/1165254125954",
+                    "name": "presentation"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165253627126/1165253890469",
+                    "name": "parameterObjectType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165253627126/1165254159533",
+                    "name": "matchingTextFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup_MatchingText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165253627126/1165254180581",
+                    "name": "descriptionTextFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup_DescriptionText"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165270418989",
+            "name": "CellMenuPart_ReplaceChild_Group",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165270418989/1165270418991",
+                    "name": "parametersFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_ReplaceChild_Group_Query",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165270418989/1165270418992",
+                    "name": "createFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_ReplaceChild_Group_Create"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165270662927",
+            "name": "CellMenuPart_ReplaceChild_Group_Query",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165270999881",
+            "name": "CellMenuPart_ReplaceChild_Group_Create",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165280503630",
+            "name": "CellMenuPart_ReplaceChild_CustomChildConcept",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165280503630/1165280503631",
+                    "name": "childConceptFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_ReplaceChild_CustomChildConcept_Query",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165280856333",
+            "name": "CellMenuPart_ReplaceChild_CustomChildConcept_Query",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165339175678",
+            "name": "CellMenuPart_ReplaceChild_Item",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165339175678/1165339639991",
+                    "name": "matchingText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165339175678/1175117579502",
+                    "name": "descriptionText"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165339175678/1165339175680",
+                    "name": "createFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_ReplaceChild_Item_Create"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165339307433",
+            "name": "CellMenuPart_ReplaceChild_Item_Create",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165420413719",
+            "name": "CellMenuPart_Generic_Group",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165420413719/1165420413720",
+                    "name": "parametersFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup_Query",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165420413719/1165420413721",
+                    "name": "handlerFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_Generic_Group_Handler",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_AbstractGroup"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165420626554",
+            "name": "CellMenuPart_Generic_Group_Handler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165424453110",
+            "name": "CellMenuPart_Generic_Item",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165424453110/1165424453111",
+                    "name": "matchingText"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165424453110/1165424453112",
+                    "name": "handlerFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_Generic_Item_Handler",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1165424657443",
+            "name": "CellMenuPart_Generic_Item_Handler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166040637528",
+            "name": "CellMenuComponent",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166040637528/1166040865497",
+                    "name": "applicableFeature",
+                    "type": "jetbrains.mps.lang.editor.CellMenuComponentFeature"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166040637528/1166041505377",
+                    "name": "menuDescriptor",
+                    "type": "jetbrains.mps.lang.editor.CellMenuDescriptor",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractComponent",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166041033436",
+            "name": "CellMenuComponentFeature",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166041033436/1166054297096",
+                    "name": "relationDeclaration",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166041748520",
+            "name": "CellMenuComponentFeature_Property",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuComponentFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166042131867",
+            "name": "CellMenuComponentFeature_Link",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuComponentFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166049232041",
+            "name": "AbstractComponent",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166049232041/1166049300910",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166059625718",
+            "name": "CellMenuPart_CellMenuComponent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1166059625718/1166059677893",
+                    "name": "cellMenuComponent",
+                    "type": "jetbrains.mps.lang.editor.CellMenuComponent",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1174088067129",
+            "name": "CellMenuPart_ReplaceChildPrimary",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176474535556",
+            "name": "QueryFunction_JComponent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717779940",
+            "name": "ConceptFunctionParameter_text",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717841777",
+            "name": "QueryFunction_ModelAccess_Getter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717871254",
+            "name": "QueryFunction_ModelAccess_Setter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717888428",
+            "name": "QueryFunction_ModelAccess_Validator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717996748",
+            "name": "ModelAccessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717996748/1176718001874",
+                    "name": "getter",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_ModelAccess_Getter",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717996748/1176718007938",
+                    "name": "setter",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_ModelAccess_Setter",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176717996748/1176718014393",
+                    "name": "validator",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_ModelAccess_Validator",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176731909317",
+            "name": "ConceptFunctionParameter_oldText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176749715029",
+            "name": "QueryFunction_CellProvider",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176809959526",
+            "name": "QueryFunction_Color",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter",
+                "jetbrains.mps.lang.editor.IQueryFunction_Color"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176897764478",
+            "name": "QueryFunction_NodeFactory",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1176899348742",
+            "name": "QueryFunction_ImagePath",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.ImagePathProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1180615838666",
+            "name": "CellMenuPart_PropertyPostfixHints",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1180615838666/1180615838667",
+                    "name": "postfixesFunction",
+                    "type": "jetbrains.mps.lang.editor.CellMenuPart_PropertyPostfixHints_GetPostfixes",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellMenuPart_Abstract"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1180616057533",
+            "name": "CellMenuPart_PropertyPostfixHints_GetPostfixes",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1182191800432",
+            "name": "QueryFunction_NodeListFilter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1182233249301",
+            "name": "ConceptFunctionParameter_childNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1184319644772",
+            "name": "CellModel_NonEmptyProperty",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_Property",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186402211651",
+            "name": "StyleSheet",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186402211651/1186402402630",
+                    "name": "styles",
+                    "type": "jetbrains.mps.lang.editor.IStyleSheetItem",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186402475462",
+            "name": "StyleClassItem",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186403694788",
+            "name": "ColorStyleClassItem",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186403694788/1186403713874",
+                    "name": "color"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186403694788/1186403803051",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.IQueryFunction_Color"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186403751766",
+            "name": "FontStyleStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186403751766/1186403771423",
+                    "name": "style"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186403751766/1220975211821",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_FontStyle"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186404549998",
+            "name": "ForegroundColorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ColorStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186404574412",
+            "name": "BackgroundColorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ColorStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186413799158",
+            "name": "BracketColorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ColorStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414536763",
+            "name": "BooleanStyleSheetItem",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414536763/1186414551515",
+                    "name": "flag",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414536763/1223387335081",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_Boolean"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414928363",
+            "name": "SelectableStyleSheetItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414949600",
+            "name": "AutoDeletableStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414976055",
+            "name": "DrawBorderStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414999511",
+            "name": "UnderlinedStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414999511/1214316229833",
+                    "name": "underlined"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414999511/1221219051630",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_Underlined"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186415722038",
+            "name": "FontSizeStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186415722038/1221209241505",
+                    "name": "value",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186415722038/1221064706952",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_Integer"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1186414860679",
+            "name": "EditableStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1187258617779",
+            "name": "ForegroundNullColorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ColorStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198256887712",
+            "name": "CellModel_Indent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198257632966",
+            "name": "CellModel_BlockStart",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198257632966/1198504797640",
+                    "name": "openBrace"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198257747917",
+            "name": "CellModel_BlockEnd",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198257747917/1198506631483",
+                    "name": "closeBrace"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198489924438",
+            "name": "CellModel_Block",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198489924438/1198508727334",
+                    "name": "openBrace"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198489924438/1198508733600",
+                    "name": "closeBrace"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198489924438/1198489985045",
+                    "name": "header",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1198489924438/1198489993734",
+                    "name": "body",
+                    "type": "jetbrains.mps.lang.editor.EditorCellModel",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1201266127262",
+            "name": "SelectParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1201268783309",
+            "name": "SelectPositionParameter",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1201268783309/1201268881975",
+                    "name": "position"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SelectParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1201270864927",
+            "name": "CaretPositionParameter",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1201270864927/1201270907764",
+                    "name": "position",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SelectParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1214317859050",
+            "name": "LayoutConstraintStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1214317859050/1214317859051",
+                    "name": "layoutConstraint"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1214406454886",
+            "name": "TextBackgroundColorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ColorStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1214406466686",
+            "name": "TextBackgroundColorSelectedStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ColorStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1214472762472",
+            "name": "DefaultCaretPositionStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1214472762472/1214472762473",
+                    "name": "position"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1215007762405",
+            "name": "FloatStyleClassItem",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1215007762405/1215007802031",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1215007883204",
+            "name": "PaddingLeftStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractPaddingStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1215007897487",
+            "name": "PaddingRightStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractPaddingStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1215085112640",
+            "name": "FirstPositionAllowedStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1215085197271",
+            "name": "LastPositionAllowedStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216308599511",
+            "name": "PositionStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216308599511/1216308761668",
+                    "name": "position"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216380990741",
+            "name": "CellModel_TransactionalProperty",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216380990741/1232439938817",
+                    "name": "runInCommand",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216380990741/8251517099537646385",
+                    "name": "allowEmptyText",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216380990741/1216381211800",
+                    "name": "handlerBlock",
+                    "type": "jetbrains.mps.lang.editor.TransactionalPropertyHandler",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216380990741/1216381219207",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_AbstractLabel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216381054717",
+            "name": "TransactionalPropertyHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216381117100",
+            "name": "TransactionPropertyHandler_oldValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216381148013",
+            "name": "TransactionPropertyHandler_newValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216560327200",
+            "name": "PositionChildrenStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1216560327200/1216560518566",
+                    "name": "position"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1219226236603",
+            "name": "DrawBracketsStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1219418625346",
+            "name": "IStyleContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1219418625346/1219418656006",
+                    "name": "styleItem",
+                    "type": "jetbrains.mps.lang.editor.StyleClassItem",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1220974635399",
+            "name": "QueryFunction_FontStyle",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1221057094638",
+            "name": "QueryFunction_Integer",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1221059528506",
+            "name": "QueryFunction_StyleParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IContextNodeAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1221062700015",
+            "name": "QueryFunction_Underlined",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1223386653097",
+            "name": "StrikeOutStyleSheet",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1223387125302",
+            "name": "QueryFunction_Boolean",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225456097782",
+            "name": "IQueryFunction_Color",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225456267680",
+            "name": "RGBColor",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225456267680/1225456424731",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IQueryFunction_Color"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225898583838",
+            "name": "ReadOnlyModelAccessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225898583838/1225898971709",
+                    "name": "getter",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_ModelAccess_Getter",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225900081164",
+            "name": "CellModel_ReadOnlyModelAccessor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1225900081164/1225900141900",
+                    "name": "modelAccessor",
+                    "type": "jetbrains.mps.lang.editor.ReadOnlyModelAccessor",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_AbstractLabel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1226339751946",
+            "name": "PaddingTopStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractPaddingStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1226339813308",
+            "name": "PaddingBottomStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractPaddingStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1226339938453",
+            "name": "AbstractPaddingStyleClassItem",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1226339938453/1226504838901",
+                    "name": "measure"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.FloatStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1227861515039",
+            "name": "NavigatableReferenceStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1227861515039/1227861587090",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1233148810477",
+            "name": "InlineStyleDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.ICellStyle"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1233758997495",
+            "name": "PunctuationLeftStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1233759184865",
+            "name": "PunctuationRightStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1233823429331",
+            "name": "HorizontalGapStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractPaddingStyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1235728439575",
+            "name": "BaseLineCell",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1235999440492",
+            "name": "HorizontalAlign",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1235999440492/1235999920262",
+                    "name": "align"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1236262245656",
+            "name": "MatchingLabelStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1236262245656/1238091709220",
+                    "name": "labelName"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1236262245656/5915179142332960580",
+                    "name": "hasNoLabel",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1236262245656/1236443321503",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_String"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1236443640684",
+            "name": "QueryFunction_String",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IContextNodeAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1237303669825",
+            "name": "CellLayout_Indent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1237307900041",
+            "name": "IndentLayoutIndentStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1237308012275",
+            "name": "IndentLayoutNewLineStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1237375020029",
+            "name": "IndentLayoutNewLineChildrenStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1237385578942",
+            "name": "IndentLayoutOnNewLineStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1239814640496",
+            "name": "CellLayout_VerticalGrid",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout_Vertical"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1240253180846",
+            "name": "IndentLayoutNoWrapClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/625126330682908270",
+            "name": "CellModel_ReferencePresentation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/625126330682908270/7783170064869818501",
+                    "name": "referentPresentation",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_RefPresentation"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847570194",
+            "name": "ParametersInformationStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847570194/8863456892852949148",
+                    "name": "parametersInformation",
+                    "type": "jetbrains.mps.lang.editor.ParametersInformationQuery",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622",
+            "name": "ParametersInformationQuery",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622/8178273524755058633",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622/7667276221847612623",
+                    "name": "methods",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_ParametersList",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622/671290755174161557",
+                    "name": "presentation",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_MethodPresentation",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622/6419604448124516218",
+                    "name": "isMethodCurrent",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_IsMethodCurrent",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622/1336839120510622371",
+                    "name": "methodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierMethodDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612622/4203201205843994215",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667276221847612943",
+            "name": "QueryFunction_ParametersList",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/671290755174094686",
+            "name": "QueryFunction_MethodPresentation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/671290755174094691",
+            "name": "ConceptFunctionParameter_parameterObject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6419604448124516209",
+            "name": "QueryFunction_IsMethodCurrent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4526149749187797167",
+            "name": "ConceptFunctionParameter_StyledText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/280151408461567367",
+            "name": "AppendTextOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractStyledTextOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/280151408461909164",
+            "name": "SetBoldOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractStyledTextOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4531786690998636238",
+            "name": "AbstractStyledTextOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4531786690998636238/4531786690998636240",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3903367331818357915",
+            "name": "StyledTextType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7620205565664569937",
+            "name": "DefaultBaseLine",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7620205565664569937/7620205565664606477",
+                    "name": "baseline"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1886960078078641793",
+            "name": "CellLayout_Superscript",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8255250703325731016",
+            "name": "ScriptKindClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8255250703325731016/8255250703325731018",
+                    "name": "script"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4203201205844553978",
+            "name": "ConceptFunctionParameter_selectedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5949640294884234625",
+            "name": "CellLayout_Table",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellLayout"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6820251943131810950",
+            "name": "TableComponentStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6820251943131810950/6820251943131810955",
+                    "name": "tableComponent"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8313721352726366579",
+            "name": "CellModel_Empty",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7597241200646296617",
+            "name": "NavigatableNodeStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7597241200646296617/7597241200646296618",
+                    "name": "functionNode",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SNode",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7597241200646296619",
+            "name": "QueryFunction_SNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3696012239575138270",
+            "name": "CellModel_URL",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellModel_WithRole",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/709996738298806197",
+            "name": "QueryFunction_SeparatorText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7651593722933768974",
+            "name": "MaxWidthStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7651593722933768974/7651593722933768975",
+                    "name": "value",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7651593722933768974/7651593722933768976",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_Integer"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667708318090877006",
+            "name": "IndentLayoutWrapAnchorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7667708318090725848",
+            "name": "IndentLayoutIndentAnchorStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1402906326895675325",
+            "name": "CellActionMap_FunctionParm_selectedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1402906326896143883",
+            "name": "CellKeyMap_FunctionParm_selectedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1402906326896143909",
+            "name": "CellKeyMap_FunctionParm_selectedNodes",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7991857262589831666",
+            "name": "ConceptFunctionParameter_prevNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7991857262589829730",
+            "name": "ConceptFunctionParameter_nextNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4151393920374910634",
+            "name": "StyleKey",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.StringLiteral",
+                "jetbrains.mps.lang.editor.IStyle"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4151393920374910722",
+            "name": "StyleKeyPack",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4151393920374910722/4151393920375014512",
+                    "name": "styleKey",
+                    "type": "jetbrains.mps.lang.editor.StyleKey",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3525058663444303551",
+            "name": "QueryFunction_Style",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6822301196700715228",
+            "name": "ConceptEditorHintDeclarationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6822301196700715228/5944657839026714445",
+                    "name": "hint",
+                    "type": "jetbrains.mps.lang.editor.ConceptEditorHintDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4242538589859161874",
+            "name": "ExplicitHintsSpecification",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4242538589859161874/4242538589859162459",
+                    "name": "hints",
+                    "type": "jetbrains.mps.lang.editor.ConceptEditorHintDeclarationReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.ContextHintsSpecification"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5944657839000868711",
+            "name": "ConceptEditorContextHints",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5944657839000868711/5944657839000877563",
+                    "name": "hints",
+                    "type": "jetbrains.mps.lang.editor.ConceptEditorHintDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5944657839003601246",
+            "name": "ConceptEditorHintDeclaration",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5944657839003601246/5944657839012629576",
+                    "name": "presentation"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5944657839003601246/168363875802087287",
+                    "name": "showInUI",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6150987479542522273",
+            "name": "QueryHintsSpecification",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.ContextHintsSpecification"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4653693564097968040",
+            "name": "ContextHintsSpecification",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4820515453818318288",
+            "name": "ConceptEditorHintDeclarationReferenceExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4820515453818318288/4820515453818318891",
+                    "name": "hint",
+                    "type": "jetbrains.mps.lang.editor.ConceptEditorHintDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7033942394256351208",
+            "name": "EditorComponentDeclarationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7033942394256351208/7033942394256351817",
+                    "name": "editorComponent",
+                    "type": "jetbrains.mps.lang.editor.EditorComponentDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3647146066980922272",
+            "name": "SelectInEditorOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3647146066980922272/1948540814633499358",
+                    "name": "editorContext",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3647146066980922272/1948540814635895774",
+                    "name": "cellSelector",
+                    "type": "jetbrains.mps.lang.editor.AbstractCellSelector"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3647146066980922272/3604384757217586546",
+                    "name": "selectionStart",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3647146066980922272/2701921320705252232",
+                    "name": "selectionEnd",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellIdScopeProviderNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1948540814635886374",
+            "name": "AbstractCellSelector",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3547227755871693971",
+            "name": "PredefinedSelector",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3547227755871693971/2162403111523065396",
+                    "name": "cellId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2162403111523059536",
+            "name": "IdSelector",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/2162403111523059536/2162403111529391190",
+                    "name": "cellId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4510086454722552739",
+            "name": "PropertyDeclarationCellSelector",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4510086454722552739/4510086454740628767",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4510086454726375946",
+            "name": "PropertyExpressionCellSelector",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4510086454726375946/4510086454769912032",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4323500428121233431",
+            "name": "EditorCellId",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4323500428136740385",
+            "name": "CellIdReferenceSelector",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4323500428136740385/4323500428136742952",
+                    "name": "id",
+                    "type": "jetbrains.mps.lang.editor.EditorCellId",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3383245079137382180",
+            "name": "StyleClass",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3383245079137382180/3383245079137422296",
+                    "name": "dominates",
+                    "type": "jetbrains.mps.lang.editor.DominatesRecord"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IStyleSheetItem",
+                "jetbrains.mps.lang.editor.IStyle",
+                "jetbrains.mps.lang.editor.IStyleContainer",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/795210086017940429",
+            "name": "ReadOnlyStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.BooleanStyleSheetItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1950447826686048995",
+            "name": "UnapplyStyle",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1950447826686048995/1950447826686049051",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.editor.StyleReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3383245079137422349",
+            "name": "StyleClassReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3383245079137422349/3383245079137422350",
+                    "name": "styleClass",
+                    "type": "jetbrains.mps.lang.editor.StyleClass",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1950447826681509042",
+            "name": "ApplyStyleClass",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1950447826681509042/1950447826683828796",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.editor.StyleReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797320402872",
+            "name": "IStyle",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8770580973047386957",
+            "name": "Synchronizeable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797276194520",
+            "name": "StyleClassReferenceList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797276194520/9122903797276195161",
+                    "name": "element",
+                    "type": "jetbrains.mps.lang.editor.StyleClassReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1381004262292414836",
+            "name": "ICellStyle",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1381004262292414836/1381004262292426837",
+                    "name": "parentStyleClass",
+                    "type": "jetbrains.mps.lang.editor.StyleClass"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IStyleContainer"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797336200704",
+            "name": "ApplyStyleClassCondition",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797336200704/9122903797336200706",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_Boolean",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ApplyStyleClass"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2491174914159318432",
+            "name": "DominatesRecord",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/2491174914159318432/2491174914159330058",
+                    "name": "dominatesStyleClassList",
+                    "type": "jetbrains.mps.lang.editor.StyleClassReferenceList"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797312246523",
+            "name": "StyleReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/9122903797312246523/9122903797312247166",
+                    "name": "style",
+                    "type": "jetbrains.mps.lang.editor.IStyle",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8714766435263473176",
+            "name": "IStyleSheetItem",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6029276237631252951",
+            "name": "StyleAttributeReferenceExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6029276237631252951/6029276237631253682",
+                    "name": "attributeDeclaration",
+                    "type": "jetbrains.mps.lang.editor.StyleAttributeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150113085419",
+            "name": "StyleAttributeDeclaration",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150113085419/8714766435264464176",
+                    "name": "inherited"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150113085419/3982520150113092206",
+                    "name": "valueType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150113085419/3982520150113147643",
+                    "name": "defaultValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IStyleSheetItem",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150122341378",
+            "name": "AttributeStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150122341378/3982520150122341379",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_AttributeStyleParameter",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150122341378/3982520150122346707",
+                    "name": "attribute",
+                    "type": "jetbrains.mps.lang.editor.StyleAttributeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3982520150125052579",
+            "name": "QueryFunction_AttributeStyleParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3610246225209162225",
+            "name": "StubCellModel_Constant",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3013115976261988961",
+            "name": "StubCellModel_Collection",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3708815482283559694",
+            "name": "StubCellModel_ReadOnlyModelAccessor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3162947552742194261",
+            "name": "StubCellModel_Component",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730538219795941030",
+            "name": "StubCellModel_RefCell",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730538219795960754",
+            "name": "StubCellModel_RefNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730538219795961225",
+            "name": "StubCellModel_ReferencePresentation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730538219796134133",
+            "name": "StubCellModel_Property",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730538219796134178",
+            "name": "StubCellModel_NonEmptyProperty",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730538219796139730",
+            "name": "StubEditorCellModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.IStubForAnotherConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2794558372793454595",
+            "name": "StubCellModel_RefNodeList",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506731195",
+            "name": "StubCellModel_Image",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506731196",
+            "name": "StubCellModel_JComponent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506731197",
+            "name": "StubCellModel_Table",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506729361",
+            "name": "StubCellModel_Alternation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506729359",
+            "name": "StubCellModel_URL",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506729358",
+            "name": "StubCellModel_TransactionalProperty",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506729357",
+            "name": "StubCellModel_ModelAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506729356",
+            "name": "StubCellModel_Error",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506730068",
+            "name": "StubCellModel_Custom",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8104358048506730066",
+            "name": "StubCellModel_Block",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3459162043708467089",
+            "name": "CellActionMap_CanExecuteFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3308309804690746362",
+            "name": "QueryFunction_ColorComposit",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_Color",
+                "jetbrains.mps.lang.editor.IQueryFunction_Color"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8383079901754291618",
+            "name": "CellModel_NextEditor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8383079901754291618/8383079901754291619",
+                    "name": "addHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8383079901754291618/8383079901754291620",
+                    "name": "removeHints",
+                    "type": "jetbrains.mps.lang.editor.ContextHintsSpecification"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5841812207174188445",
+            "name": "QueryFunction_ModuleAndPath",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.editor.ImagePathProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5841812207174730858",
+            "name": "ImagePathProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/784421273959504534",
+            "name": "QueryFunction_TransformationMenu",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_Menu",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7448661365106227749",
+            "name": "StubCellModel_ContextAssistant",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StubEditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3360401466585705291",
+            "name": "CellModel_ContextAssistant",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608610798",
+            "name": "QueryFunction_TransformationMenu_Execute",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608610278",
+            "name": "TransformationMenuPart_Action",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608610278/5692353713941573325",
+                    "name": "textFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_ActionLabelText",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608610278/6202297022026447496",
+                    "name": "canExecuteFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Condition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608610278/1638911550608610281",
+                    "name": "executeFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Execute",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractOutputConceptContainerTransformationMenuPart",
+                "jetbrains.mps.lang.editor.IParameterizableMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleTransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608572414",
+            "name": "TransformationMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7429591467341004871",
+            "name": "TransformationMenuPart_Group",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7429591467341004871/7655327340756279373",
+                    "name": "variables",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenuVariableDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7429591467341004871/7429591467341004877",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Condition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7429591467341004871/7429591467341004872",
+                    "name": "parts",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenuPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8449131619432941427",
+            "name": "TransformationMenuPart_Super",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5624877018228264944",
+            "name": "TransformationMenuContribution",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5624877018228264944/6718020819489956031",
+                    "name": "menuReference",
+                    "type": "jetbrains.mps.lang.editor.ITransformationMenuReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenu_Contribution",
+                "jetbrains.mps.lang.editor.ITransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5692353713941573329",
+            "name": "QueryFunction_TransformationMenu_ActionLabelText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5624877018228267058",
+            "name": "ITransformationMenu",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5624877018228267058/1638911550608572412",
+                    "name": "sections",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenuSection",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1638911550608571617",
+            "name": "TransformationMenu_Default",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenu",
+                "jetbrains.mps.lang.editor.IMenu_Default"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6718020819487620873",
+            "name": "TransformationMenuReference_Named",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6718020819487620873/6718020819487620874",
+                    "name": "menu",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenu",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenuReference_Named",
+                "jetbrains.mps.lang.editor.ITransformationMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6718020819487620876",
+            "name": "TransformationMenuReference_Default",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenuReference_Default",
+                "jetbrains.mps.lang.editor.ITransformationMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/784421273959492578",
+            "name": "TransformationMenuPart_IncludeMenu",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/784421273959492578/784421273959492606",
+                    "name": "nodeFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_TargetNode"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/784421273959492578/6718020819487784677",
+                    "name": "menuReference",
+                    "type": "jetbrains.mps.lang.editor.ITransformationMenuReference"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/784421273959492578/1873541086576603957",
+                    "name": "location",
+                    "type": "jetbrains.mps.lang.editor.TransformationLocation"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5624877018226904808",
+            "name": "TransformationMenu_Named",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenu",
+                "jetbrains.mps.lang.editor.IMenu_Named"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4056398722183895535",
+            "name": "TransformationMenuPart_SubMenu",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4056398722183895535/5692353713941631155",
+                    "name": "textFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Text",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4056398722183895535/4056398722183895554",
+                    "name": "items",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenuPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5624877018226900666",
+            "name": "TransformationMenu",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenu_Concept",
+                "jetbrains.mps.lang.editor.ITransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1597643335227097138",
+            "name": "QueryFunctionParameter_TransformationMenu_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8740634663377256691",
+            "name": "INodeProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IContextVariableProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8740634663377256692",
+            "name": "ContextVariable_Node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ContextVariable"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8740634663377264852",
+            "name": "IEditorContextProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IContextVariableProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8740634663377264853",
+            "name": "ContextVariable_EditorContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.ContextVariable"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8740634663377280921",
+            "name": "ContextVariable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7009685902974608209",
+            "name": "IContextProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IContextVariableProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/189578833592126798",
+            "name": "IContextVariableProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/784421273959493166",
+            "name": "QueryFunction_TransformationMenu_TargetNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6516520003787916624",
+            "name": "QueryFunction_TransformationMenu_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4233361609415247331",
+            "name": "QueryFunction_TransformationMenu_Parameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7980428675268276156",
+            "name": "TransformationMenuSection",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7980428675268276156/7980428675268276157",
+                    "name": "locations",
+                    "type": "jetbrains.mps.lang.editor.TransformationLocation",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7980428675268276156/7980428675268276159",
+                    "name": "parts",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenuPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3473224453637651916",
+            "name": "TransformationLocation_SideTransform_PlaceInCellHolder",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3473224453637651916/3473224453637651917",
+                    "name": "placeInCell"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4233361609415240997",
+            "name": "TransformationMenuPart_Parameterized",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4233361609415240997/4233361609415241000",
+                    "name": "parameterQuery",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Parameter",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/4233361609415240997/4233361609415240998",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.editor.TransformationMenuPart",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IMenuPartParameterized",
+                "jetbrains.mps.lang.editor.IMenuPartWithOutputConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2896773699153795590",
+            "name": "TransformationLocation_SideTransform",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/2896773699153795590/3473224453637651919",
+                    "name": "placeInCell",
+                    "type": "jetbrains.mps.lang.editor.TransformationLocation_SideTransform_PlaceInCellHolder",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationLocation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8954657570916342474",
+            "name": "QueryFunction_TransformationMenu_Node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8954657570916027046",
+            "name": "TransformationLocation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8954657570916027045",
+            "name": "TransformationFeature",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388673617",
+            "name": "TransformationFeature_Icon",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388673617/1838685759388685689",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Icon",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388685703",
+            "name": "TransformationFeature_DescriptionText",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388685703/1838685759388685704",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_DescriptionText",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2468431357014947084",
+            "name": "QueryFunction_TransformationMenu_Text",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7985135009827365938",
+            "name": "TransformationMenuPart_Placeholder",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7291101478617127464",
+            "name": "IExtensibleTransformationMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7291101478617127464/8954657570916349207",
+                    "name": "features",
+                    "type": "jetbrains.mps.lang.editor.TransformationFeature",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388690418",
+            "name": "TransformationFeature_ActionType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388690418/1838685759388690419",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Node",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1838685759388690401",
+            "name": "QueryFunction_TransformationMenu_DescriptionText",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7291101478622008880",
+            "name": "QueryFunction_TransformationMenu_Extensible",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8954657570917870539",
+            "name": "TransformationLocation_ContextAssistant",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationLocation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697344083",
+            "name": "IMenu_Concept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697344083/5991739802479788259",
+                    "name": "type",
+                    "type": "jetbrains.mps.lang.editor.MenuType"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697344083/6591946374543067572",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenu",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/615427434521884870",
+            "name": "SubstituteMenuPart_Subconcepts",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/615427434521884870/7522821015001791840",
+                    "name": "filter",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_FilterConcepts"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697344071",
+            "name": "IMenu_Default",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenu_Concept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697344070",
+            "name": "IMenu_Named",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenu_Concept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697343046",
+            "name": "IMenu",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136886962269",
+            "name": "SubstituteFeature_Icon",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136886962269/8478191136886962270",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_Icon",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7991336459489871999",
+            "name": "IOutputConceptSubstituteMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7991336459489871999/7991336459489872009",
+                    "name": "outputConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136882577348",
+            "name": "QueryFunctionParameter_SubstituteMenu_CreatedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1221634900557",
+            "name": "QueryFunctionParameter_SubstituteMenu_Link",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697282620",
+            "name": "QueryFunction_Menu",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1196434661488",
+            "name": "ISubstituteMenu_String",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697286851",
+            "name": "QueryFunctionParameter_parameterObject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8612453216082658037",
+            "name": "QueryFunction_SubstituteMenu",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_Menu",
+                "jetbrains.mps.lang.editor.IEditorContextAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136882577194",
+            "name": "QueryFunction_SubstituteMenu_Select",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7342352913006985483",
+            "name": "SubstituteMenuPart_Action",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7342352913006985483/8612453216082699922",
+                    "name": "substituteHandler",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_Substitute",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractOutputConceptContainerSubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IParameterizableMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleSubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7342352913006985500",
+            "name": "TransformationLocation_Completion",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationLocation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2000375450116423800",
+            "name": "SubstituteMenu",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenu_Concept",
+                "jetbrains.mps.lang.editor.ISubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/308059530142752797",
+            "name": "SubstituteMenuPart_Parameterized",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/308059530142752797/8371900013785948365",
+                    "name": "parameterQuery",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_Parameter"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/308059530142752797/8371900013785948359",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IMenuPartParameterized",
+                "jetbrains.mps.lang.editor.IMenuPartWithOutputConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/730181322658904464",
+            "name": "SubstituteMenuPart_IncludeMenu",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/730181322658904464/730181322658904467",
+                    "name": "menuReference",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenuReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IIncludeSubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6089045305654894366",
+            "name": "SubstituteMenuReference_Default",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenuReference_Default",
+                "jetbrains.mps.lang.editor.ISubstituteMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6089045305654894367",
+            "name": "SubstituteMenuReference_Named",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6089045305654894367/6089045305654944382",
+                    "name": "menu",
+                    "type": "jetbrains.mps.lang.editor.SubstituteMenu",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenuReference_Named",
+                "jetbrains.mps.lang.editor.ISubstituteMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697725282",
+            "name": "IMenu_Contribution",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenu",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1896914160037421068",
+            "name": "TransformationMenuPart_WrapSubstituteMenu",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1896914160037421068/1896914160037421069",
+                    "name": "menuReference",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenuReference",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1896914160037421068/4647688914585456566",
+                    "name": "targetNode",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Node"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1896914160037421068/1896914160037423677",
+                    "name": "handler",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_WrapperHandler",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IIncludeSubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleTransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7671875129586001610",
+            "name": "TransformationMenuPart_IncludeSubstituteMenu",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7671875129586001610/6089045305656903122",
+                    "name": "menuReference",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenuReference"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7671875129586001610/6089045305656903095",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IIncludeSubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697057551",
+            "name": "IMenuPartParameterized",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697057551/1630016958697057552",
+                    "name": "parameterType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697057549",
+            "name": "IParameterizableMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6684862045052059649",
+            "name": "QueryFunction_SubstituteMenu_WrapperHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697718209",
+            "name": "IMenuReference_Default",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697718209/1630016958698373342",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5425882385312046132",
+            "name": "QueryFunctionParameter_SubstituteMenu_CurrentTargetNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5329678514806335510",
+            "name": "SubstituteMenuPart_Concepts",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5329678514806335510/2857509971901910028",
+                    "name": "concepts",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_Concepts",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractOutputConceptContainerSubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136886971898",
+            "name": "QueryFunction_SubstituteMenu_Icon",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1154465273778",
+            "name": "QueryFunctionParameter_SubstituteMenu_ParentNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3961072808176441686",
+            "name": "IIncludeSubstituteMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6089045305654857712",
+            "name": "SubstituteMenuReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697718198",
+            "name": "IMenuReference_Named",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1630016958697718195",
+            "name": "IMenuReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583125082",
+            "name": "SubstituteFeature_MatchingText",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583125082/8998492695583129244",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenu_String",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534237",
+            "name": "IExtensibleSubstituteMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534237/8478191136883534238",
+                    "name": "features",
+                    "type": "jetbrains.mps.lang.editor.SubstituteFeature",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1196434649611",
+            "name": "SubstituteMenu_SimpleString",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1196434649611/1196434851095",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.ISubstituteMenu_String",
+                "jetbrains.mps.lang.editor.ISubstituteMenu_RefDescription"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583129991",
+            "name": "SubstituteFeature_CanSubstitute",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583129991/8998492695583129992",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_CanSubstitute",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3961072808175293133",
+            "name": "ITransformationMenuReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1896914160037437306",
+            "name": "QueryFunctionParameter_TransformationMenu_CreatedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583109601",
+            "name": "QueryFunction_SubstituteMenu_CanSubstitute",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2857509971901907635",
+            "name": "QueryFunction_SubstituteMenu_Concepts",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8371900013785948369",
+            "name": "QueryFunction_SubstituteMenu_Parameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274424754",
+            "name": "SubstituteMenuPart_AddConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274424754/697754674827630451",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IMenuPartWithOutputConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3738029991950788349",
+            "name": "SubstituteMenu_Named",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenu",
+                "jetbrains.mps.lang.editor.IMenu_Named"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583129971",
+            "name": "SubstituteFeature_DescriptionText",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8998492695583129971/8998492695583129972",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenu_String",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3961072808175705682",
+            "name": "ISubstituteMenuReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534188",
+            "name": "SubstituteFeature_ActionType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534188/8478191136883534189",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_ActionType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534185",
+            "name": "SubstituteFeature",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1177335944525",
+            "name": "QueryFunction_SubstituteMenu_SubstituteString",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart",
+                "jetbrains.mps.lang.editor.ISubstituteMenu_String"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1177327274449",
+            "name": "QueryFunctionParameter_pattern",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534207",
+            "name": "SubstituteFeature_Selection",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8478191136883534207/8478191136883534208",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_Select",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteFeature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1896914160037423680",
+            "name": "QueryFunction_TransformationMenu_WrapperHandler",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6684862045052059291",
+            "name": "SubstituteMenuPart_Wrapper",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6684862045052059291/6684862045053873740",
+                    "name": "handler",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_WrapperHandler",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6684862045052059291/6089045305655104958",
+                    "name": "reference",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenuReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractOutputConceptContainerSubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IIncludeSubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleSubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274418284",
+            "name": "QueryFunction_SubstituteMenu_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274418282",
+            "name": "SubstituteMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274418283",
+            "name": "SubstituteMenuPart_Group",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274418283/540685334802084769",
+                    "name": "variables",
+                    "type": "jetbrains.mps.lang.editor.SubstituteMenuVariableDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274418283/414384289274424750",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu_Condition"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/414384289274418283/414384289274424751",
+                    "name": "parts",
+                    "type": "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1230300670420",
+            "name": "QueryFunction_SubstituteMenu_ActionType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3308396621974588243",
+            "name": "SubstituteMenu_Contribution",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3308396621974588243/7173407872095451092",
+                    "name": "menuReference",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenuReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.IMenu_Contribution",
+                "jetbrains.mps.lang.editor.ISubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1177327570013",
+            "name": "QueryFunction_SubstituteMenu_Substitute",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2000375450116454183",
+            "name": "ISubstituteMenu",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/2000375450116454183/414384289274416996",
+                    "name": "parts",
+                    "type": "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.IMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6684862045052272180",
+            "name": "QueryFunctionParameter_SubstituteMenu_NodeToWrap",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3308396621974580100",
+            "name": "SubstituteMenu_Default",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenu",
+                "jetbrains.mps.lang.editor.IMenu_Default"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2314756748950088783",
+            "name": "TransformationMenuVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1178539929008",
+            "name": "TransformationMenuVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/1178539929008/540685334799973431",
+                    "name": "initializerBlock",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenuVariable_Initializer",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/540685334799947899",
+            "name": "SubstituteMenuVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/540685334799947899/540685334802085316",
+                    "name": "initializerBlock",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuVariable_Initializer",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/540685334799947902",
+            "name": "SubstituteMenuVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/540685334799965957",
+            "name": "QueryFunction_TransformationMenuVariable_Initializer",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/540685334802085318",
+            "name": "QueryFunction_SubstituteMenuVariable_Initializer",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5266818545798688928",
+            "name": "ShowBoundariesInStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5266818545798688928/5266818545798701312",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6524522039911481730",
+            "name": "QueryFunction_SubstituteMenuPart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2070581930059912763",
+            "name": "QueryFunction_TransformationMenu_Icon",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Extensible"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/159226422139203647",
+            "name": "OrCellSelector",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/159226422139203647/159226422139203648",
+                    "name": "leftSelector",
+                    "type": "jetbrains.mps.lang.editor.AbstractCellSelector",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/159226422139203647/159226422139203650",
+                    "name": "rightSelector",
+                    "type": "jetbrains.mps.lang.editor.AbstractCellSelector",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8210508057161359084",
+            "name": "QueryFunction_SubstituteMenu_Concept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu",
+                "jetbrains.mps.lang.editor.IConceptQuery"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8210508057161359081",
+            "name": "SubstituteMenuReference_DefaultWithFunction",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8210508057161359081/8210508057161359082",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.IConceptQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.ISubstituteMenuReference"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7580468736840446506",
+            "name": "ConceptFunctionParameter_model",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6481697812325410509",
+            "name": "QueryFunctionParameter_SubstituteMenu_Strictly",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4647688914602775700",
+            "name": "QueryFunctionParameter_TransformationMenu_targetNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7522821015001613004",
+            "name": "QueryFunction_SubstituteMenu_FilterConcepts",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenu"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7522821015001613016",
+            "name": "QueryFunctionParameter_SubstituteMenu_Concept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/843003353410421233",
+            "name": "OptionalConceptReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/843003353410421233/843003353410421234",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/843003353410421268",
+            "name": "IOutputConceptTransformationMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/843003353410421268/843003353410424960",
+                    "name": "outputConceptReference",
+                    "type": "jetbrains.mps.lang.editor.OptionalConceptReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/562388756446465666",
+            "name": "MigratedSideTransformMenuAttribute",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/562388756446465666/562388756446465811",
+                    "name": "transformTag"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/562388756457499018",
+            "name": "MigratedToAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/562388756457499018/562388756457499129",
+                    "name": "migratedTo",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/562388756460228274",
+            "name": "MigrateManuallyAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/562388756460228274/562388756460228275",
+                    "name": "migrateTo",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2722384699544370949",
+            "name": "SubstituteMenuPart_Placeholder",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3634216896999201706",
+            "name": "AbstractOutputConceptContainerSubstituteMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IOutputConceptSubstituteMenuPart",
+                "jetbrains.mps.lang.editor.IMenuPartWithOutputConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6546895743634568409",
+            "name": "AbstractOutputConceptContainerTransformationMenuPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IOutputConceptTransformationMenuPart",
+                "jetbrains.mps.lang.editor.IMenuPartWithOutputConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3861697222582467190",
+            "name": "IMenuPartWithOutputConcept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/332515575062761725",
+            "name": "LayoutContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2116464250555401291",
+            "name": "IEditorContextAccessQualifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7674872385216913084",
+            "name": "IContextNodeAccessQualifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6918029743850308467",
+            "name": "QueryFunction_RefPresentation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6918029743850363446",
+            "name": "ConceptFunctionParameter_sourceNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6918029743850363447",
+            "name": "ConceptFunctionParameter_targetNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3622263992595020489",
+            "name": "SubstituteMenuItem_DescriptionText_Operation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuItem_AbstractOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3622263992595020491",
+            "name": "SubstituteMenuItem_OutputConcept_Operation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuItem_AbstractOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3622263992595020486",
+            "name": "SubstituteMenuItem_MatchingText_Operation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.SubstituteMenuItem_AbstractOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3622263992592371436",
+            "name": "QueryFunctionParameter_SubstituteMenu_WrappedItem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3622263992592371437",
+            "name": "SubstituteMenuItemType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3622263992595042292",
+            "name": "SubstituteMenuItem_AbstractOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3488897807488117050",
+            "name": "CellMenuPart_ReplaceChild_defaultChildConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8428109087107030357",
+            "name": "SubstituteMenuPart_ReferenceScope",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8428109087107030357/4307758654694904293",
+                    "name": "matchingTextFunction",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenu_RefPresentation"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8428109087107030357/1154858122099170744",
+                    "name": "visibleMatchingTextFunction",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenu_RefPresentation"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8428109087107030357/4307758654694907855",
+                    "name": "descriptionTextFunction",
+                    "type": "jetbrains.mps.lang.editor.ISubstituteMenu_RefDescription"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8428109087107030357/8428109087107339113",
+                    "name": "reference",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractOutputConceptContainerSubstituteMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4307758654694982904",
+            "name": "ISubstituteMenu_RefPresentation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4307758654696938365",
+            "name": "QueryFunction_SubstituteMenu_RefPresentation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_SubstituteMenuPart",
+                "jetbrains.mps.lang.editor.ISubstituteMenu_RefPresentation",
+                "jetbrains.mps.lang.editor.ISubstituteMenu_RefDescription"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4307758654696952957",
+            "name": "QueryFunctionParameter_SubstituteMenu_ReferencedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4307758654696984618",
+            "name": "ISubstituteMenu_RefDescription",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/4307758654697524022",
+            "name": "SubstituteMenu_RefPresentationTemplate",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.RefPresentationTemplate",
+                "jetbrains.mps.lang.editor.ISubstituteMenu_RefPresentation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2115302367868116903",
+            "name": "GeneratedSubstituteMenuAttribute",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3017733173184487098",
+            "name": "SmartRefMigrationData",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3017733173184487098/3017733173184487121",
+                    "name": "entities",
+                    "type": "jetbrains.mps.lang.editor.SmartRefMigrationDataEntity",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/3017733173184487099",
+            "name": "SmartRefMigrationDataEntity",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3017733173184487099/3017733173184487102",
+                    "name": "conceptNode",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/3017733173184487099/3017733173184487105",
+                    "name": "generatedMenu",
+                    "type": "jetbrains.mps.lang.editor.SubstituteMenu_Named",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8329266386016608055",
+            "name": "ApproveDelete_Operation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8329266386016608055/8979250711607012232",
+                    "name": "cellSelector",
+                    "type": "jetbrains.mps.lang.editor.AbstractCellSelector"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8329266386016608055/8329266386016685951",
+                    "name": "editorContext",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.AbstractCellIdScopeProviderNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8979250711609513465",
+            "name": "AbstractCellIdScopeProviderNodeOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7418278005949660372",
+            "name": "FontFamilyStyleClassItem",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7418278005949660372/7418278005949660373",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_FontFamily"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem",
+                "jetbrains.mps.lang.editor.FontFamilyContainer"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5358065249857880460",
+            "name": "QueryFunction_FontFamily",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7228435049763037222",
+            "name": "FontFamilyLiteral",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.editor.FontFamilyContainer"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7228435049763093185",
+            "name": "FontFamilyContainer",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7228435049763093185/7228435049763093186",
+                    "name": "family"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6681408443912431607",
+            "name": "URLStyleClassItem",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6681408443912431607/6681408443912457593",
+                    "name": "url"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/6681408443912431607/6681408443912431608",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_URL"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.StyleClassItem"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/6681408443912573553",
+            "name": "QueryFunction_URL",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_StyleParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2508844969609391938",
+            "name": "IConceptQuery",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2508844969609391941",
+            "name": "QueryFunction_TransformationMenu_Concept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu",
+                "jetbrains.mps.lang.editor.IConceptQuery"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/2816844678677370764",
+            "name": "TransformationMenuPart_PropertyMenu",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/2816844678677370764/2816844678677370765",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/422708224287891156",
+            "name": "TransformationMenuPart_ReferenceMenu",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/422708224287891156/8537008540390643508",
+                    "name": "textFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_ActionLabelText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/422708224287891156/7136626533202861118",
+                    "name": "visibleTextFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_ActionLabelText"
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/422708224287891156/8135300941717330507",
+                    "name": "canExecuteFunction",
+                    "type": "jetbrains.mps.lang.editor.QueryFunction_TransformationMenu_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/422708224287891156/422708224287891157",
+                    "name": "referenceLink",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleTransformationMenuPart",
+                "jetbrains.mps.lang.editor.IReferenceContextProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/1588042961790478360",
+            "name": "IReferenceContextProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/732853304284119468",
+            "name": "ModuleImageProvider",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/732853304284119468/4098264106349410193",
+                    "name": "imagePath"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/732853304284119468/4098264106349410195",
+                    "name": "moduleRef",
+                    "type": "jetbrains.mps.lang.modelapi.ModulePointer",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.ImagePathProvider"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/8528336319562672599",
+            "name": "CellActionMapImport",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8528336319562672599/5730897613507031771",
+                    "name": "selector",
+                    "type": "jetbrains.mps.lang.editor.CellActionMapImportSelector",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/8528336319562672599/8528336319562672600",
+                    "name": "cellActionMap",
+                    "type": "jetbrains.mps.lang.editor.CellActionMapDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5730897613506180558",
+            "name": "CellActionMapImportSelector",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5730897613507860227",
+            "name": "CellActionMapImportSelectorByActionId",
+            "properties": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/5730897613507860227/5730897613507860230",
+                    "name": "actionId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellActionMapImportSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5730897613506180559",
+            "name": "CellActionMapImportWildcardSelector",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CellActionMapImportSelector"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7818019076292260194",
+            "name": "CompletionStyling",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7818019076292260194/7250830207897909099",
+                    "name": "specificator",
+                    "type": "jetbrains.mps.lang.editor.CompletionCustomizationContextSpecificator",
+                    "optional": false
+                },
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7818019076292260194/772883491827840107",
+                    "name": "customizeFunction",
+                    "type": "jetbrains.mps.lang.editor.CompletionCustomization_CustomizeFunction",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7250830207897895674",
+            "name": "CompletionCustomizationContextSpecificator_Concept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7250830207897895674/9115396979021131941",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.editor.CompletionCustomizationContextSpecificator"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7250830207897895677",
+            "name": "CompletionCustomizationConceptModifyingSpecificator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/7250830207897895677/772883491822711743",
+                    "name": "feature",
+                    "type": "jetbrains.mps.lang.editor.CompletionCustomization_Feature"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CompletionCustomizationContextSpecificator_Concept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/7250830207897895678",
+            "name": "CompletionCustomizationConceptCreatingSpecificator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CompletionCustomizationContextSpecificator_Concept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/9115396979021130786",
+            "name": "CompletionCustomizationContextSpecificator",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491822711654",
+            "name": "CompletionCustomization_Feature",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491822711657",
+            "name": "CompletionCustomization_PropertyFeature",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491822711657/772883491822711661",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CompletionCustomization_Feature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491822711658",
+            "name": "CompletionCustomization_LinkFeature",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491822711658/772883491822711663",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.CompletionCustomization_Feature"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827578824",
+            "name": "CompletionCustomization_CustomizeFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827671409",
+            "name": "ConceptFunctionParameterCustomize_CompletionItemInformation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827671446",
+            "name": "ConceptFunctionParameterCustomize_Style",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827672260",
+            "name": "ConceptFunctionParameterCustomize_ContextNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827672261",
+            "name": "ConceptFunctionParameterCustomize_ParentNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827677936",
+            "name": "ConceptFunctionParameterCustomize_CurrentChild",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/772883491827680373",
+            "name": "ConceptFunctionParameterCustomize_ContainmentLink",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5991739802479784072",
+            "name": "MenuType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5991739802479784073",
+            "name": "MenuTypeDefault",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.MenuType"
+            ]
+        },
+        {
+            "uid": "mps:18bc6592-03a6-4e29-a83a-7ff23bde13ba/5991739802479784074",
+            "name": "MenuTypeNamed",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.MenuType",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.menus.extras.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.menus.extras.json
@@ -1,0 +1,79 @@
+{
+    "uid": "cffe907e-d3de-433f-89d6-57d9c449c0e2",
+    "name": "jetbrains.mps.lang.editor.menus.extras",
+    "concepts": [
+        {
+            "uid": "mps:cffe907e-d3de-433f-89d6-57d9c449c0e2/2926686622729992785",
+            "name": "TransformationMenuPart_Intention",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "cffe907e-d3de-433f-89d6-57d9c449c0e2/2926686622729992785/2926686622729992786",
+                    "name": "intention",
+                    "type": "jetbrains.mps.lang.intentions.BaseIntentionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleTransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:cffe907e-d3de-433f-89d6-57d9c449c0e2/2468431357014363369",
+            "name": "QueryFunctionParameter_IntentionExecutable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:cffe907e-d3de-433f-89d6-57d9c449c0e2/4736696158595695479",
+            "name": "TransformationMenuPart_Refactoring",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "cffe907e-d3de-433f-89d6-57d9c449c0e2/4736696158595695479/4736696158595695482",
+                    "name": "refactoring",
+                    "type": "jetbrains.mps.lang.refactoring.Refactoring",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleTransformationMenuPart"
+            ]
+        },
+        {
+            "uid": "mps:cffe907e-d3de-433f-89d6-57d9c449c0e2/2319156231054332300",
+            "name": "TransformationMenuPart_PluginAction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "cffe907e-d3de-433f-89d6-57d9c449c0e2/2319156231054332300/2319156231054332308",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.TransformationMenuPart",
+                "jetbrains.mps.lang.editor.IExtensibleTransformationMenuPart"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.table.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.editor.table.json
@@ -1,0 +1,72 @@
+{
+    "uid": "0272d3b4-4cc8-481e-9e2f-07793fbfcb41",
+    "name": "jetbrains.mps.lang.editor.table",
+    "concepts": [
+        {
+            "uid": "mps:0272d3b4-4cc8-481e-9e2f-07793fbfcb41/4677325677876400523",
+            "name": "CellModel_Table",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0272d3b4-4cc8-481e-9e2f-07793fbfcb41/4677325677876400523/4490468428501048483",
+                    "name": "tableModel",
+                    "type": "jetbrains.mps.lang.editor.table.QueryFunction_TableModel",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        },
+        {
+            "uid": "mps:0272d3b4-4cc8-481e-9e2f-07793fbfcb41/4490468428501056077",
+            "name": "QueryFunction_TableModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:0272d3b4-4cc8-481e-9e2f-07793fbfcb41/2253133157536766818",
+            "name": "CellModel_HierarchycalTable",
+            "properties": [
+                {
+                    "uid": "0272d3b4-4cc8-481e-9e2f-07793fbfcb41/2253133157536766818/2253133157537011702",
+                    "name": "myProp"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "0272d3b4-4cc8-481e-9e2f-07793fbfcb41/2253133157536766818/6216065619544939793",
+                    "name": "headerRowLinkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration"
+                },
+                {
+                    "uid": "0272d3b4-4cc8-481e-9e2f-07793fbfcb41/2253133157536766818/6216065619544939794",
+                    "name": "rowsLinkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "0272d3b4-4cc8-481e-9e2f-07793fbfcb41/2253133157536766818/6216065619544939795",
+                    "name": "cellsInRowLinkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.editor.EditorCellModel"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.extension.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.extension.json
@@ -1,0 +1,239 @@
+{
+    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549",
+    "name": "jetbrains.mps.lang.extension",
+    "concepts": [
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192404",
+            "name": "ExtensionDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192404/8029776554053057811",
+                    "name": "objectGetter",
+                    "type": "jetbrains.mps.lang.extension.ExtensionObjectGetter",
+                    "optional": false
+                },
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192404/7036359038356050926",
+                    "name": "activator",
+                    "type": "jetbrains.mps.lang.extension.ExtensionFunction"
+                },
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192404/7036359038356050934",
+                    "name": "deactivator",
+                    "type": "jetbrains.mps.lang.extension.ExtensionFunction"
+                },
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192404/7036359038356115164",
+                    "name": "fieldDeclaration",
+                    "type": "jetbrains.mps.lang.extension.ExtensionFieldDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192404/3729007189729192405",
+                    "name": "extensionPoint",
+                    "type": "jetbrains.mps.lang.extension.ExtensionPointDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192406",
+            "name": "ExtensionPointDeclaration",
+            "properties": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192406/5911785528834333590",
+                    "name": "extensionName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3729007189729192406/8029776554053057803",
+                    "name": "objectType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.extension.IRootWithUniqueName",
+                "jetbrains.mps.lang.extension.IRegisterable"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/8029776554053043557",
+            "name": "ExtensionObjectGetter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/6626851894249711936",
+            "name": "ExtensionPointExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/6626851894249711936/6626851894249712469",
+                    "name": "extensionPoint",
+                    "type": "jetbrains.mps.lang.extension.ExtensionPointDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/7036359038356050927",
+            "name": "ExtensionFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/7036359038356115097",
+            "name": "ExtensionFieldDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/7036359038356115097/7036359038356115101",
+                    "name": "fieldType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/7036359038356115102",
+            "name": "ExtensionFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/7036359038356115102/7036359038356115103",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.extension.ExtensionFieldDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/3175313036448544056",
+            "name": "ExtensionPointType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/3175313036448544056/3175313036448544057",
+                    "name": "extensionPoint",
+                    "type": "jetbrains.mps.lang.extension.ExtensionPointDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/3175313036448560967",
+            "name": "GetExtensionObjectsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractOperation"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/126958800891274162",
+            "name": "Extension",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c0080a47-7e37-4558-bee9-9ae18e690549/126958800891274162/126958800891274597",
+                    "name": "extensionPoint",
+                    "type": "jetbrains.mps.lang.extension.ExtensionPointDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.AutoInitDSLClass",
+                "jetbrains.mps.lang.extension.IRegisterable"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/195736285282737522",
+            "name": "IRootWithUniqueName",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.extension.IRegisterable"
+            ]
+        },
+        {
+            "uid": "mps:c0080a47-7e37-4558-bee9-9ae18e690549/1252437031490516165",
+            "name": "IRegisterable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.json
@@ -1,0 +1,26 @@
+{
+    "uid": "cd17a113-ca4e-472f-a8de-c49008f9eea8",
+    "name": "jetbrains.mps.lang.feedback",
+    "concepts": [
+        {
+            "uid": "mps:cd17a113-ca4e-472f-a8de-c49008f9eea8/6285588811486118729",
+            "name": "Feedback",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "cd17a113-ca4e-472f-a8de-c49008f9eea8/6285588811486118729/6285588811486118732",
+                    "name": "problem",
+                    "type": "jetbrains.mps.lang.feedback.problem.Problem",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.skeleton.FeedbackRootMember"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.messages.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.messages.json
@@ -1,0 +1,27 @@
+{
+    "uid": "16e76fe3-9534-4def-afb7-925a169a7c0b",
+    "name": "jetbrains.mps.lang.feedback.messages",
+    "concepts": [
+        {
+            "uid": "mps:16e76fe3-9534-4def-afb7-925a169a7c0b/7291380803381892689",
+            "name": "ShowMessage",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "16e76fe3-9534-4def-afb7-925a169a7c0b/7291380803381892689/5258059200641510856",
+                    "name": "message",
+                    "type": "jetbrains.mps.lang.messages.CombinedMessageExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.feedback.Feedback",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.childAndProp.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.childAndProp.json
@@ -1,0 +1,25 @@
+{
+    "uid": "cddf55b3-117e-46ec-837c-ff50eb7b89b0",
+    "name": "jetbrains.mps.lang.feedback.problem.childAndProp",
+    "concepts": [
+        {
+            "uid": "mps:cddf55b3-117e-46ec-837c-ff50eb7b89b0/24399255755597574",
+            "name": "FailingPropertyConstraintsProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "cddf55b3-117e-46ec-837c-ff50eb7b89b0/24399255755597574/24399255755615671",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.failingRule.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.failingRule.json
@@ -1,0 +1,27 @@
+{
+    "uid": "db2a46c2-ebec-4b6c-b6c2-f9b55b9b6f8a",
+    "name": "jetbrains.mps.lang.feedback.problem.failingRule",
+    "concepts": [
+        {
+            "uid": "mps:db2a46c2-ebec-4b6c-b6c2-f9b55b9b6f8a/6285588811486137591",
+            "name": "FailingRuleProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "db2a46c2-ebec-4b6c-b6c2-f9b55b9b6f8a/6285588811486137591/6285588811486139544",
+                    "name": "rule",
+                    "type": "jetbrains.mps.lang.constraints.rules.Rule",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.feedback.problem.Problem",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.json
@@ -1,0 +1,61 @@
+{
+    "uid": "033598a4-76a9-47e1-ac89-a300c0fceab8",
+    "name": "jetbrains.mps.lang.feedback.problem",
+    "concepts": [
+        {
+            "uid": "mps:033598a4-76a9-47e1-ac89-a300c0fceab8/6285588811486000940",
+            "name": "Problem",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:033598a4-76a9-47e1-ac89-a300c0fceab8/24399255755750911",
+            "name": "ProblemKind",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "033598a4-76a9-47e1-ac89-a300c0fceab8/24399255755750911/24399255755751437",
+                    "name": "context",
+                    "type": "jetbrains.mps.lang.context.Context",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:033598a4-76a9-47e1-ac89-a300c0fceab8/7716791493892884282",
+            "name": "ProblemPointsToKindRoot",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "033598a4-76a9-47e1-ac89-a300c0fceab8/7716791493892884282/7716791493892884283",
+                    "name": "kind",
+                    "type": "jetbrains.mps.lang.feedback.problem.ProblemKind",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.feedback.problem.Problem",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.scopes.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.scopes.json
@@ -1,0 +1,25 @@
+{
+    "uid": "feec32f9-bc8f-4da8-8efd-7f3f9dd4101b",
+    "name": "jetbrains.mps.lang.feedback.problem.scopes",
+    "concepts": [
+        {
+            "uid": "mps:feec32f9-bc8f-4da8-8efd-7f3f9dd4101b/1592627013225787355",
+            "name": "RefOutOfScopeProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "feec32f9-bc8f-4da8-8efd-7f3f9dd4101b/1592627013225787355/1592627013225788494",
+                    "name": "ref",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.structural.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.problem.structural.json
@@ -1,0 +1,132 @@
+{
+    "uid": "7127d409-29f0-43e8-917f-f016ea288944",
+    "name": "jetbrains.mps.lang.feedback.problem.structural",
+    "concepts": [
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/5724083730281438001",
+            "name": "MissingPropertyInConceptProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/2554379189374329844",
+            "name": "MissingChildInConceptProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/1640022677634386488",
+            "name": "MissingRefInConceptProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/2559059706675257210",
+            "name": "NoChildInObligatoryRoleProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/5741876244398306563",
+            "name": "NoRefInObligatoryRoleProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/5741876244398306564",
+            "name": "MultipleChildrenInSingleRoleProblem",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/1135569809051362833",
+            "name": "InConceptProblem",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.Problem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/7574732359718311403",
+            "name": "TargetConceptIncorrectChild",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        },
+        {
+            "uid": "mps:7127d409-29f0-43e8-917f-f016ea288944/7574732359718312109",
+            "name": "TargetConceptIncorrectRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.feedback.problem.ProblemPointsToKindRoot",
+                "jetbrains.mps.lang.feedback.problem.structural.InConceptProblem"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.skeleton.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.feedback.skeleton.json
@@ -1,0 +1,46 @@
+{
+    "uid": "517077fd-e44f-4338-a475-1d29781dfdb8",
+    "name": "jetbrains.mps.lang.feedback.skeleton",
+    "concepts": [
+        {
+            "uid": "mps:517077fd-e44f-4338-a475-1d29781dfdb8/7291380803381892615",
+            "name": "FeedbackPerConceptRoot",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "517077fd-e44f-4338-a475-1d29781dfdb8/7291380803381892615/7291380803381927154",
+                    "name": "feedbacks",
+                    "type": "jetbrains.mps.lang.feedback.skeleton.FeedbackRootMember",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "517077fd-e44f-4338-a475-1d29781dfdb8/7291380803381892615/7188575577281228125",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:517077fd-e44f-4338-a475-1d29781dfdb8/6285588811486094606",
+            "name": "FeedbackRootMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.findUsages.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.findUsages.json
@@ -1,0 +1,441 @@
+{
+    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30",
+    "name": "jetbrains.mps.lang.findUsages",
+    "concepts": [
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488840",
+            "name": "FindBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488845",
+            "name": "FinderDeclaration",
+            "properties": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488845/1197385993272",
+                    "name": "description"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488845/1202838325511",
+                    "name": "longDescription"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488845/1216396839916",
+                    "name": "isVisibleBlock",
+                    "type": "jetbrains.mps.lang.findUsages.IsVisibleBlock"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488845/100784871544251463",
+                    "name": "isUsedByDefault",
+                    "type": "jetbrains.mps.lang.findUsages.IsUsedByDefault"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.findUsages.AbstractFinderDeclaration",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1197044488852",
+            "name": "IsApplicableBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1197386047362",
+            "name": "ConceptFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1200242336756",
+            "name": "ResultStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1200242336756/1200242376867",
+                    "name": "foundNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1200242562138",
+            "name": "NodeStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1200242562138/1200242582311",
+                    "name": "foundNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1206197741569",
+            "name": "ExecuteFinderExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1206197741569/1206197741572",
+                    "name": "queryNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1206197741569/1206197741573",
+                    "name": "queryScope",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1206197741569/8441762775553277663",
+                    "name": "monitor",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1206197741569/1206197741576",
+                    "name": "finder",
+                    "type": "jetbrains.mps.lang.findUsages.FinderDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1206461221942",
+            "name": "CategorizeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1206461516825",
+            "name": "SearchedNodesBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1207141825411",
+            "name": "CheckCancelledStatusStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1216396788049",
+            "name": "IsVisibleBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1218978086674",
+            "name": "AbstractFinderDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1218978086674/1218978125364",
+                    "name": "isApplicableFunction",
+                    "type": "jetbrains.mps.lang.findUsages.IsApplicableBlock"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1218978086674/1218978125365",
+                    "name": "findFunction",
+                    "type": "jetbrains.mps.lang.findUsages.FindBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1218978086674/1218978125366",
+                    "name": "searchedNodesBlock",
+                    "type": "jetbrains.mps.lang.findUsages.SearchedNodesBlock"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1218978086674/1218978125367",
+                    "name": "categorizeBlock",
+                    "type": "jetbrains.mps.lang.findUsages.CategorizeBlock"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/1218978086674/1218978181697",
+                    "name": "forConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995353",
+            "name": "ExecuteFindersGetSearchResults",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995353/6366407517031970110",
+                    "name": "queryNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995353/6366407517031970111",
+                    "name": "scope",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995353/6366407517031970112",
+                    "name": "progress",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995353/8150507060913099385",
+                    "name": "finder",
+                    "type": "jetbrains.mps.lang.findUsages.FinderReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995359",
+            "name": "FinderReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/2005690715325995359/7222148688691763792",
+                    "name": "finder",
+                    "type": "jetbrains.mps.lang.findUsages.FinderDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/6366407517031508177",
+            "name": "MakeResultProvider",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6366407517031508177/6366407517031508178",
+                    "name": "finder",
+                    "type": "jetbrains.mps.lang.findUsages.FinderReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/100784871586155151",
+            "name": "IsUsedByDefault",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/6818267381900876460",
+            "name": "FinderReferenceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6818267381900876460/6818267381900876461",
+                    "name": "finder",
+                    "type": "jetbrains.mps.lang.findUsages.FinderReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/6869265041613827495",
+            "name": "OnEachNodeFoundByExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6869265041613827495/1237139122105344154",
+                    "name": "callback",
+                    "type": "jetbrains.mps.lang.findUsages.OnEachFoundNodeCallback",
+                    "optional": false
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6869265041613827495/6869265041613827496",
+                    "name": "queryNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6869265041613827495/6869265041613827497",
+                    "name": "queryScope",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6869265041613827495/6869265041613827498",
+                    "name": "monitor",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/6869265041613827495/6869265041613949328",
+                    "name": "finders",
+                    "type": "jetbrains.mps.lang.findUsages.FinderReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1237139122104740206",
+            "name": "OnEachFoundNodeCallback",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/1237139122105327474",
+            "name": "ForEachNodeFoundClosureParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ParameterDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:64d34fcd-ad02-4e73-aff8-a581124c2e30/8961083547754843027",
+            "name": "ResultStatement2",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "64d34fcd-ad02-4e73-aff8-a581124c2e30/8961083547754843027/8961083547754843028",
+                    "name": "result",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.generationContext.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.generationContext.json
@@ -1,0 +1,701 @@
+{
+    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5",
+    "name": "jetbrains.mps.lang.generator.generationContext",
+    "concepts": [
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049619",
+            "name": "GenerationContextOp_Base",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049622",
+            "name": "GenerationContextOp_GetOutputByLabel",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049622/1217271982808",
+                    "name": "labelName_intern"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049622/6851978633175404162",
+                    "name": "forModel",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049622/1216860049623",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049627",
+            "name": "GenerationContextOp_GetOutputByLabelAndInput",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049627/1217272005596",
+                    "name": "labelName_intern"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049627/1216860049632",
+                    "name": "inputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049627/1138978740058216218",
+                    "name": "input2",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049627/1216860049628",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049633",
+            "name": "GenerationContextType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1216860049635",
+            "name": "TemplateFunctionParameter_generationContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217004708011",
+            "name": "GenerationContextOp_GetInputModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217026863835",
+            "name": "GenerationContextOp_GetOriginalInputModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217282130234",
+            "name": "GenerationContextOp_GetOutputModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217881979074",
+            "name": "GenerationContextOp_GetPrevInputByLabel",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1217881979074/1217881979079",
+                    "name": "labelName_intern"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1217881979074/1217881979075",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217884725453",
+            "name": "GenerationContextOp_GetCopiedOutputByInput",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1217884725453/1217884725459",
+                    "name": "inputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217889725928",
+            "name": "GenerationContextOp_SessionObjectAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_UserObjectAccessBase"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217889960776",
+            "name": "GenerationContextOp_UserObjectAccessBase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1217889960776/1217890689512",
+                    "name": "userKey",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217894011536",
+            "name": "GenerationContextOp_StepObjectAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_UserObjectAccessBase"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217894033795",
+            "name": "GenerationContextOp_TransientObjectAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_UserObjectAccessBase"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217960179967",
+            "name": "GenerationContextOp_ShowErrorMessage",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_ShowMessageBase"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217960314443",
+            "name": "GenerationContextOp_ShowMessageBase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1217960314443/1217960314448",
+                    "name": "messageText",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1217960314443/1217960407512",
+                    "name": "referenceNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217969995796",
+            "name": "GenerationContextOp_ShowWarningMessage",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_ShowMessageBase"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1217970068025",
+            "name": "GenerationContextOp_ShowInfoMessage",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_ShowMessageBase"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1218047638031",
+            "name": "GenerationContextOp_CreateUniqueName",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1218047638031/1218047638032",
+                    "name": "baseName",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1218047638031/1218049772449",
+                    "name": "contextNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1221156564099",
+            "name": "GenerationContextOp_GetOutputListByLabelAndInput",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221156564099/1221156564100",
+                    "name": "labelName_intern"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221156564099/1221156564104",
+                    "name": "inputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221156564099/2735079070567646928",
+                    "name": "input2",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221156564099/1221156564101",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1221218985173",
+            "name": "GenerationContextOp_GetOutputByLabelAndInputAndReferenceScope",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221218985173/1221219363547",
+                    "name": "labelName_intern"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221218985173/1221219370977",
+                    "name": "inputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1221218985173/1221219379823",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1229477454423",
+            "name": "GenerationContextOp_GetOriginalCopiedInputByOutput",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1229477454423/1229477520175",
+                    "name": "outputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/4589968773278056990",
+            "name": "GenerationContextOp_NodePatternRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/4589968773278056990/4589968773278063829",
+                    "name": "patternVarDecl",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_PatternRef"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/5190093307972723402",
+            "name": "GenerationContextOp_ParameterRef",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5190093307972723402/8224086392574645374",
+                    "name": "name_intern"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5190093307972723402/5190093307972736266",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.generator.TemplateParameterDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1758784108619220823",
+            "name": "GenerationContextOp_LinkPatternRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1758784108619220823/1758784108619220827",
+                    "name": "linkPatternVar",
+                    "type": "jetbrains.mps.lang.pattern.LinkPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_PatternRef"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1758784108619220824",
+            "name": "GenerationContextOp_PropertyPatternRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1758784108619220824/1758784108619220828",
+                    "name": "propertyPatternVar",
+                    "type": "jetbrains.mps.lang.pattern.PropertyPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_PatternRef"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1758784108619328022",
+            "name": "GenerationContextOp_PatternRef",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1758784108619328022/1758784108619487309",
+                    "name": "name_intern"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/2507865635201615235",
+            "name": "GenerationContextOp_GenParameterRef",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/2507865635201615235/4517825979522476799",
+                    "name": "name_intern"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/2507865635201615235/2507865635201615236",
+                    "name": "importClause",
+                    "type": "jetbrains.mps.lang.generator.GeneratorParameterReference",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/7430509679014182526",
+            "name": "GenerationContextOp_ContextVarRef",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/7430509679014182526/7430509679014182818",
+                    "name": "contextVarName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/5615708520036906189",
+            "name": "GenerationContextOp_RegisterLabel",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5615708520036906189/5615708520036923224",
+                    "name": "labelName_intern"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5615708520036906189/5615708520036924270",
+                    "name": "inputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5615708520036906189/5615708520036924280",
+                    "name": "outputNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5615708520036906189/5615708520036923218",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/2537089342344712322",
+            "name": "GenerationContextOp_CopyWithTrace",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/2537089342344712322/2537089342344730415",
+                    "name": "nodes",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1187483539462121947",
+            "name": "GenerationContextOp_CreateIndexedName",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1187483539462121947/1187483539462194806",
+                    "name": "skipFirstIndex",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1187483539462121947/1187483539462121948",
+                    "name": "baseName",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1187483539462121947/1187483539462121949",
+                    "name": "contextNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/1048903277984174662",
+            "name": "GenerationContextOp_VarRef2",
+            "properties": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1048903277984174662/1048903277984174664",
+                    "name": "name_intern"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/1048903277984174662/1048903277984174663",
+                    "name": "vardecl",
+                    "type": "jetbrains.mps.lang.generator.VarDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/3228980938641126117",
+            "name": "GenerationContextOp_UniqueValidId",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/3228980938641126117/2537089342344730415",
+                    "name": "node",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.generationContext.GenerationContextOp_Base"
+            ]
+        },
+        {
+            "uid": "mps:d7706f63-9be2-479c-a3da-ae92af1e64d5/5233329333133561157",
+            "name": "TypeHintAttribute",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7706f63-9be2-479c-a3da-ae92af1e64d5/5233329333133561157/1199964767385",
+                    "name": "typeHint",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.generationParameters.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.generationParameters.json
@@ -1,0 +1,66 @@
+{
+    "uid": "289fcc83-6543-41e8-a5ca-768235715ce4",
+    "name": "jetbrains.mps.lang.generator.generationParameters",
+    "concepts": [
+        {
+            "uid": "mps:289fcc83-6543-41e8-a5ca-768235715ce4/8484425748929510068",
+            "name": "DefaultGeneratorParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.IGeneratorParameter",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:289fcc83-6543-41e8-a5ca-768235715ce4/8484425748929510072",
+            "name": "DefaultGeneratorParameterContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "289fcc83-6543-41e8-a5ca-768235715ce4/8484425748929510072/8484425748929510073",
+                    "name": "parameters",
+                    "type": "jetbrains.mps.lang.generator.generationParameters.DefaultGeneratorParameter",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:289fcc83-6543-41e8-a5ca-768235715ce4/3064182000795631740",
+            "name": "DefaultGenerationParameterId",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "289fcc83-6543-41e8-a5ca-768235715ce4/3064182000795631740/3064182000795631810",
+                    "name": "container",
+                    "type": "jetbrains.mps.lang.generator.generationParameters.DefaultGeneratorParameterContainer",
+                    "optional": false
+                },
+                {
+                    "uid": "289fcc83-6543-41e8-a5ca-768235715ce4/3064182000795631740/3064182000795631811",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.generator.generationParameters.DefaultGeneratorParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.json
@@ -1,0 +1,2265 @@
+{
+    "uid": "b401a680-8325-4110-8fd3-84331ff25bef",
+    "name": "jetbrains.mps.lang.generator",
+    "concepts": [
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1087833241328",
+            "name": "PropertyMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1087833241328/1167756362303",
+                    "name": "propertyValueFunction",
+                    "type": "jetbrains.mps.lang.generator.PropertyMacro_GetPropertyValue",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.PropertyAttribute",
+                "jetbrains.mps.lang.generator.AbstractMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1087833466690",
+            "name": "NodeMacro",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1087833466690/1200912223215",
+                    "name": "mappingLabel",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.generator.AbstractMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1088761943574",
+            "name": "ReferenceMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1088761943574/1167770376702",
+                    "name": "referentFunction",
+                    "type": "jetbrains.mps.lang.generator.ReferenceMacro_GetReferent",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.LinkAttribute",
+                "jetbrains.mps.lang.generator.AbstractMacro",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1092059087312",
+            "name": "TemplateDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1092059087312/1092060348987",
+                    "name": "contentNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1092059087312/1168285871518",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.generator.IParameterizedTemplate",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1095416546421",
+            "name": "MappingConfiguration",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1184950341882",
+                    "name": "topPriorityGroup",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/7830515785164764091",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.generator.MappingConfiguration_Condition"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1167514678247",
+                    "name": "rootMappingRule",
+                    "type": "jetbrains.mps.lang.generator.Root_MappingRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1167172143858",
+                    "name": "weavingMappingRule",
+                    "type": "jetbrains.mps.lang.generator.Weaving_MappingRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1167328349397",
+                    "name": "reductionMappingRule",
+                    "type": "jetbrains.mps.lang.generator.Reduction_MappingRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1805153994416813171",
+                    "name": "patternReductionRule",
+                    "type": "jetbrains.mps.lang.generator.PatternReduction_MappingRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1167088157977",
+                    "name": "createRootRule",
+                    "type": "jetbrains.mps.lang.generator.CreateRootRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1219952894531",
+                    "name": "dropRootRule",
+                    "type": "jetbrains.mps.lang.generator.DropRootRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1195502100749",
+                    "name": "preMappingScript",
+                    "type": "jetbrains.mps.lang.generator.MappingScriptReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1195502346405",
+                    "name": "postMappingScript",
+                    "type": "jetbrains.mps.lang.generator.MappingScriptReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/1200911492601",
+                    "name": "mappingLabel",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/2456082753387314114",
+                    "name": "generationParameters",
+                    "type": "jetbrains.mps.lang.generator.GeneratorParameterReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/7473026166162327259",
+                    "name": "dropAttrubuteRule",
+                    "type": "jetbrains.mps.lang.generator.DropAttributeRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095416546421/8612733435393315377",
+                    "name": "referenceReductionRule",
+                    "type": "jetbrains.mps.lang.generator.ReferenceReductionRule",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IMemberContainer",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1095672379244",
+            "name": "TemplateFragment",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1095672379244/1200916687663",
+                    "name": "labelDeclaration",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1112730859144",
+            "name": "TemplateSwitch",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1112730859144/1167340453568",
+                    "name": "reductionMappingRule",
+                    "type": "jetbrains.mps.lang.generator.Reduction_MappingRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1112730859144/1168558750579",
+                    "name": "defaultConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1112730859144/1226355936225",
+                    "name": "nullInputMessage",
+                    "type": "jetbrains.mps.lang.generator.GeneratorMessage"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1112730859144/1112820671508",
+                    "name": "modifiedSwitch",
+                    "type": "jetbrains.mps.lang.generator.TemplateSwitch"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.generator.IParameterizedTemplate",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1112911581741",
+            "name": "TemplateSwitchReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1112911581741/1112911598335",
+                    "name": "templateSwitch",
+                    "type": "jetbrains.mps.lang.generator.TemplateSwitch",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1114706874351",
+            "name": "CopySrcNodeMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1114706874351/1168024447342",
+                    "name": "sourceNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodeQuery"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1114729360583",
+            "name": "CopySrcListMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1114729360583/1168278589236",
+                    "name": "sourceNodesQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodesQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1118773211870",
+            "name": "IfMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1118773211870/1167945861827",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.IfMacro_Condition",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1118773211870/1194989344771",
+                    "name": "alternativeConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1118786554307",
+            "name": "LoopMacro",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1118786554307/7430509679011668804",
+                    "name": "counterVarName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1118786554307/1167952069335",
+                    "name": "sourceNodesQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodesQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro",
+                "jetbrains.mps.lang.generator.ContextVariableProvider"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1131073187192",
+            "name": "MapSrcNodeMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1131073187192/1168281849769",
+                    "name": "sourceNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodeQuery"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1131073187192/1170725844563",
+                    "name": "mapperFunction",
+                    "type": "jetbrains.mps.lang.generator.MapSrcMacro_MapperFunction"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1131073187192/1225229330048",
+                    "name": "postMapperFunction",
+                    "type": "jetbrains.mps.lang.generator.MapSrcMacro_PostMapperFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1133037731736",
+            "name": "MapSrcListMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1133037731736/1168291362368",
+                    "name": "sourceNodesQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodesQuery",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1133037731736/1170871384825",
+                    "name": "mapperFunction",
+                    "type": "jetbrains.mps.lang.generator.MapSrcMacro_MapperFunction"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1133037731736/1225229689103",
+                    "name": "postMapperFunction",
+                    "type": "jetbrains.mps.lang.generator.MapSrcMacro_PostMapperFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167087469898",
+            "name": "CreateRootRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167087469898/1167087469900",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.CreateRootRule_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167087469898/1167087469901",
+                    "name": "templateNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167087469898/1200923511980",
+                    "name": "label",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167087518662",
+            "name": "CreateRootRule_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167168920554",
+            "name": "BaseMappingRule_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167169188348",
+            "name": "TemplateFunctionParameter_sourceNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167169308231",
+            "name": "BaseMappingRule",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167169308231/1167272244852",
+                    "name": "applyToConceptInheritors",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167169308231/7898029224680692134",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167169308231/1167169362365",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.BaseMappingRule_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167169308231/1167169349424",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167169308231/1200917515464",
+                    "name": "labelDeclaration",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167171569011",
+            "name": "Weaving_MappingRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167171569011/1169570368028",
+                    "name": "ruleConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167171569011/1184616230853",
+                    "name": "contextNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.Weaving_MappingRule_ContextNodeQuery",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167171569011/1021062414717374968",
+                    "name": "anchorQuery",
+                    "type": "jetbrains.mps.lang.generator.WeavingAnchorQuery"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.BaseMappingRule",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167327847730",
+            "name": "Reduction_MappingRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167327847730/1169672767469",
+                    "name": "ruleConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.BaseMappingRule",
+                "jetbrains.mps.lang.generator.ReductionRule"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167514355419",
+            "name": "Root_MappingRule",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167514355419/1177959072138",
+                    "name": "keepSourceRoot"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1167514355419/1167514355421",
+                    "name": "template",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.BaseMappingRule",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167756080639",
+            "name": "PropertyMacro_GetPropertyValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167756221419",
+            "name": "TemplateFunctionParameter_templatePropertyValue",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167770111131",
+            "name": "ReferenceMacro_GetReferent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167770229866",
+            "name": "TemplateFunctionParameter_templateReferent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167945743726",
+            "name": "IfMacro_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167951328751",
+            "name": "SourceSubstituteMacro",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1167951910403",
+            "name": "SourceSubstituteMacro_SourceNodesQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1168024337012",
+            "name": "SourceSubstituteMacro_SourceNodeQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1168559098955",
+            "name": "RuleConsequence",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1168559333462",
+            "name": "TemplateDeclarationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence",
+                "jetbrains.mps.lang.generator.ITemplateCall"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1168559512253",
+            "name": "DismissTopMappingRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1168559512253/1169669152123",
+                    "name": "generatorMessage",
+                    "type": "jetbrains.mps.lang.generator.GeneratorMessage"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1168619357332",
+            "name": "RootTemplateAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1168619357332/1168619429071",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.ImplementationPart",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1169569792945",
+            "name": "WeaveEach_RuleConsequence",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1169569792945/1169569939267",
+                    "name": "sourceNodesQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodesQuery",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1169569792945/7771219649169827299",
+                    "name": "templateCall",
+                    "type": "jetbrains.mps.lang.generator.TemplateCall",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1169670156577",
+            "name": "GeneratorMessage",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1169670156577/1169670356567",
+                    "name": "messageType"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1169670156577/1169670173015",
+                    "name": "messageText"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1170725621272",
+            "name": "MapSrcMacro_MapperFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1177093525992",
+            "name": "InlineTemplate_RuleConsequence",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1177093525992/1177093586806",
+                    "name": "templateNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1184374096829",
+            "name": "TemplateFunctionParameter_mainContextNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1184616041890",
+            "name": "Weaving_MappingRule_ContextNodeQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1184690432998",
+            "name": "TemplateFunctionParameter_outputNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1184792613450",
+            "name": "TemplateFunctionParameter_parentOutputNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1195158154974",
+            "name": "InlineSwitch_RuleConsequence",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195158154974/1195158408710",
+                    "name": "case",
+                    "type": "jetbrains.mps.lang.generator.InlineSwitch_Case",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195158154974/1195158241124",
+                    "name": "defaultConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1195158388553",
+            "name": "InlineSwitch_Case",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195158388553/1195158608805",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.BaseMappingRule_Condition",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195158388553/1195158637244",
+                    "name": "caseConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1195499912406",
+            "name": "MappingScript",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195499912406/1195595592106",
+                    "name": "scriptKind"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195499912406/1195595611951",
+                    "name": "modifiesModel",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195499912406/1195501105008",
+                    "name": "codeBlock",
+                    "type": "jetbrains.mps.lang.generator.MappingScript_CodeBlock",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1195500722856",
+            "name": "MappingScript_CodeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1195502151594",
+            "name": "MappingScriptReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1195502151594/1195502167610",
+                    "name": "mappingScript",
+                    "type": "jetbrains.mps.lang.generator.MappingScript",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1200911316486",
+            "name": "MappingLabelDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1200911316486/1200911342686",
+                    "name": "sourceConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1200911316486/3541437991299124310",
+                    "name": "sourceConcept2",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1200911316486/1200913004646",
+                    "name": "targetConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1202776937179",
+            "name": "AbandonInput_RuleConsequence",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1216768419888",
+            "name": "TemplateQueryBase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1219952072943",
+            "name": "DropRootRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1219952072943/1219952317655",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.DropRootRule_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1219952072943/1219952338328",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1219952151850",
+            "name": "DropRootRule_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1225228973247",
+            "name": "MapSrcMacro_PostMapperFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1227303129915",
+            "name": "AbstractMacro",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1227303129915/3265704088513289864",
+                    "name": "comment"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1805153994415891174",
+            "name": "TemplateParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1805153994415891174/1805153994415893199",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1805153994416516020",
+            "name": "PatternReduction_MappingRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1805153994416516020/1805153994416556314",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternExpression",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1805153994416516020/1805153994416516024",
+                    "name": "ruleConsequence",
+                    "type": "jetbrains.mps.lang.generator.RuleConsequence",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1805153994416516020/1805153994416516021",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.BaseMappingRule_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1805153994416516020/1805153994416516026",
+                    "name": "labelDeclaration",
+                    "type": "jetbrains.mps.lang.generator.MappingLabelDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.ReductionRule"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1722980698497626400",
+            "name": "ITemplateCall",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1722980698497626400/1722980698497626405",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1722980698497626400/1722980698497626483",
+                    "name": "template",
+                    "type": "jetbrains.mps.lang.generator.IParameterizedTemplate",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.TypeDerivable"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/4035562641222585520",
+            "name": "TemplateArgumentQueryExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/4035562641222585520/4035562641222618754",
+                    "name": "query",
+                    "type": "jetbrains.mps.lang.generator.TemplateArgumentQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/4035562641222622437",
+            "name": "TemplateArgumentQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/4665309944889425032",
+            "name": "TemplateArgumentPatternVarRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/4665309944889425032/4665309944889425604",
+                    "name": "patternVarDecl",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateArgumentPatternRef"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3860274746541219069",
+            "name": "ReductionRule",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/4816349095291127781",
+            "name": "TemplateArgumentPatternRef",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/4816349095291149799",
+            "name": "TemplateArgumentPropertyPatternRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/4816349095291149799/4816349095291149801",
+                    "name": "propertyPattern",
+                    "type": "jetbrains.mps.lang.pattern.PropertyPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateArgumentPatternRef"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/4816349095291149800",
+            "name": "TemplateArgumentLinkPatternRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/4816349095291149800/4816349095291149802",
+                    "name": "patternVar",
+                    "type": "jetbrains.mps.lang.pattern.LinkPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateArgumentPatternRef"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1510949579266781519",
+            "name": "TemplateCallMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1510949579266781519/1510949579266801461",
+                    "name": "sourceNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodeQuery"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro",
+                "jetbrains.mps.lang.generator.ITemplateCall"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/8900764248744213868",
+            "name": "InlineTemplateWithContext_RuleConsequence",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/8900764248744213868/8900764248744213871",
+                    "name": "contentNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.RuleConsequence",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/650531548511609556",
+            "name": "IGeneratorParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/650531548511609556/650531548511609557",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/650531548511911818",
+            "name": "GeneratorParameterReference",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/650531548511911818/5540778578667478296",
+                    "name": "isOptional",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/650531548511911818/650531548511911820",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.generator.IGeneratorParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/5005282049925926521",
+            "name": "TemplateArgumentParameterExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5005282049925926521/5005282049925926522",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.generator.TemplateParameterDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7830515785164762753",
+            "name": "MappingConfiguration_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/5133195082121471908",
+            "name": "LabelMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5133195082121471908/3541437991299113739",
+                    "name": "input1",
+                    "type": "jetbrains.mps.lang.generator.LabelMacroInputQuery"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5133195082121471908/3541437991299113741",
+                    "name": "input2",
+                    "type": "jetbrains.mps.lang.generator.LabelMacroInputQuery"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1311078761699563726",
+            "name": "InsertMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1311078761699563726/1311078761699602381",
+                    "name": "createNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.InsertMacro_CreateNodeQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1311078761699563727",
+            "name": "InsertMacro_CreateNodeQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3462145372628071891",
+            "name": "WeaveMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3462145372628071891/3462145372628083181",
+                    "name": "ruleConsequence",
+                    "type": "jetbrains.mps.lang.generator.TemplateDeclarationReference",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3462145372628071891/3462145372628083179",
+                    "name": "nodesToWeaveQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodesQuery",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3462145372628071891/2614815860187382413",
+                    "name": "anchorQuery",
+                    "type": "jetbrains.mps.lang.generator.WeavingAnchorQuery"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/5015072279636592410",
+            "name": "VarMacro_ValueQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3118009927543452571",
+            "name": "TraceMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3118009927543452571/3118009927543452625",
+                    "name": "sourceNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodeQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/982871510068000147",
+            "name": "TemplateSwitchMacro",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/982871510068000147/982871510068000158",
+                    "name": "sourceNodeQuery",
+                    "type": "jetbrains.mps.lang.generator.SourceSubstituteMacro_SourceNodeQuery"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.SourceSubstituteMacro",
+                "jetbrains.mps.lang.generator.ITemplateCall"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/982871510064032177",
+            "name": "IParameterizedTemplate",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/982871510064032177/1796073355504430601",
+                    "name": "needCallSite",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/982871510064032177/982871510064032342",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.generator.TemplateParameterDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2338220375237995425",
+            "name": "GeneratorInternal_ReferenceDescriptor",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375237995425/2338220375238055294",
+                    "name": "targetModel"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375237995425/2338220375238055296",
+                    "name": "targetNodeId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.GeneratorInternal_AbstractReferenceDescriptor"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2338220375238032411",
+            "name": "GeneratorInternal_InternalReferenceDescriptor",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375238032411/2338220375238042931",
+                    "name": "templateNodeId"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375238032411/2338220375238042933",
+                    "name": "resolveInfo"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.GeneratorInternal_AbstractReferenceDescriptor"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2338220375236868589",
+            "name": "GeneratorInternal_PropertyDescriptor",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375236868589/8389748773577451513",
+                    "name": "propertyValue"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375236868589/3413262193425582356",
+                    "name": "propertyIndex",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375236868589/2836521009934148516",
+                    "name": "propertyIdentity",
+                    "type": "jetbrains.mps.lang.smodel.PropertyId",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2338220375238032426",
+            "name": "GeneratorInternal_AbstractReferenceDescriptor",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375238032426/3413262193426811125",
+                    "name": "linkIndex",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2338220375238032426/521066010460921405",
+                    "name": "role",
+                    "type": "jetbrains.mps.lang.smodel.AssociationIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7430509679011384492",
+            "name": "ContextVariableProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7430509679011469471",
+            "name": "ContextVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/7430509679011469471/7430509679011528948",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1021062414717307707",
+            "name": "WeavingAnchorQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3864140621129707969",
+            "name": "GeneratorDebug_Mappings",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129707969/3864140621129713349",
+                    "name": "labels",
+                    "type": "jetbrains.mps.lang.generator.GeneratorDebug_LabelEntry",
+                    "multiple": true
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129707969/2471977144750369546",
+                    "name": "records",
+                    "type": "jetbrains.mps.lang.generator.CP_LabelRecord",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713348",
+            "name": "GeneratorDebug_LabelEntry",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713348/3864140621129715945",
+                    "name": "label"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713348/3864140621129715947",
+                    "name": "entries",
+                    "type": "jetbrains.mps.lang.generator.GeneratorDebug_NodeMapEntry",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713351",
+            "name": "GeneratorDebug_NodeMapEntry",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713351/5843998055530255671",
+                    "name": "isNewRoot",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713351/5808518347809748862",
+                    "name": "inputNode",
+                    "type": "jetbrains.mps.lang.generator.GeneratorDebug_InputNode"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713351/3864140621129713365",
+                    "name": "outputNode",
+                    "type": "jetbrains.mps.lang.generator.GeneratorDebug_NodeRef",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713351/3864140621129713371",
+                    "name": "inputOrigin",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713362",
+            "name": "GeneratorDebug_NodeRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3864140621129713362/3864140621129713363",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7473026166162297926",
+            "name": "DropAttributeRule_Condition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7473026166162297915",
+            "name": "DropAttributeRule",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/7473026166162297915/1515402509390413598",
+                    "name": "applyToSubConcepts",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/7473026166162297915/7473026166162322215",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.generator.DropAttributeRule_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/7473026166162297915/7473026166162297918",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/5808518347809715508",
+            "name": "GeneratorDebug_InputNode",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5808518347809715508/5808518347809748738",
+                    "name": "presentation"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5808518347809715508/5808518347810439643",
+                    "name": "modelName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5808518347809715508/5808518347809747118",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.generator.NodeIdentity"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/5808518347809715508/5808518347809748735",
+                    "name": "nodePtr",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/8612733435392875258",
+            "name": "ReferenceReductionRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/8612733435392875258/3145152795238947898",
+                    "name": "referentFunction",
+                    "type": "jetbrains.mps.lang.generator.ReferenceMacro_GetReferent",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/8612733435392875258/518316622382812505",
+                    "name": "conditionFunction",
+                    "type": "jetbrains.mps.lang.generator.BaseMappingRule_Condition"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/8612733435392875258/8612733435392875261",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/8612733435392875258/518316622382812518",
+                    "name": "applicableConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.ReductionRule"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/9032177546941580387",
+            "name": "TrivialNodeId",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/9032177546941580387/9032177546941580392",
+                    "name": "nodeId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/9032177546941580387/8557539026538618631",
+                    "name": "cncpt",
+                    "type": "jetbrains.mps.lang.smodel.ConceptIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.NodeIdentity"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/9032177546941555544",
+            "name": "NodeIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3637169702552512264",
+            "name": "ElementaryNodeId",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/3637169702552512264/3637169702552512269",
+                    "name": "nodeId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.NodeIdentity"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7980339663309897032",
+            "name": "OriginTrace",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/7980339663309897032/7980339663309897037",
+                    "name": "origin",
+                    "type": "jetbrains.mps.lang.generator.NodeIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/7771219649169826771",
+            "name": "TemplateCall",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.ITemplateCall"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1048903277984099198",
+            "name": "VarMacro2",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1048903277984099198/1048903277984099213",
+                    "name": "variables",
+                    "type": "jetbrains.mps.lang.generator.VarDeclaration",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1048903277984099206",
+            "name": "VarDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1048903277984099206/1048903277984099209",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1048903277984099206/1048903277984099210",
+                    "name": "value",
+                    "type": "jetbrains.mps.lang.generator.VarMacro_ValueQuery",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/1048903277989260815",
+            "name": "TemplateArgumentVarRefExpression2",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/1048903277989260815/1048903277989260816",
+                    "name": "vardecl",
+                    "type": "jetbrains.mps.lang.generator.VarDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/5324767449430213525",
+            "name": "InsertCallSiteMacro",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.NodeMacro"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/3541437991299094512",
+            "name": "LabelMacroInputQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.TemplateQueryBase"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2880994019885263230",
+            "name": "AbstractNodeMacroNamespace",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2880994019885263148",
+            "name": "LoopMacroNamespaceAccessor",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2880994019885263148/1501378878163388321",
+                    "name": "variable"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.AbstractNodeMacroNamespace"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333947",
+            "name": "CP_InputKey",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333948",
+            "name": "CP_InputNode",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333948/2471977144750438736",
+                    "name": "nodeId"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333948/2471977144750389791",
+                    "name": "presentation"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333948/2471977144750389792",
+                    "name": "modelName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333948/2471977144750389802",
+                    "name": "nodePtr",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333948/2471977144750333941",
+                    "name": "inputOrigin",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.CP_InputKey"
+            ]
+        },
+        {
+            "uid": "mps:b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333938",
+            "name": "CP_LabelRecord",
+            "properties": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333938/2471977144750333939",
+                    "name": "label"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333938/2471977144750333964",
+                    "name": "isNewRoot",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333938/2471977144750333957",
+                    "name": "input1",
+                    "type": "jetbrains.mps.lang.generator.CP_InputKey"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333938/2471977144750333960",
+                    "name": "input2",
+                    "type": "jetbrains.mps.lang.generator.CP_InputKey"
+                },
+                {
+                    "uid": "b401a680-8325-4110-8fd3-84331ff25bef/2471977144750333938/2471977144750333943",
+                    "name": "output",
+                    "type": "jetbrains.mps.lang.generator.GeneratorDebug_NodeRef",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.plan.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.generator.plan.json
@@ -1,0 +1,372 @@
+{
+    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00",
+    "name": "jetbrains.mps.lang.generator.plan",
+    "concepts": [
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471803",
+            "name": "Plan",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471803/1820634577908471815",
+                    "name": "steps",
+                    "type": "jetbrains.mps.lang.generator.plan.Step",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471804",
+            "name": "Step",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471809",
+            "name": "Checkpoint",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471809/3750601816081740498",
+                    "name": "cpSpec",
+                    "type": "jetbrains.mps.lang.generator.plan.CheckpointSpecification",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471810",
+            "name": "Transform",
+            "properties": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471810/2209292798354050154",
+                    "name": "individualStepPerGenerator",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471810/2944629966652439181",
+                    "name": "languages",
+                    "type": "jetbrains.mps.lang.smodel.LanguageIdentity",
+                    "multiple": true
+                },
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1820634577908471810/1152961914448142326",
+                    "name": "entries",
+                    "type": "jetbrains.mps.lang.generator.plan.LanguageEntry",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/8296877263936070001",
+            "name": "ApplyGenerators",
+            "properties": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/8296877263936070001/869728027904938835",
+                    "name": "withExtended",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/8296877263936070001/1113384811373540783",
+                    "name": "withPriorityRules",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/8296877263936070001/8296877263936660572",
+                    "name": "generator",
+                    "type": "jetbrains.mps.lang.smodel.GeneratorIdentity",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/869728027904920839",
+            "name": "CheckpointSynchronization",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/869728027904920839/3750601816087335480",
+                    "name": "checkpoint",
+                    "type": "jetbrains.mps.lang.generator.plan.CheckpointSpecification",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/6257322641293267918",
+            "name": "CheckpointDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3750601816081736033",
+            "name": "InPlaceCheckpointSpec",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.plan.CheckpointSpecification",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3750601816081736036",
+            "name": "CheckpointSpecification",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3750601816081740541",
+            "name": "DeclaredCheckpointSpec",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3750601816081740541/3750601816081740544",
+                    "name": "cpDecl",
+                    "type": "jetbrains.mps.lang.generator.plan.CheckpointDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.plan.CheckpointSpecification"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3750601816081740588",
+            "name": "InPlaceCheckpointRefSpec",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3750601816081740588/3750601816081740591",
+                    "name": "checkpoint",
+                    "type": "jetbrains.mps.lang.generator.plan.Checkpoint",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.plan.CheckpointSpecification"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3705377275350227759",
+            "name": "IncludePlan",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3705377275350227759/3705377275350227762",
+                    "name": "plan",
+                    "type": "jetbrains.mps.lang.generator.plan.Plan",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/894680215637491805",
+            "name": "DocumentationStep",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/894680215637491805/894680215637528532",
+                    "name": "comments",
+                    "type": "jetbrains.mps.lang.generator.plan.DocumentationLine",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/894680215637528423",
+            "name": "DocumentationLine",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/2959971211779300533",
+            "name": "TextDocLine",
+            "properties": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/2959971211779300533/2959971211779300563",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.plan.DocumentationLine"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3167863533095527371",
+            "name": "Fork",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3167863533095527371/2209292798354253807",
+                    "name": "filter",
+                    "type": "jetbrains.mps.lang.generator.plan.ForkSelector"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/3167863533095527371/3167863533095527372",
+                    "name": "plan",
+                    "type": "jetbrains.mps.lang.generator.plan.Plan",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.generator.plan.Step"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1152961914448136207",
+            "name": "LanguageEntry",
+            "properties": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1152961914448136207/1152961914448142318",
+                    "name": "kind"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/1152961914448136207/1152961914448136208",
+                    "name": "language",
+                    "type": "jetbrains.mps.lang.smodel.LanguageIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/2209292798354253806",
+            "name": "ForkSelector",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/2209292798354253810",
+            "name": "ConceptListSelector",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7ab1a6fa-0a11-4b95-9e48-75f363d6cb00/2209292798354253810/2209292798354253813",
+                    "name": "concepts",
+                    "type": "jetbrains.mps.lang.smodel.ConceptReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.generator.plan.ForkSelector"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.intentions.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.intentions.json
@@ -1,0 +1,326 @@
+{
+    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20",
+    "name": "jetbrains.mps.lang.intentions",
+    "concepts": [
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1192794744107",
+            "name": "IntentionDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.intentions.BaseIntentionDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1192794782375",
+            "name": "DescriptionBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1192795771125",
+            "name": "IsApplicableBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1192795911897",
+            "name": "ExecuteBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1192796902958",
+            "name": "ConceptFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1240316299033",
+            "name": "QueryBlock",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/1240316299033/1240393479918",
+                    "name": "paramType",
+                    "type": "jetbrains.mps.baseLanguage.Type"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1240322627579",
+            "name": "IntentionParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1240395258925",
+            "name": "ParameterizedIntentionDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/1240395258925/1240395532443",
+                    "name": "queryFunction",
+                    "type": "jetbrains.mps.lang.intentions.QueryBlock"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.intentions.IntentionDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/3618415754251190715",
+            "name": "ChildFilterFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/3618415754251192144",
+            "name": "ConceptFunctionParameter_childNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381",
+            "name": "BaseIntentionDeclaration",
+            "properties": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638091385",
+                    "name": "isErrorIntention",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638091386",
+                    "name": "isAvailableInChildNodes",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638093993",
+                    "name": "descriptionFunction",
+                    "type": "jetbrains.mps.lang.intentions.DescriptionBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638093994",
+                    "name": "childFilterFunction",
+                    "type": "jetbrains.mps.lang.intentions.ChildFilterFunction"
+                },
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638093995",
+                    "name": "isApplicableFunction",
+                    "type": "jetbrains.mps.lang.intentions.IsApplicableBlock"
+                },
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638198291",
+                    "name": "executeFunction",
+                    "type": "jetbrains.mps.lang.intentions.ExecuteBlock",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638091381/2522969319638198290",
+                    "name": "forConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/2522969319638198293",
+            "name": "SurroundWithIntentionDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.intentions.BaseIntentionDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1812109616120608865",
+            "name": "ParameterizedDescriptionBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.intentions.DescriptionBlock"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/1812109616120795373",
+            "name": "ParameterizedExecuteBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.intentions.ExecuteBlock"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/8214474548715792907",
+            "name": "Intention",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/8214474548715792907/6431842707461916273",
+                    "name": "priority",
+                    "type": "jetbrains.mps.lang.intentions.ErrorIntentionPriority"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/8214474548715792907/75717156636551009",
+                    "name": "forConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.baseLanguage.lightweightdsl.AutoInitDSLClass",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/7388353295030897530",
+            "name": "Parameter",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d7a92d38-f7db-40d0-8431-763b0c3c9f20/7388353295030897530/7388353295030898576",
+                    "name": "parameterType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.InstanceMethodDeclaration",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/4958616572666404607",
+            "name": "ForConceptMethodParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ParameterDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/6431842707461916181",
+            "name": "ErrorIntentionPriority",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.intentions.IntentionPriority"
+            ]
+        },
+        {
+            "uid": "mps:d7a92d38-f7db-40d0-8431-763b0c3c9f20/6431842707461916183",
+            "name": "IntentionPriority",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.makeup.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.makeup.json
@@ -1,0 +1,23 @@
+{
+    "uid": "0edf22a4-42bc-4e5d-954f-06aaaf51df00",
+    "name": "jetbrains.mps.lang.makeup",
+    "concepts": [
+        {
+            "uid": "mps:0edf22a4-42bc-4e5d-954f-06aaaf51df00/1223283106984741523",
+            "name": "CopyOutcome",
+            "properties": [
+                {
+                    "uid": "0edf22a4-42bc-4e5d-954f-06aaaf51df00/1223283106984741523/1223283106984741524",
+                    "name": "location"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.messages.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.messages.json
@@ -1,0 +1,76 @@
+{
+    "uid": "ad93155d-79b2-4759-b10c-55123e763903",
+    "name": "jetbrains.mps.lang.messages",
+    "concepts": [
+        {
+            "uid": "mps:ad93155d-79b2-4759-b10c-55123e763903/5258059200641510852",
+            "name": "MessageExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:ad93155d-79b2-4759-b10c-55123e763903/5258059200641510853",
+            "name": "LiteralMessageExpression",
+            "properties": [
+                {
+                    "uid": "ad93155d-79b2-4759-b10c-55123e763903/5258059200641510853/5258059200641510854",
+                    "name": "message"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.messages.MessageExpression"
+            ]
+        },
+        {
+            "uid": "mps:ad93155d-79b2-4759-b10c-55123e763903/5258059200642278562",
+            "name": "MacroMessageExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ad93155d-79b2-4759-b10c-55123e763903/5258059200642278562/2716118816014328328",
+                    "name": "defRef",
+                    "type": "jetbrains.mps.lang.context.defs.TypedDefReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.messages.MessageExpression"
+            ]
+        },
+        {
+            "uid": "mps:ad93155d-79b2-4759-b10c-55123e763903/5258059200642172255",
+            "name": "CombinedMessageExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ad93155d-79b2-4759-b10c-55123e763903/5258059200642172255/5258059200642172257",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.messages.MessageExpression",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.migration.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.migration.json
@@ -1,0 +1,909 @@
+{
+    "uid": "90746344-04fd-4286-97d5-b46ae6a81709",
+    "name": "jetbrains.mps.lang.migration",
+    "concepts": [
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/4436301628118948495",
+            "name": "RequiredDataDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/4436301628118948495/7907688626602625066",
+                    "name": "dependencies",
+                    "type": "jetbrains.mps.lang.migration.DataDependency",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/4950161090496546961",
+            "name": "DataDependency",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/4950161090496546961/5722749943445015285",
+                    "name": "script",
+                    "type": "jetbrains.mps.lang.migration.IMigrationUnit",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.IVariableDeclaration",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.ClassifierMember"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/5820409521797704955",
+            "name": "ProducedDataDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/5820409521797704955/5820409521797704981",
+                    "name": "dataType",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/7153805464398780214",
+            "name": "DataDependencyReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7153805464398780214/7153805464398780217",
+                    "name": "dataDependency",
+                    "type": "jetbrains.mps.lang.migration.DataDependency",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IVariableReference"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/4144229974054253572",
+            "name": "ExecuteAfterDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/4144229974054253572/4144229974054377645",
+                    "name": "dependencies",
+                    "type": "jetbrains.mps.lang.migration.OrderDependency",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/4144229974054378362",
+            "name": "OrderDependency",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/4144229974054378362/4144229974054378363",
+                    "name": "script",
+                    "type": "jetbrains.mps.lang.migration.IMigrationUnit",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/5636302460526173897",
+            "name": "TransformStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/5636302460526173897/5636302460526173934",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternExpression",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/5636302460526173897/5636302460526173936",
+                    "name": "consequence",
+                    "type": "jetbrains.mps.lang.migration.TransformConsequence",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/5636302460526173897/5636302460526173940",
+                    "name": "precondition",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/5636302460526173897/5636302460526173944",
+                    "name": "postprocess",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/5636302460526173939",
+            "name": "TransformConsequence",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/5636302460526210369",
+            "name": "QuotationConsequence",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/5636302460526210369/6129256022887780734",
+                    "name": "quotation",
+                    "type": "jetbrains.mps.lang.quotation.Quotation",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.migration.TransformConsequence"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/5636302460526210743",
+            "name": "ConsequenceFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.closures.ClosureLiteral",
+                "jetbrains.mps.lang.migration.TransformConsequence"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3220955710218421371",
+            "name": "LinkPatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3220955710218421371/3220955710218421372",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.LinkPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/7527743013695058339",
+            "name": "NodePatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7527743013695058339/7527743013695058340",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3220955710218030028",
+            "name": "PropertyPatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3220955710218030028/3220955710218036329",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.PropertyPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/6129256022887940218",
+            "name": "ListPatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6129256022887940218/6129256022887940219",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.ListPattern",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623353",
+            "name": "MoveProperty",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623353/8415841354033040057",
+                    "name": "sourceId",
+                    "type": "jetbrains.mps.lang.smodel.PropertyId"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623353/8415841354033040058",
+                    "name": "targetId",
+                    "type": "jetbrains.mps.lang.smodel.PropertyId"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.MoveConceptMember"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623351",
+            "name": "MoveReferenceLink",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623351/8415841354033040061",
+                    "name": "sourceId",
+                    "type": "jetbrains.mps.lang.smodel.ReferenceLinkId"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623351/8415841354033040062",
+                    "name": "targetId",
+                    "type": "jetbrains.mps.lang.smodel.ReferenceLinkId"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.MoveConceptMember"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623354",
+            "name": "MoveContainmentLink",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623354/8415841354033040053",
+                    "name": "sourceId",
+                    "type": "jetbrains.mps.lang.smodel.ContainmentLinkId"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623354/8415841354033040054",
+                    "name": "targetId",
+                    "type": "jetbrains.mps.lang.smodel.ContainmentLinkId"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.MoveConceptMember"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/7431903976166007326",
+            "name": "MoveNodeMigrationPart",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166007326/7431903976166276373",
+                    "name": "fromNode",
+                    "type": "jetbrains.mps.lang.migration.AbstractNodeReference",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166007326/7431903976166276375",
+                    "name": "toNode",
+                    "type": "jetbrains.mps.lang.migration.AbstractNodeReference"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166007326/3116305438947564633",
+                    "name": "specialization",
+                    "type": "jetbrains.mps.lang.migration.MoveNodeSpecialization",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.PureMigrationPart"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/7431903976166443707",
+            "name": "PureMigrationScript",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166443707/7431903976166443708",
+                    "name": "fromVersion",
+                    "type": "INT"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166443707/2151301691306162408",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166443707/5168866961623780816",
+                    "name": "executeAfter",
+                    "type": "jetbrains.mps.lang.migration.OrderDependency",
+                    "multiple": true
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166443707/7431903976166447091",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.migration.PureMigrationPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect",
+                "jetbrains.mps.lang.migration.IMigrationUnit"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695645",
+            "name": "RefactoringOrderDependency",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695645/2015900981881695646",
+                    "name": "refactoring",
+                    "type": "jetbrains.mps.lang.migration.RefactoringLog",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947559628",
+            "name": "AbstractNodeReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623352",
+            "name": "MoveConceptMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.MoveNodeSpecialization"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695631",
+            "name": "RefactoringLog",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695631/2015900981881695633",
+                    "name": "fromVersion",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695631/3597905718825595708",
+                    "name": "options",
+                    "type": "jetbrains.mps.lang.migration.RefactoringOptions"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695631/2015900981881695632",
+                    "name": "executeAfter",
+                    "type": "jetbrains.mps.lang.migration.RefactoringOrderDependency",
+                    "multiple": true
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2015900981881695631/2015900981881695634",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.migration.RefactoringPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623350",
+            "name": "MoveConcept",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623350/8415841354030700266",
+                    "name": "sourceId",
+                    "type": "jetbrains.mps.lang.smodel.ConceptId"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947623350/8415841354030700269",
+                    "name": "targetId",
+                    "type": "jetbrains.mps.lang.smodel.ConceptId"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.MoveNodeSpecialization"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947553624",
+            "name": "RefactoringPart",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947553624/3628660716136424362",
+                    "name": "participant"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947553624/3628660716136424364",
+                    "name": "initialState",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3116305438947553624/3628660716136424366",
+                    "name": "finalState",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3116305438947564637",
+            "name": "MoveNodeSpecialization",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/5168866961621042390",
+            "name": "IMigrationUnit",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/2864063292004102367",
+            "name": "ReflectionNodeReference",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2864063292004102367/2864063292004103247",
+                    "name": "nodeId"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2864063292004102367/2864063292004102809",
+                    "name": "nodeName"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2864063292004102367/2864063292004103235",
+                    "name": "modelRef"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.AbstractNodeReference"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/7431903976166012785",
+            "name": "DirectNodeReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7431903976166012785/7431903976166013456",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.AbstractNodeReference"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3597905718825595712",
+            "name": "RefactoringOptions",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3597905718825595712/3597905718825595718",
+                    "name": "options",
+                    "type": "jetbrains.mps.lang.migration.RefactoringOption",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3597905718825595715",
+            "name": "RefactoringOption",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3597905718825595715/3597905718825595716",
+                    "name": "optionId"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3597905718825595715/3597905718825650036",
+                    "name": "description"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/2770867049910679810",
+            "name": "PureMigrationPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/2770867049910679811",
+            "name": "IncludeMigrationPart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/2770867049910679811/2770867049910679904",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.migration.IMigrationUnit",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.migration.PureMigrationPart"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/3897914186547825813",
+            "name": "ConceptMigrationReference",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3897914186547825813/3897914186547825814",
+                    "name": "migrationScript",
+                    "type": "jetbrains.mps.lang.migration.MigrationScriptReference",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/3897914186547825813/3897914186547825817",
+                    "name": "oldConcept",
+                    "type": "jetbrains.mps.lang.migration.AbstractNodeReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/7417095922908675018",
+            "name": "MigrationScriptReference",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7417095922908675018/7417095922908725794",
+                    "name": "fromVersion",
+                    "type": "INT"
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/7417095922908675018/7417095922909370996",
+                    "name": "module"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/9088427053758923239",
+            "name": "ClassifierMemberData",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/9088427053758923239/9088427053758923240",
+                    "name": "nodeData",
+                    "type": "jetbrains.mps.lang.migration.ReflectionNodeReference",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/9088427053758923239/9088427053758923242",
+                    "name": "classifierData",
+                    "type": "jetbrains.mps.lang.migration.ReflectionNodeReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/6807933448469990957",
+            "name": "PutDataExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448469990957/6807933448469991411",
+                    "name": "dataNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448469990957/6807933448469991413",
+                    "name": "contextNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/6807933448471189901",
+            "name": "ProducedAnnotationDataDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448471189901/6807933448471189902",
+                    "name": "dataType",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/6807933448472075200",
+            "name": "RequiredAnnotationDataDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448472075200/6807933448472075201",
+                    "name": "dependencies",
+                    "type": "jetbrains.mps.lang.migration.AnnotationDataDependency",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.baseLanguage.lightweightdsl.MemberInstance"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/6807933448472489193",
+            "name": "AnnotationDataDependency",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448472489193/6807933448472489194",
+                    "name": "script",
+                    "type": "jetbrains.mps.lang.migration.IMigrationUnit",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.core.IResolveInfo",
+                "jetbrains.mps.baseLanguage.ClassifierMember"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/6807933448472898689",
+            "name": "GetDataExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448472898689/6807933448474152583",
+                    "name": "module",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/6807933448472898689/6807933448472899878",
+                    "name": "requiredDataDeclararion",
+                    "type": "jetbrains.mps.lang.migration.AnnotationDataDependency",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:90746344-04fd-4286-97d5-b46ae6a81709/8352104482584315555",
+            "name": "MigrationScript",
+            "properties": [
+                {
+                    "uid": "90746344-04fd-4286-97d5-b46ae6a81709/8352104482584315555/5820409521797704727",
+                    "name": "fromVersion",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassConcept",
+                "jetbrains.mps.lang.migration.IMigrationUnit",
+                "jetbrains.mps.baseLanguage.lightweightdsl.AutoInitDSLClass"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.migration.util.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.migration.util.json
@@ -1,0 +1,46 @@
+{
+    "uid": "9882f4ad-1955-46fe-8269-94189e5dbbf2",
+    "name": "jetbrains.mps.lang.migration.util",
+    "concepts": [
+        {
+            "uid": "mps:9882f4ad-1955-46fe-8269-94189e5dbbf2/3211321119092784894",
+            "name": "StringData",
+            "properties": [
+                {
+                    "uid": "9882f4ad-1955-46fe-8269-94189e5dbbf2/3211321119092784894/3211321119092784906",
+                    "name": "data"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:9882f4ad-1955-46fe-8269-94189e5dbbf2/7417095922908669705",
+            "name": "StepData",
+            "properties": [
+                {
+                    "uid": "9882f4ad-1955-46fe-8269-94189e5dbbf2/7417095922908669705/1973338949477451252",
+                    "name": "script"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "9882f4ad-1955-46fe-8269-94189e5dbbf2/7417095922908669705/7417095922908725798",
+                    "name": "data",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.modelapi.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.modelapi.json
@@ -1,0 +1,175 @@
+{
+    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e",
+    "name": "jetbrains.mps.lang.modelapi",
+    "concepts": [
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193247",
+            "name": "NodePointer",
+            "properties": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193247/5035511943546916744",
+                    "name": "nodeId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193247/5035511943546916740",
+                    "name": "modelRef",
+                    "type": "jetbrains.mps.lang.modelapi.ModelIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.modelapi.NodeIdentity"
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193248",
+            "name": "ModelPointer",
+            "properties": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193248/1863527487546097494",
+                    "name": "modelId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193248/679099339649067980",
+                    "name": "name",
+                    "type": "jetbrains.mps.lang.modelapi.ModelName",
+                    "optional": false
+                },
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193248/1863527487546123100",
+                    "name": "moduleRef",
+                    "type": "jetbrains.mps.lang.modelapi.ModuleIdentity"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.modelapi.ModelIdentity"
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193249",
+            "name": "ModulePointer",
+            "properties": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193249/1863527487545993577",
+                    "name": "moduleName"
+                },
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826193249/1863527487546097500",
+                    "name": "moduleId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.modelapi.ModuleIdentity"
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/9032177546942789331",
+            "name": "ModelIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826268407",
+            "name": "NodeIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/361130699826268409",
+            "name": "ConceptIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/679099339649053840",
+            "name": "ModelName",
+            "properties": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/679099339649053840/679099339649053841",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/679099339649067977",
+            "name": "ModuleIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:446c26eb-2b7b-4bf0-9b35-f83fa582753e/4733039728785194814",
+            "name": "NamedNodeReference",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/4733039728785194814/7256306938026143676",
+                    "name": "child",
+                    "type": "jetbrains.mps.lang.modelapi.NamedNodeReference"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "446c26eb-2b7b-4bf0-9b35-f83fa582753e/4733039728785194814/7256306938026143658",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.modelapi.NodeIdentity"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.pattern.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.pattern.json
@@ -1,0 +1,650 @@
+{
+    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7",
+    "name": "jetbrains.mps.lang.pattern",
+    "concepts": [
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037773",
+            "name": "AsPattern",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.PatternVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037775",
+            "name": "Pattern",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037777",
+            "name": "PatternExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037777/9046399079000773837",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.quotation.Quotation",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037779",
+            "name": "PatternVariableDeclaration",
+            "properties": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037779/1136720037780",
+                    "name": "varName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.Pattern",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037781",
+            "name": "PropertyPatternVariableDeclaration",
+            "properties": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037781/1136720037782",
+                    "name": "varName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.PropertyAttribute",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.quotation.StringToTypedValueMigrationInfo"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136720037783",
+            "name": "WildcardPattern",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.Pattern"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1136727061274",
+            "name": "ListPattern",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.AsPattern"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1137418540378",
+            "name": "LinkPatternVariableDeclaration",
+            "properties": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1137418540378/1137418571428",
+                    "name": "varName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.LinkAttribute",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/4413230749907733332",
+            "name": "ActionAsPattern",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/4413230749907733332/8990057180226016446",
+                    "name": "position",
+                    "type": "jetbrains.mps.lang.pattern.InsertPosition",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/4413230749907733332/4413230749907733337",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.pattern.ActionStatement",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.AsPattern"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/4413230749907802464",
+            "name": "ActionStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/3133930811460119173",
+            "name": "PatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/3133930811460119173/3133930811460119174",
+                    "name": "variable",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/2879868312062962308",
+            "name": "OrPattern",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/2879868312062962308/2879868312062970574",
+                    "name": "clause",
+                    "type": "jetbrains.mps.lang.pattern.OrPatternClause",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/2879868312062962308/4264731254635442558",
+                    "name": "variable",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.Pattern",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/4855904478356877904",
+            "name": "OrPatternClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.PatternExpression"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/4264731254635442556",
+            "name": "OrPatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/4264731254635442556/4264731254635442557",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1649655856141352248",
+            "name": "InsertAfterPosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.InsertPosition"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1649655856141352250",
+            "name": "InsertBeforePosition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.InsertPosition"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1649655856141352252",
+            "name": "InsertPosition",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655302167",
+            "name": "GeneratorInternal_ChildDescriptor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655302167/9117569544655305157",
+                    "name": "childLinkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655302167/9117569544655305584",
+                    "name": "mainNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655309654",
+            "name": "GeneratorInternal_ReferenceDescriptor",
+            "properties": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655309654/9117569544655311213",
+                    "name": "id"
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655309654/9117569544655311214",
+                    "name": "model"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655309654/8767425448057210504",
+                    "name": "referenceLinkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655309654/9117569544655309656",
+                    "name": "mainNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655310702",
+            "name": "GeneratorInternal_PropertyDescriptor",
+            "properties": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655310702/9117569544655310711",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655310702/8389748773577465499",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/9117569544655310702/9117569544655310703",
+                    "name": "mainNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/2595803291918203417",
+            "name": "PatternBuilder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/2595803291918203417/2595803291918205969",
+                    "name": "builder",
+                    "type": "jetbrains.mps.lang.quotation.NodeBuilderNode",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.quotation.INodeBuilderContainer"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/2595803291918990192",
+            "name": "PatternVariableNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue",
+                "jetbrains.mps.lang.quotation.NodeBuilderInitValueChild",
+                "jetbrains.mps.lang.pattern.PatternBuilderVariable"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/5834644128080314032",
+            "name": "PatternBuilderClassifierMember",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/5834644128080314032/5834644128080314035",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternBuilder",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.ClassifierMember",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/6985522012210239842",
+            "name": "PatternVariableProperty",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitPropertyValue",
+                "jetbrains.mps.lang.pattern.PatternBuilderVariable"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540923217",
+            "name": "PatternSwitchStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540923217/5944356402132808752",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540923217/5944356402132808753",
+                    "name": "case",
+                    "type": "jetbrains.mps.lang.pattern.PatternSwitchCase",
+                    "multiple": true
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540923217/6039268229365417680",
+                    "name": "defaultBlock",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540978710",
+            "name": "PatternSwitchCase",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540978710/1163670683720",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199540978710/1678856199549152500",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.AbstractPatternProvider",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199549152507",
+            "name": "AbstractPatternProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199549152508",
+            "name": "LocalPatternReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/1678856199549152508/1678856199549152509",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.PatternBuilderClassifierMember",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.AbstractPatternProvider"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/8950533135208478267",
+            "name": "InlinePatternProvider",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/8950533135208478267/8950533135208478269",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternBuilder",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.AbstractPatternProvider"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/2793477601721978990",
+            "name": "PatternBuilderVariable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/2793477601721979013",
+            "name": "PatternBuilderVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/2793477601721979013/2793477601721979016",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.pattern.PatternBuilderVariable"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/967124561399721191",
+            "name": "LabeledNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderNode",
+                "jetbrains.mps.lang.pattern.PatternBuilderVariable"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/7939357357339014136",
+            "name": "ExpressionPatternProvider",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/7939357357339014136/7939357357339014137",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.pattern.AbstractPatternProvider"
+            ]
+        },
+        {
+            "uid": "mps:d4615e3b-d671-4ba9-af01-2b78369b0ba7/7939357357339023064",
+            "name": "QualifiedPatternReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/7939357357339023064/7939357357339023557",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                },
+                {
+                    "uid": "d4615e3b-d671-4ba9-af01-2b78369b0ba7/7939357357339023064/7939357357339023572",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternBuilderClassifierMember",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.QualifiedReference"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.plugin.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.plugin.json
@@ -1,0 +1,2368 @@
+{
+    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1",
+    "name": "jetbrains.mps.lang.plugin",
+    "concepts": [
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203071677434",
+            "name": "ToolDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071677434/1214307129846",
+                    "name": "getComponentBlock",
+                    "type": "jetbrains.mps.lang.plugin.GetComponentBlock",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.BaseToolDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203082695294",
+            "name": "DoUpdateBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.UpdateBlock"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203082903663",
+            "name": "ConceptFunctionParameter_AnActionEvent",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203083511112",
+            "name": "ExecuteBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642",
+            "name": "ActionGroupDeclaration",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1204991940915",
+                    "name": "caption"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1205160812895",
+                    "name": "mnemonic"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1205160838084",
+                    "name": "isInternal",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1213283637680",
+                    "name": "isPopup",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1217005992861",
+                    "name": "isInvisibleWhenDisabled",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/6368583333374291912",
+                    "name": "isPluginXmlGroup",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1204991552650",
+                    "name": "modifier",
+                    "type": "jetbrains.mps.lang.plugin.ModificationStatement",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203087890642/1207145245948",
+                    "name": "contents",
+                    "type": "jetbrains.mps.lang.plugin.GroupContents",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.plugin.ActionGroupMember",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203088046679",
+            "name": "ActionInstance",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203088046679/1227011543811",
+                    "name": "actualParameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203088046679/1203088061055",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionGroupMember"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203092361741",
+            "name": "ModificationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203092361741/1203092736097",
+                    "name": "modifiedGroup",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203092361741/1204992316090",
+                    "name": "point",
+                    "type": "jetbrains.mps.lang.plugin.GroupAnchor"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203680534665",
+            "name": "GroupAnchor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.plugin.ActionGroupMember"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203851983563",
+            "name": "GetNodeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.plugin.NodesBlock"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203852029150",
+            "name": "GetNodesBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.plugin.NodesBlock"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203853034639",
+            "name": "ConceptFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.ConceptFunctionParameter_CreatorType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204039194827",
+            "name": "ConceptFunctionParameter_OperationContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204383956737",
+            "name": "InterfaceGroup",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1204383956737/1206193920040",
+                    "name": "groupID",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.ActionGroupDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204391079391",
+            "name": "ActionGroupMember",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204397573187",
+            "name": "InterfaceExtentionPoint",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1204397573187/1206194300534",
+                    "name": "pointID",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.GroupAnchor"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204471433283",
+            "name": "ToolInstanceExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204477852167",
+            "name": "ConceptFunctionParameter_IModule",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.ConceptFunctionParameter_CreatorType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204478074808",
+            "name": "ConceptFunctionParameter_MPSProject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1204908117386",
+            "name": "Separator",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionGroupMember"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1205679047295",
+            "name": "ActionParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.FieldDeclaration",
+                "jetbrains.mps.baseLanguage.classifiers.IMember",
+                "jetbrains.mps.lang.plugin.ActionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1205681149025",
+            "name": "UpdateBlock",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1205681243813",
+            "name": "IsApplicableBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.UpdateBlock"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1205852320419",
+            "name": "ActionType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1205852320419/1205852349655",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1206092561075",
+            "name": "ActionParameterReferenceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1207145102141",
+            "name": "GroupContents",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1207145360364",
+            "name": "BuildGroupBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.plugin.GroupContents"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1207145163717",
+            "name": "ElementListContents",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1207145163717/1207145201301",
+                    "name": "reference",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupMember",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.GroupContents"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1207318242772",
+            "name": "KeyMapKeystroke",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1207318242772/1207318242773",
+                    "name": "modifiers"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1207318242772/1207318242774",
+                    "name": "keycode"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1207318242772/6785623076777470797",
+                    "name": "change"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1207490810216",
+            "name": "GroupType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1207490810216/1207490810218",
+                    "name": "actionGroup",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1208528650020",
+            "name": "ToolType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1208528650020/1208529537963",
+                    "name": "tool",
+                    "type": "jetbrains.mps.lang.plugin.BaseToolDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1209911036758",
+            "name": "GetGroupOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1209911036758/1209911052601",
+                    "name": "group",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210179134063",
+            "name": "PreferencesComponentDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210179134063/1210179829398",
+                    "name": "persistenPropertyDeclaration",
+                    "type": "jetbrains.mps.lang.plugin.PersistentPropertyDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210179134063/1210676907584",
+                    "name": "afterReadBlock",
+                    "type": "jetbrains.mps.lang.plugin.OnAfterReadBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210179134063/1210676918600",
+                    "name": "beforeWriteBlock",
+                    "type": "jetbrains.mps.lang.plugin.OnBeforeWriteBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210179134063/1210684426855",
+                    "name": "preferencePage",
+                    "type": "jetbrains.mps.lang.plugin.PreferencePage",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier",
+                "jetbrains.mps.lang.structure.INamedAspect"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210179190070",
+            "name": "PersistentPropertyDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration",
+                "jetbrains.mps.baseLanguage.classifiers.IMember"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210180874794",
+            "name": "PersistentPropertyReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210184105060",
+            "name": "PreferencesComponentType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210184105060/1210184138184",
+                    "name": "componentDeclaration",
+                    "type": "jetbrains.mps.lang.plugin.PreferencesComponentDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210676672555",
+            "name": "OnBeforeWriteBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210676879526",
+            "name": "OnAfterReadBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183",
+            "name": "PreferencePage",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1210686783787",
+                    "name": "iconPath"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1557260317236259345",
+                    "name": "helpTopic"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1210686845551",
+                    "name": "component",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1210763647050",
+                    "name": "isModifiedBlock",
+                    "type": "jetbrains.mps.lang.plugin.PreferencePageIsModifiedBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1210686936988",
+                    "name": "resetBlock",
+                    "type": "jetbrains.mps.lang.plugin.PreferencePageResetBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1210686956582",
+                    "name": "commitBlock",
+                    "type": "jetbrains.mps.lang.plugin.PreferencePageCommitBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1210684385183/1113888653567546995",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210686882550",
+            "name": "PreferencePageResetBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210686969356",
+            "name": "PreferencePageCommitBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210690798207",
+            "name": "ConceptFunctionParameter_PreferencePage_component",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1210763550007",
+            "name": "PreferencePageIsModifiedBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1213888653896",
+            "name": "InitBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1213888677711",
+            "name": "DisposeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1213888797251",
+            "name": "ConceptFunctionParameter_Project",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1214307303872",
+            "name": "GetComponentBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1217252042208",
+            "name": "ActionDataParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1217252042208/1217252646389",
+                    "name": "key",
+                    "type": "jetbrains.mps.baseLanguage.StaticFieldDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMember",
+                "jetbrains.mps.lang.plugin.ActionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1217252428768",
+            "name": "ActionDataParameterReferenceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1217413147516",
+            "name": "ActionParameter",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1217413147516/1221669969834",
+                    "name": "isOptional",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1217413147516/5538333046911298738",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.plugin.ActionParameterCondition",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1227008846812",
+            "name": "ActionConstructionParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1227008846812/1227019158144",
+                    "name": "toStringFunction",
+                    "type": "jetbrains.mps.lang.plugin.ToStringConceptFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierFieldDeclaration",
+                "jetbrains.mps.baseLanguage.classifiers.IMember"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1227008925923",
+            "name": "ActionConstructorParameterReferenceOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1227013049127",
+            "name": "AddStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1227013049127/1227013166210",
+                    "name": "item",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupMember",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1227019068586",
+            "name": "ToStringConceptFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1227019310584",
+            "name": "ToStringParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1239975356883",
+            "name": "UpdateGroupBlock",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1239975356883/1239975488603",
+                    "name": "updateFunction",
+                    "type": "jetbrains.mps.lang.plugin.UpdateGroupFunction",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1239975356883/1239975503745",
+                    "name": "enumerateFunction",
+                    "type": "jetbrains.mps.lang.plugin.EnumerateChildrenFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.GroupContents"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1239975436002",
+            "name": "UpdateGroupFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1239975563668",
+            "name": "EnumerateChildrenFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1562714432501166197",
+            "name": "KeymapChangesDeclaration",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1562714432501166197/1562714432501166281",
+                    "name": "keymap"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1562714432501166197/8646726056720906098",
+                    "name": "isPluginXmlKeymap",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1562714432501166197/1562714432501166199",
+                    "name": "shortcutChange",
+                    "type": "jetbrains.mps.lang.plugin.ShortcutChange",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1562714432501166198",
+            "name": "SimpleShortcutChange",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1562714432501166198/1562714432501166206",
+                    "name": "keystroke",
+                    "type": "jetbrains.mps.lang.plugin.KeyMapKeystroke",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ShortcutChange"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/6193305307616715384",
+            "name": "ShortcutChange",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6193305307616715384/6193305307616734326",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/6193305307616734266",
+            "name": "ParameterizedShortcutChange",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6193305307616734266/617467876802702218",
+                    "name": "change"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.plugin.ShortcutChange"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/394857668356997867",
+            "name": "SimpleActionPlace",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionPlaceSpecification"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/394857668356997868",
+            "name": "ActionPlaceSpecification",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/394857668357022342",
+            "name": "ToolActionPlace",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionPlaceSpecification"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/394857668357342104",
+            "name": "EverywhereActionPlace",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionPlaceSpecification"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5854436268949437205",
+            "name": "ConceptFunctionParameter_Model",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.ConceptFunctionParameter_CreatorType"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5854436268949437211",
+            "name": "ConceptFunctionParameter_CreatorType",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268",
+            "name": "BaseToolDeclaration",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/6547237850567462620",
+                    "name": "caption"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/6547237850567462701",
+                    "name": "number"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/2498620720770664572",
+                    "name": "position"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/6547237850567462766",
+                    "name": "icon"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/6547237850567462848",
+                    "name": "methodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierMethodDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/6547237850567462849",
+                    "name": "fieldDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierFieldDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/8096638938275469614",
+                    "name": "toolInitBlock",
+                    "type": "jetbrains.mps.lang.plugin.InitBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/8096638938275469615",
+                    "name": "toolDisposeBlock",
+                    "type": "jetbrains.mps.lang.plugin.DisposeBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/6791676465872004185",
+                    "name": "toolIcon",
+                    "type": "jetbrains.mps.lang.resources.Icon"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6547237850567458268/471625927503648174",
+                    "name": "shortcut",
+                    "type": "jetbrains.mps.lang.plugin.AbstractToolShortcut"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5896642449625981893",
+            "name": "TabbedToolDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.BaseToolDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5896642449625987000",
+            "name": "AddTabOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5896642449625987000/7566788359602201160",
+                    "name": "tab",
+                    "type": "jetbrains.mps.lang.plugin.ToolTab",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.TabbedToolOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5818192529492099570",
+            "name": "CloseTabOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5818192529492099570/5818192529492102108",
+                    "name": "componentExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.TabbedToolOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1862809785209122566",
+            "name": "GetSelectedTabOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.TabbedToolOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/8096638938275438668",
+            "name": "TabbedToolOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/485694842828664424",
+            "name": "SmartDisposeClosureParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.closures.UnboundClosureParameterDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/6938053545825350222",
+            "name": "ToolTab",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6938053545825350222/6938053545825381648",
+                    "name": "componentExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6938053545825350222/6938053545825381649",
+                    "name": "titleExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6938053545825350222/6938053545825381650",
+                    "name": "iconExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/6938053545825350222/6938053545825381651",
+                    "name": "disposeTabClosure",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3339131993542057767",
+            "name": "BaseProjectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3205675194086589964",
+            "name": "ActionAccessOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3205675194086589964/3205675194086671728",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3205675194086686068",
+            "name": "GroupAccessOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3205675194086686068/3205675194086686070",
+                    "name": "group",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364",
+            "name": "IdeaInitializerDescriptor",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5023285075122009366",
+                    "name": "id"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5023285075122009368",
+                    "name": "descripttion"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5023285075122009369",
+                    "name": "version"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5023285075122009371",
+                    "name": "vendor"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5023285075122009372",
+                    "name": "vendorUrl"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/4167053799973858143",
+                    "name": "vendorLogo"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5023285075122009373",
+                    "name": "ideaVersion"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/8842945788826116904",
+                    "name": "loadModules",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/1573568368168371217",
+                    "name": "handleErrors",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/5864553086652219115",
+                    "name": "dependency",
+                    "type": "jetbrains.mps.lang.plugin.PluginDependency",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5023285075122009364/331224023792859996",
+                    "name": "actions",
+                    "type": "jetbrains.mps.lang.plugin.IdeaActionsDescriptor"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/8817525066851790100",
+            "name": "KeyStrokeType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1821622352985038318",
+            "name": "ActionParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableReference"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/8131292300541727132",
+            "name": "AddKeystrokeStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/8131292300541727132/8131292300541905245",
+                    "name": "stroke",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611750",
+            "name": "CreateNodeAspectBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759",
+            "name": "EditorTab",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070611767",
+                    "name": "shortcutChar"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/8204570419206313935",
+                    "name": "commandOnCreate",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/2386275659558598338",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070613126",
+                    "name": "order",
+                    "type": "jetbrains.mps.lang.plugin.OrderConstraints"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070613134",
+                    "name": "listenBlock",
+                    "type": "jetbrains.mps.lang.plugin.ListenBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070611762",
+                    "name": "baseNodeBlock",
+                    "type": "jetbrains.mps.lang.plugin.BaseNodeBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070657666",
+                    "name": "isApplicableBlock",
+                    "type": "jetbrains.mps.lang.plugin.IsApplicableTabBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070612960",
+                    "name": "nodesBlock",
+                    "type": "jetbrains.mps.lang.plugin.NodesBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/1640281869714699888",
+                    "name": "createTabBlock",
+                    "type": "jetbrains.mps.lang.plugin.CreateTabBlock"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070611759/3743831881070611760",
+                    "name": "baseNodeConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070612962",
+            "name": "NodesBlock",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070613135",
+            "name": "IsApplicableTabBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070657672",
+            "name": "BaseNodeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3743831881070657680",
+            "name": "ListenBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534683973",
+            "name": "OrderConstraints",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534683975",
+            "name": "Order",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534683975/2450897840534683977",
+                    "name": "tab",
+                    "type": "jetbrains.mps.lang.plugin.EditorTabReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.OrderConstraints",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534683979",
+            "name": "EditorTabReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534683979/2450897840534683980",
+                    "name": "editorTab",
+                    "type": "jetbrains.mps.lang.plugin.EditorTab",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534688273",
+            "name": "OrderReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/2450897840534688273/2450897840534688274",
+                    "name": "order",
+                    "type": "jetbrains.mps.lang.plugin.Order",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.OrderConstraints"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776",
+            "name": "ActionDeclaration",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1205250923097",
+                    "name": "caption"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/3984210554599197374",
+                    "name": "ID"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/320225375803393754",
+                    "name": "overrides",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1213273179528",
+                    "name": "description"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1215865999894",
+                    "name": "mnemonic"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1207149998849",
+                    "name": "isAlwaysVisible",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1211298967294",
+                    "name": "outsideCommandExecution",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/7458746815261976739",
+                    "name": "requiredAccess"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/997079742910640235",
+                    "name": "fillActionContext",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1203083196627",
+                    "name": "updateBlock",
+                    "type": "jetbrains.mps.lang.plugin.UpdateBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/8976425910813834639",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1203083461638",
+                    "name": "executeFunction",
+                    "type": "jetbrains.mps.lang.plugin.ExecuteBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1205851242421",
+                    "name": "methodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierMethodDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1217413222820",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.plugin.ActionParameter",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/1227008813498",
+                    "name": "constructionParameter",
+                    "type": "jetbrains.mps.lang.plugin.ActionConstructionParameterDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1203071646776/394857668356997869",
+                    "name": "places",
+                    "type": "jetbrains.mps.lang.plugin.ActionPlaceSpecification",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier",
+                "jetbrains.mps.lang.checkedName.ICheckedNamePolicy",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101112751",
+            "name": "ButtonCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101112751/1988288734101112916",
+                    "name": "action",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101112747",
+            "name": "PopupCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101112747/9011731583464088751",
+                    "name": "group",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101108470",
+            "name": "ToolbarCreator",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101108470/2983858627857066398",
+                    "name": "isHorizontal",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1988288734101108470/9011731583464032515",
+                    "name": "group",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1640281869714699879",
+            "name": "CreateTabBlock",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1640281869714699879/1640281869714699886",
+                    "name": "commandOnCreate",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1640281869714699879/7459370737647652579",
+                    "name": "conceptsBlock",
+                    "type": "jetbrains.mps.lang.plugin.ConceptsBlock"
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1640281869714699879/7459370737647652611",
+                    "name": "createBlock",
+                    "type": "jetbrains.mps.lang.plugin.CreateBlock"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5538333046911298739",
+            "name": "CustomCondition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.plugin.ActionParameterCondition"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5538333046911348647",
+            "name": "ParameterCondition_ConceptFunctionParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5538333046911348652",
+            "name": "ActionParameterCondition",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5538333046911348654",
+            "name": "RequiredCondition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionParameterCondition"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5678361901872075170",
+            "name": "EditableModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionParameterCondition"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5864553086652219113",
+            "name": "PluginDependency",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5864553086652219116",
+            "name": "IdeaPluginDependency",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5864553086652219116/5864553086652219119",
+                    "name": "pluginId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.PluginDependency"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/203415309825565488",
+            "name": "MPSPluginDependency",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/203415309825565488/203415309825565489",
+                    "name": "plugin",
+                    "type": "jetbrains.mps.lang.plugin.IdeaInitializerDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.PluginDependency"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792854814",
+            "name": "IdeaActionsDescriptor",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792854814/331224023792855168",
+                    "name": "keymapsRef",
+                    "type": "jetbrains.mps.lang.plugin.KeymapRef",
+                    "multiple": true
+                },
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792854814/331224023792854818",
+                    "name": "actionGroups",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupRef",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792854815",
+            "name": "ActionGroupRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792854815/331224023792854816",
+                    "name": "group",
+                    "type": "jetbrains.mps.lang.plugin.ActionGroupDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792855166",
+            "name": "KeymapRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/331224023792855166/331224023792855167",
+                    "name": "keymap",
+                    "type": "jetbrains.mps.lang.plugin.KeymapChangesDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/3205778618063718746",
+            "name": "IdeaConfigurationXml",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3205778618063718746/1004145947012803941",
+                    "name": "outputPath"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/3205778618063718746/3205778618063718748",
+                    "name": "actions",
+                    "type": "jetbrains.mps.lang.plugin.IdeaActionsDescriptor"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1050311802978903937",
+            "name": "ConceptCondition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1050311802978903937/1050311802978903949",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.plugin.ActionParameterCondition"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1207145475354",
+            "name": "AddElementStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1207145475354/1207145494930",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1512255007353869532",
+            "name": "NonDumbAwareActions",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1512255007353869532/1512255007353869533",
+                    "name": "actions",
+                    "type": "jetbrains.mps.lang.plugin.ActionReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/1512255007353869535",
+            "name": "ActionReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/1512255007353869535/1512255007353869536",
+                    "name": "actionDeclaration",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/4295816563224240545",
+            "name": "PinTabOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/4295816563224240545/5386424596292315200",
+                    "name": "componentExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.TabbedToolOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/5386424596292331400",
+            "name": "UnpinTabOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/5386424596292331400/5386424596292331403",
+                    "name": "componentExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.TabbedToolOperation",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/7459370737647652607",
+            "name": "ConceptsBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/7459370737647652609",
+            "name": "CreateBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/7459370737647671570",
+            "name": "ConceptFunctionParameter_SConceptClass",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503601957",
+            "name": "CustomToolShortcut",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503601957/471625927503603128",
+                    "name": "changes",
+                    "type": "jetbrains.mps.lang.plugin.AbstractToolKeystroke",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.AbstractToolShortcut"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503601927",
+            "name": "NumberToolShortcut",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503601927/471625927503601955",
+                    "name": "number"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.AbstractToolShortcut"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503603120",
+            "name": "ToolKeystroke",
+            "properties": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503603120/471625927503603126",
+                    "name": "keymap"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503603120/471625927503601958",
+                    "name": "keystroke",
+                    "type": "jetbrains.mps.lang.plugin.KeyMapKeystroke",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.AbstractToolKeystroke"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/471625927506494666",
+            "name": "AbstractToolKeystroke",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:28f9e497-3b42-4291-aeba-0a1039153ab1/471625927503509889",
+            "name": "AbstractToolShortcut",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.plugin.standalone.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.plugin.standalone.json
@@ -1,0 +1,225 @@
+{
+    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343",
+    "name": "jetbrains.mps.lang.plugin.standalone",
+    "concepts": [
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178819",
+            "name": "ProjectPluginDisposeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178825",
+            "name": "ProjectPluginInitBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178831",
+            "name": "ApplicationPluginType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178831/481983775135178833",
+                    "name": "plugin",
+                    "type": "jetbrains.mps.lang.plugin.standalone.ApplicationPluginDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178834",
+            "name": "ProjectPluginDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178834/481983775135178836",
+                    "name": "initBlock",
+                    "type": "jetbrains.mps.lang.plugin.standalone.ProjectPluginInitBlock"
+                },
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178834/481983775135178837",
+                    "name": "disposeBlock",
+                    "type": "jetbrains.mps.lang.plugin.standalone.ProjectPluginDisposeBlock"
+                },
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178834/481983775135178838",
+                    "name": "fieldDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierFieldDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178840",
+            "name": "ApplicationPluginDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178840/481983775135178842",
+                    "name": "initBlock",
+                    "type": "jetbrains.mps.lang.plugin.standalone.ApplicationPluginInitBlock"
+                },
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178840/481983775135178843",
+                    "name": "disposeBlock",
+                    "type": "jetbrains.mps.lang.plugin.standalone.ApplicationPluginDisposeBlock"
+                },
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178840/481983775135178844",
+                    "name": "fieldDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierFieldDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178846",
+            "name": "ApplicationPluginDisposeBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178851",
+            "name": "ApplicationPluginInitBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178856",
+            "name": "ProjectPluginType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/481983775135178856/481983775135178858",
+                    "name": "plugin",
+                    "type": "jetbrains.mps.lang.plugin.standalone.ProjectPluginDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.classifiers.BaseClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/681855071694758165",
+            "name": "GetToolInProjectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/681855071694758165/681855071694758166",
+                    "name": "tool",
+                    "type": "jetbrains.mps.lang.plugin.BaseToolDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.BaseProjectOperation"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/681855071694758168",
+            "name": "GetPreferencesComponentInProjectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/681855071694758168/681855071694758169",
+                    "name": "componentDeclaration",
+                    "type": "jetbrains.mps.lang.plugin.PreferencesComponentDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.plugin.BaseProjectOperation"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/7520713872864775836",
+            "name": "StandalonePluginDescriptor",
+            "properties": [
+                {
+                    "uid": "ef7bf5ac-d06c-4342-b11d-e42104eb9343/7520713872864775836/6862207549896125199",
+                    "name": "needInitConfig",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:ef7bf5ac-d06c-4342-b11d-e42104eb9343/3418954410726344423",
+            "name": "PlatformAccessExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.project.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.project.json
@@ -1,0 +1,524 @@
+{
+    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9",
+    "name": "jetbrains.mps.lang.project",
+    "concepts": [
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894",
+            "name": "Module",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/6370754048397540898",
+                    "name": "uuid"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/6370754048397540899",
+                    "name": "namespace"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/6370754048397540900",
+                    "name": "compileInMPS",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/6370754048397540907",
+                    "name": "model",
+                    "type": "jetbrains.mps.lang.project.ModelReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/1855399583446017057",
+                    "name": "modelRoots",
+                    "type": "jetbrains.mps.lang.project.ModelRoot",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/6370754048397540908",
+                    "name": "dependencies",
+                    "type": "jetbrains.mps.lang.project.ModuleDependency",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/1855399583446017055",
+                    "name": "usedLanguages",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/1855399583446017056",
+                    "name": "usedDevkits",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/1855399583446017641",
+                    "name": "stubModels",
+                    "type": "jetbrains.mps.lang.project.StubEntry",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540894/269654322145263551",
+                    "name": "sourcePaths",
+                    "type": "jetbrains.mps.lang.project.SourcePath",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895",
+            "name": "Language",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/269654322145296906",
+                    "name": "genPath"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/6835717623312062005",
+                    "name": "languagePath"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/5778538955526664797",
+                    "name": "version",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/6370754048397540919",
+                    "name": "generator",
+                    "type": "jetbrains.mps.lang.project.Generator",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/269654322145263488",
+                    "name": "accessoryModels",
+                    "type": "jetbrains.mps.lang.project.ModelReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/269654322145263489",
+                    "name": "extendedLanguages",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/269654322145263490",
+                    "name": "runtimeModules",
+                    "type": "jetbrains.mps.lang.project.ModuleDependency",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/269654322145263491",
+                    "name": "runtimeStubModels",
+                    "type": "jetbrains.mps.lang.project.StubEntry",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540895/269654322145263515",
+                    "name": "stubSolutions",
+                    "type": "jetbrains.mps.lang.project.StubSolution",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.Module"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540896",
+            "name": "Solution",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540896/269654322145299054",
+                    "name": "outputPath"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540896/269654322145299057",
+                    "name": "dontLoadClasses",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540896/6835717623312030364",
+                    "name": "solutionPath"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.Module"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540897",
+            "name": "Generator",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540897/3240282110432486018",
+                    "name": "generatorAlias"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540897/3000929436959691392",
+                    "name": "generateTemplates",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540897/1855399583446016267",
+                    "name": "priorityRules",
+                    "type": "jetbrains.mps.lang.project.MappingPriorityRule",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540897/1855399583446016271",
+                    "name": "depGenerators",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.Module"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540903",
+            "name": "ModelReference",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540903/6370754048397540909",
+                    "name": "uuid"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540903/6370754048397540910",
+                    "name": "qualifiedName"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540903/6655394244919476145",
+                    "name": "stereotype"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540903/3021261446821270705",
+                    "name": "module",
+                    "type": "jetbrains.mps.lang.project.ModuleReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540904",
+            "name": "ModuleDependency",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540904/6370754048397540905",
+                    "name": "reexport",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540904/1855399583446017054",
+                    "name": "moduleRef",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540911",
+            "name": "DevKit",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540911/6966544519551784804",
+                    "name": "plugin"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540911/6966544519551784808",
+                    "name": "devkitPath"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540911/6966544519551784805",
+                    "name": "exportedLanguages",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540911/6966544519551784806",
+                    "name": "exportedSolutions",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540911/6966544519551784807",
+                    "name": "extendedDevkits",
+                    "type": "jetbrains.mps.lang.project.ModuleReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.Module"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540920",
+            "name": "MappingPriorityRule",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540920/6370754048397540925",
+                    "name": "type"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540920/2721285250110391021",
+                    "name": "left",
+                    "type": "jetbrains.mps.lang.project.MappingConfigRefBase",
+                    "optional": false
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/6370754048397540920/2721285250110391022",
+                    "name": "right",
+                    "type": "jetbrains.mps.lang.project.MappingConfigRefBase",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446016268",
+            "name": "ModuleReference",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446016268/1855399583446016269",
+                    "name": "uuid"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446016268/1855399583446016270",
+                    "name": "qualifiedName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446017058",
+            "name": "StubEntry",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446017058/1855399583446017059",
+                    "name": "path"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446017062",
+            "name": "ModelRoot",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446017062/1666927970458410904",
+                    "name": "type"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/1855399583446017062/1855399583446017567",
+                    "name": "path"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110256909",
+            "name": "MappingConfigRefBase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110256911",
+            "name": "MappingConfigRefAllGlobal",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.MappingConfigRefBase"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110390996",
+            "name": "MappingConfigRefAllLocal",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.MappingConfigRefBase"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110391051",
+            "name": "MappingConfigRefSet",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110391051/2721285250110391052",
+                    "name": "refs",
+                    "type": "jetbrains.mps.lang.project.MappingConfigRefBase",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.MappingConfigRefBase"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400375",
+            "name": "MappingConfigNormalRef",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400375/2721285250110400376",
+                    "name": "modelUID"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400375/2721285250110400377",
+                    "name": "nodeID"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400375/6921375397022353881",
+                    "name": "mcName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.MappingConfigRefBase"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400481",
+            "name": "MappingConfigExternalRef",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400481/2721285250110400483",
+                    "name": "generator",
+                    "type": "jetbrains.mps.lang.project.ModuleReference"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/2721285250110400481/2721285250110400482",
+                    "name": "innerRef",
+                    "type": "jetbrains.mps.lang.project.MappingConfigRefBase"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.project.MappingConfigRefBase"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/269654322145263495",
+            "name": "StubSolution",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/269654322145263495/269654322145263496",
+                    "name": "uuid"
+                },
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/269654322145263495/269654322145263497",
+                    "name": "name"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:86ef8290-12bb-4ca7-947f-093788f263a9/269654322145263543",
+            "name": "SourcePath",
+            "properties": [
+                {
+                    "uid": "86ef8290-12bb-4ca7-947f-093788f263a9/269654322145263543/269654322145263544",
+                    "name": "value"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.quotation.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.quotation.json
@@ -1,0 +1,508 @@
+{
+    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555",
+    "name": "jetbrains.mps.lang.quotation",
+    "concepts": [
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785110",
+            "name": "AbstractAntiquotation",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785110/6489343236075007666",
+                    "name": "label"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785110/1196350785111",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.IMetaLevelChanger",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785112",
+            "name": "Antiquotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.quotation.AbstractAntiquotation"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785113",
+            "name": "Quotation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785113/1196350785114",
+                    "name": "quotedNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785113/3316618969910744744",
+                    "name": "modelToCreate",
+                    "type": "jetbrains.mps.lang.quotation.ModelNodeInitializer"
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785113/1196350785115",
+                    "name": "modelToCreate_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785113/3180306201267182597",
+                    "name": "nodeId_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.IMetaLevelChanger",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785117",
+            "name": "ReferenceAntiquotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.LinkAttribute",
+                "jetbrains.mps.lang.quotation.AbstractAntiquotation"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1196350785118",
+            "name": "ListAntiquotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.quotation.AbstractAntiquotation"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1196866233735",
+            "name": "PropertyAntiquotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.PropertyAttribute",
+                "jetbrains.mps.lang.quotation.AbstractAntiquotation",
+                "jetbrains.mps.lang.quotation.StringToTypedValueMigrationInfo"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993911077",
+            "name": "NodeBuilderInitProperty",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993911077/1595412875168045201",
+                    "name": "initValue",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993911077/5455284157993911078",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitPart"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/8182547171709738802",
+            "name": "NodeBuilderList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/8182547171709738802/8182547171709738803",
+                    "name": "nodes",
+                    "type": "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863837",
+            "name": "NodeBuilder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863837/5455284157993863838",
+                    "name": "quotedNode",
+                    "type": "jetbrains.mps.lang.quotation.NodeBuilderNode",
+                    "optional": false
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863837/5455284157993863839",
+                    "name": "modelToCreate_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863837/3316618969911717433",
+                    "name": "modelToCreate",
+                    "type": "jetbrains.mps.lang.quotation.ModelNodeInitializer"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ScopeProvider",
+                "jetbrains.mps.lang.quotation.INodeBuilderContainer"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157994012186",
+            "name": "NodeBuilderInitLink",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157994012186/1595412875168045827",
+                    "name": "initValue",
+                    "type": "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157994012186/5455284157994012188",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitPart",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/8182547171709614739",
+            "name": "NodeBuilderRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/8182547171709614739/8182547171709614741",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/8182547171709752110",
+            "name": "NodeBuilderExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/8182547171709752110/8182547171709752112",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue",
+                "jetbrains.mps.lang.quotation.NodeBuilderInitValueChild"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863840",
+            "name": "NodeBuilderNode",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863840/5455284157993911099",
+                    "name": "values",
+                    "type": "jetbrains.mps.lang.quotation.NodeBuilderInitPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993863840/5455284157993910961",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitLinkValue",
+                "jetbrains.mps.lang.quotation.NodeBuilderInitValueChild",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993911097",
+            "name": "NodeBuilderInitPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/5455284157993911097/5455284157993911094",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/8389748773577451463",
+            "name": "GeneratorInternal_PropertyDescriptor",
+            "properties": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/8389748773577451463/8389748773577451513",
+                    "name": "propertyValue"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/8389748773577451463/1615573325506896698",
+                    "name": "propertyIdentity",
+                    "type": "jetbrains.mps.lang.smodel.PropertyId",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/2652588855789590333",
+            "name": "GeneratorInternal_ReferenceDescriptor",
+            "properties": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/2652588855789590333/2652588855789590335",
+                    "name": "targetNodeId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/2652588855789590333/7936339385822777656",
+                    "name": "linkId",
+                    "type": "jetbrains.mps.lang.smodel.ReferenceLinkId",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/2038730470042956328",
+            "name": "GeneratorInternal_InternalReferenceHolder",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/2038730470042956328/7936339385822777651",
+                    "name": "linkId",
+                    "type": "jetbrains.mps.lang.smodel.ReferenceLinkId",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/2038730470042956328/2038730470042956329",
+                    "name": "role",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration"
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/2038730470042956328/2038730470042970053",
+                    "name": "sourceNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/2038730470042956328/2038730470042970044",
+                    "name": "targetNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/4056363777117001481",
+            "name": "StringToTypedValueMigrationInfo",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/4056363777117001481/2173356959483005420",
+                    "name": "stringValueMigrated",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1595412875168045824",
+            "name": "NodeBuilderInitLinkValue",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/3316618969910743150",
+            "name": "ModelNodeInitializer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/3316618969910743150/3316618969910743151",
+                    "name": "modelToCreate",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/3316618969910743150/3316618969910743152",
+                    "name": "nodeId",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/8642609567145363710",
+            "name": "NodeBuilderInitValueChild",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/6985522012210239874",
+            "name": "NodeBuilderInitPropertyValue",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/6985522012210254362",
+            "name": "NodeBuilderPropertyExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3a13115c-633c-4c5c-bbcc-75c4219e9555/6985522012210254362/6985522012210254363",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.quotation.NodeBuilderInitPropertyValue",
+                "jetbrains.mps.lang.core.IWrapper"
+            ]
+        },
+        {
+            "uid": "mps:3a13115c-633c-4c5c-bbcc-75c4219e9555/1010197743173864766",
+            "name": "INodeBuilderContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.refactoring.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.refactoring.json
@@ -1,0 +1,813 @@
+{
+    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742",
+    "name": "jetbrains.mps.lang.refactoring",
+    "concepts": [
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1189694053795",
+            "name": "DoRefactorClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1189694741717",
+            "name": "ConceptFunctionParameter_SModel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1198577376375",
+            "name": "UpdateModelProcedure",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/1198577376375/1198577431631",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199619425400",
+            "name": "AbstractMoveExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/1199619425400/1199619459778",
+                    "name": "whatToMove",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/1199619425400/1199619459779",
+                    "name": "destination",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.refactoring.RefactoringAction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199620122561",
+            "name": "AbstractMoveNodeExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.AbstractMoveExpression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199620153270",
+            "name": "AbstractMoveNodesExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.AbstractMoveExpression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199620319099",
+            "name": "MoveNodeToModelExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.AbstractMoveNodeExpression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199620589385",
+            "name": "MoveNodeToNodeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/1199620589385/1199620651934",
+                    "name": "roleInTarget",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.AbstractMoveNodeExpression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199620728600",
+            "name": "MoveNodesToModelExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.AbstractMoveNodesExpression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1199620920737",
+            "name": "MoveNodesToNodeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/1199620920737/1199620959025",
+                    "name": "roleInTarget",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.AbstractMoveNodesExpression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1200932465350",
+            "name": "AffectedNodesClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1209559069560",
+            "name": "IsApplicableToModelClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1209559114970",
+            "name": "ConceptFunctionParameter_Model",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1210941725884",
+            "name": "GetModelsToUpdateClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/3242588059496701743",
+            "name": "RefactoringAction",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310761",
+            "name": "RefactoringTarget",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310761/6895093993902310999",
+                    "name": "allowMultiple",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310761/5497648299878742039",
+                    "name": "isApplicableBlock",
+                    "type": "jetbrains.mps.baseLanguage.ConceptFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310762",
+            "name": "ModelTarget",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.RefactoringTarget"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310763",
+            "name": "ModuleTarget",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310763/6895093993902310767",
+                    "name": "moduleType",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.RefactoringTarget"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310764",
+            "name": "NodeTarget",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310764/6895093993902310806",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.RefactoringTarget"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310769",
+            "name": "IsApplicableToModuleClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310775",
+            "name": "ConceptFunctionParameter_Module",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310808",
+            "name": "IsApplicableToNodeClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902310814",
+            "name": "ConceptFunctionParameter_SNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902311010",
+            "name": "RefactoringField",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableDeclaration",
+                "jetbrains.mps.lang.refactoring.RefactoringArgument"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902311012",
+            "name": "RefactoringParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableDeclaration",
+                "jetbrains.mps.lang.refactoring.RefactoringArgument"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902496262",
+            "name": "RefactoringParameterReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902496262/6895093993902496263",
+                    "name": "refactoringParameter",
+                    "type": "jetbrains.mps.lang.refactoring.RefactoringParameter",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.refactoring.RefactoringArgumentReference"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/5497648299878398634",
+            "name": "RefactoringFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableReference",
+                "jetbrains.mps.lang.refactoring.RefactoringArgumentReference"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/5497648299878741970",
+            "name": "InitClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229",
+            "name": "Refactoring",
+            "properties": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/6895093993902236371",
+                    "name": "userFriendlyName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/6895093993902310998",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.refactoring.RefactoringTarget",
+                    "optional": false
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/6895093993902236376",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.refactoring.RefactoringParameter",
+                    "multiple": true
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/6895093993902236377",
+                    "name": "field",
+                    "type": "jetbrains.mps.lang.refactoring.RefactoringField",
+                    "multiple": true
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/5497648299878741976",
+                    "name": "initBlock",
+                    "type": "jetbrains.mps.lang.refactoring.InitClause"
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/6895093993902236381",
+                    "name": "doRefactorBlock",
+                    "type": "jetbrains.mps.lang.refactoring.DoRefactorClause",
+                    "optional": false
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/616550569928923871",
+                    "name": "modelsToGenerateBlock",
+                    "type": "jetbrains.mps.lang.refactoring.ModelsToGenerateClause"
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/2058726427123891193",
+                    "name": "doWhenDoneBlock",
+                    "type": "jetbrains.mps.lang.refactoring.DoWhenDoneClause"
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/1347577327951503399",
+                    "name": "affectedNodesBlock",
+                    "type": "jetbrains.mps.lang.refactoring.AffectedNodesClause"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6895093993902236229/6895093993902236387",
+                    "name": "overrides",
+                    "type": "jetbrains.mps.lang.refactoring.Refactoring"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.structure.IConceptAspect",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/2058726427123891188",
+            "name": "DoWhenDoneClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/478744034994715997",
+            "name": "RefactoringArgument",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/478744034994716100",
+            "name": "RefactoringArgumentReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252909",
+            "name": "ContextMemberOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252911",
+            "name": "ModelDescriptorOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252913",
+            "name": "ModuleOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252915",
+            "name": "NodeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252917",
+            "name": "NodesOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252921",
+            "name": "ProjectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066252923",
+            "name": "ScopeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066256458",
+            "name": "RefactoringContext_ConceptFunctionParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/7953996722066536522",
+            "name": "ContextType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/1682834381185132063",
+            "name": "ModelsToGenerateClause",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/8113680833395644310",
+            "name": "MainProjectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/4347648036456711197",
+            "name": "ModelsToGenerateByDefault",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/3700868637771181541",
+            "name": "CreateRefactoringContext",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/3700868637771181541/3700868637771294533",
+                    "name": "target",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/3700868637771181541/3700868637771354794",
+                    "name": "parameters",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/3700868637771181541/7340098493333217414",
+                    "name": "project",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/3700868637771181541/3700868637771248810",
+                    "name": "refactoring",
+                    "type": "jetbrains.mps.lang.refactoring.Refactoring",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/6598645150040035709",
+            "name": "IsRefactoringApplicable",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6598645150040035709/6598645150040036518",
+                    "name": "target",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/6598645150040035709/6598645150040035710",
+                    "name": "refactoring",
+                    "type": "jetbrains.mps.lang.refactoring.Refactoring",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/2298239814950983788",
+            "name": "ExecuteRefactoringStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/2298239814950983788/2298239814950983792",
+                    "name": "target",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/2298239814950983788/2298239814950983793",
+                    "name": "parameters",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/2298239814950983788/2298239814950983794",
+                    "name": "project",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "3ecd7c84-cde3-45de-886c-135ecc69b742/2298239814950983788/2298239814950983795",
+                    "name": "refactoring",
+                    "type": "jetbrains.mps.lang.refactoring.Refactoring",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:3ecd7c84-cde3-45de-886c-135ecc69b742/5938312768538179915",
+            "name": "RepositoryOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.refactoring.ContextMemberOperation"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.resources.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.resources.json
@@ -1,0 +1,438 @@
+{
+    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5",
+    "name": "jetbrains.mps.lang.resources",
+    "concepts": [
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029883",
+            "name": "FileIcon",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029883/2756621024541341363",
+                    "name": "file"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029883/6976585500156684809",
+                    "name": "iconExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.resources.Icon"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029885",
+            "name": "OldIconBundle",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029885/8974276187400029886",
+                    "name": "icons",
+                    "type": "jetbrains.mps.lang.resources.OldIconDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029888",
+            "name": "OldIconDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029888/8974276187400029889",
+                    "name": "iconExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029891",
+            "name": "IconExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029891/8974276187400029893",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029895",
+            "name": "OldIconReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029895/8974276187400029896",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.resources.OldIconDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/8974276187400029898",
+            "name": "Resource",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/5979521222239143262",
+            "name": "IconResourceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/5979521222239143262/5979521222239172928",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541318894",
+            "name": "Icon",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.resources.Resource"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541674821",
+            "name": "TextIcon",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541674821/1358878980655415353",
+                    "name": "iconId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541674821/2756621024541675110",
+                    "name": "layers",
+                    "type": "jetbrains.mps.lang.resources.IconLayerDescription",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.resources.Icon"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541675104",
+            "name": "Circle",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541675104/2756621024541681857",
+                    "name": "r"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.resources.Primitive"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541675105",
+            "name": "Rect",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541675105/2756621024541675106",
+                    "name": "r"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.resources.Primitive"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541675109",
+            "name": "IconLayerDescription",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541681841",
+            "name": "Primitive",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541681841/1860120738943552529",
+                    "name": "fillColor",
+                    "type": "jetbrains.mps.lang.resources.Color",
+                    "optional": false
+                },
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541681841/1860120738943552531",
+                    "name": "borderColor",
+                    "type": "jetbrains.mps.lang.resources.Color"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.resources.IconLayerDescription"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541681849",
+            "name": "Text",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541681849/2756621024541681854",
+                    "name": "text"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/2756621024541681849/1860120738943552534",
+                    "name": "color",
+                    "type": "jetbrains.mps.lang.resources.Color",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.resources.IconLayerDescription"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/831924260440060775",
+            "name": "Image",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/831924260440060775/831924260440060859",
+                    "name": "file"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.resources.IconLayerDescription"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/1860120738943552477",
+            "name": "ColorLiteral",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/1860120738943552477/1860120738943552481",
+                    "name": "val"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.resources.Color"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/1860120738943552478",
+            "name": "Color",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/562388756444790046",
+            "name": "ConceptIconResourceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/562388756444790046/4786190798786350692",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/562388756444790046/562388756444790088",
+                    "name": "concept_old",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/562388756444896282",
+            "name": "NodeIconResourceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/562388756444896282/562388756444896284",
+                    "name": "node",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/5177162104569058199",
+            "name": "HelpURL",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/5177162104569058199/5177162104569058200",
+                    "name": "url"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/5177162104569058199/4726480899534317252",
+                    "name": "baseURL",
+                    "type": "jetbrains.mps.lang.resources.BaseURL"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/4726480899534317142",
+            "name": "BaseURLFunction",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/4726480899534317142/4726480899534317143",
+                    "name": "calculator",
+                    "type": "jetbrains.mps.baseLanguage.closures.ClosureLiteral",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.resources.BaseURL"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/4726480899534370999",
+            "name": "BaseURL",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect"
+            ]
+        },
+        {
+            "uid": "mps:982eb8df-2c96-4bd7-9963-11712ea622e5/4726480899534371000",
+            "name": "BaseURLLiteral",
+            "properties": [
+                {
+                    "uid": "982eb8df-2c96-4bd7-9963-11712ea622e5/4726480899534371000/4726480899534371059",
+                    "name": "url"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.resources.BaseURL"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.rulesAndMessages.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.rulesAndMessages.json
@@ -1,0 +1,51 @@
+{
+    "uid": "b3551702-269c-4f05-ba61-58060cef4292",
+    "name": "jetbrains.mps.lang.rulesAndMessages",
+    "concepts": [
+        {
+            "uid": "mps:b3551702-269c-4f05-ba61-58060cef4292/315923949160549991",
+            "name": "RuleWithMessage",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b3551702-269c-4f05-ba61-58060cef4292/315923949160549991/1400749580825440508",
+                    "name": "rule",
+                    "type": "jetbrains.mps.lang.constraints.rules.Rule",
+                    "optional": false
+                },
+                {
+                    "uid": "b3551702-269c-4f05-ba61-58060cef4292/315923949160549991/315923949160550022",
+                    "name": "messageProvider",
+                    "type": "jetbrains.mps.lang.rulesAndMessages.InlineMessageProvider",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.constraints.rules.skeleton.RuleBlockMember"
+            ]
+        },
+        {
+            "uid": "mps:b3551702-269c-4f05-ba61-58060cef4292/315923949160550017",
+            "name": "InlineMessageProvider",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b3551702-269c-4f05-ba61-58060cef4292/315923949160550017/5258059200641510856",
+                    "name": "messagesExpr",
+                    "type": "jetbrains.mps.lang.messages.CombinedMessageExpression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.scopes.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.scopes.json
@@ -1,0 +1,71 @@
+{
+    "uid": "d8f591ec-4d86-4af2-9f92-a9e93c803ffa",
+    "name": "jetbrains.mps.lang.scopes",
+    "concepts": [
+        {
+            "uid": "mps:d8f591ec-4d86-4af2-9f92-a9e93c803ffa/8077936094962850237",
+            "name": "CompositeWithParentScopeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "d8f591ec-4d86-4af2-9f92-a9e93c803ffa/8077936094962850237/8077936094962969171",
+                    "name": "expr",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:d8f591ec-4d86-4af2-9f92-a9e93c803ffa/8077936094962911282",
+            "name": "ParentScope",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:d8f591ec-4d86-4af2-9f92-a9e93c803ffa/8077936094962944991",
+            "name": "ComeFromExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "d8f591ec-4d86-4af2-9f92-a9e93c803ffa/8077936094962944991/8077936094962945822",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:d8f591ec-4d86-4af2-9f92-a9e93c803ffa/2995585510566823808",
+            "name": "UniformScopeProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.script.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.script.json
@@ -1,0 +1,356 @@
+{
+    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470",
+    "name": "jetbrains.mps.lang.script",
+    "concepts": [
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821",
+            "name": "MigrationScript",
+            "properties": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821/1177457669450",
+                    "name": "title"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821/1206123256132",
+                    "name": "migrationFromBuild"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821/1206123296179",
+                    "name": "category"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821/5299416737274925395",
+                    "name": "type"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821/5299416737274925397",
+                    "name": "toBuild"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457067821/1177458178889",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.script.MigrationScriptPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457850499",
+            "name": "MigrationScriptPart_Instance",
+            "properties": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457850499/1177457972041",
+                    "name": "description"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457850499/1225457189692",
+                    "name": "showAsIntention",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457850499/1177457957478",
+                    "name": "affectedInstancePredicate",
+                    "type": "jetbrains.mps.lang.script.MigrationScriptPart_Instance_Predicate"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457850499/1177458005323",
+                    "name": "affectedInstanceUpdater",
+                    "type": "jetbrains.mps.lang.script.MigrationScriptPart_Instance_Updater",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177457850499/1177457957477",
+                    "name": "affectedInstanceConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.MigrationScriptPart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177458061340",
+            "name": "MigrationScriptPart_Instance_Predicate",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177458237937",
+            "name": "MigrationScriptPart_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/1177458491964",
+            "name": "MigrationScriptPart_Instance_Updater",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/2598676492883164205",
+            "name": "FactoryMigrationScriptPart",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/2598676492883164205/2598676492883164207",
+                    "name": "factoryMethod",
+                    "type": "jetbrains.mps.baseLanguage.StaticMethodCall",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.MigrationScriptPart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/2598676492883244606",
+            "name": "WhitespaceMigrationScriptPart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.MigrationScriptPart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6970965131508596229",
+            "name": "MigrationScriptPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912204546",
+            "name": "CommentMigrationScriptPart",
+            "properties": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912204546/6655357163912204547",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.MigrationScriptPart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912246425",
+            "name": "ExtractInterfaceMigration",
+            "properties": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912246425/7867202088808133349",
+                    "name": "updateClassifierTypes",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912246425/5434557751112108415",
+                    "name": "oldClassifier",
+                    "type": "jetbrains.mps.lang.script.AbstractClassifierSpecification",
+                    "optional": false
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912246425/849077997121893197",
+                    "name": "pullUpMethods",
+                    "type": "jetbrains.mps.lang.script.PullUpMethod",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/6655357163912246425/6655357163912246427",
+                    "name": "newClassifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.MigrationScriptPart"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/849077997121870276",
+            "name": "PullUpMethod",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/849077997121870276/4774682482449846913",
+                    "name": "oldMethodSpecification",
+                    "type": "jetbrains.mps.lang.script.AbstractMethodSpecification"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/849077997121870276/4242940223545038298",
+                    "name": "newMethodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.BaseMethodDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112081978",
+            "name": "AbstractClassifierSpecification",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112207651",
+            "name": "DirectClassifierSpecification",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112207651/5434557751112207965",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.Classifier",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.AbstractClassifierSpecification"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112207835",
+            "name": "FQNameClassifierSpecification",
+            "properties": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112207835/5434557751112752962",
+                    "name": "classifierFQName"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112207835/5434557751113468451",
+                    "name": "smodelReference"
+                },
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/5434557751112207835/8915466921781754528",
+                    "name": "snodeId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.AbstractClassifierSpecification"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/4774682482449847011",
+            "name": "FQNameMethodSpecification",
+            "properties": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/4774682482449847011/2291767839160466985",
+                    "name": "snodeId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.AbstractMethodSpecification"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/4774682482449869981",
+            "name": "AbstractMethodSpecification",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:0eddeefa-c2d6-4437-bc2c-de50fd4ce470/2291767839159498115",
+            "name": "DirectMethodSpecification",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "0eddeefa-c2d6-4437-bc2c-de50fd4ce470/2291767839159498115/2291767839159499865",
+                    "name": "methodDeclaration",
+                    "type": "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.script.AbstractMethodSpecification"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.sharedConcepts.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.sharedConcepts.json
@@ -1,0 +1,84 @@
+{
+    "uid": "13744753-c81f-424a-9c1b-cf8943bf4e86",
+    "name": "jetbrains.mps.lang.sharedConcepts",
+    "concepts": [
+        {
+            "uid": "mps:13744753-c81f-424a-9c1b-cf8943bf4e86/1161622665029",
+            "name": "ConceptFunctionParameter_model",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:13744753-c81f-424a-9c1b-cf8943bf4e86/1161622753914",
+            "name": "ConceptFunctionParameter_operationContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:13744753-c81f-424a-9c1b-cf8943bf4e86/1161622878565",
+            "name": "ConceptFunctionParameter_scope",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:13744753-c81f-424a-9c1b-cf8943bf4e86/1194033889146",
+            "name": "ConceptFunctionParameter_editorContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:13744753-c81f-424a-9c1b-cf8943bf4e86/1206467714548",
+            "name": "ConceptFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:13744753-c81f-424a-9c1b-cf8943bf4e86/558005353046640020",
+            "name": "ConceptFunctionParameter_progressMonitor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.slanguage.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.slanguage.json
@@ -1,0 +1,70 @@
+{
+    "uid": "69b8a993-9b87-4d96-bf0c-3559f4bb0c63",
+    "name": "jetbrains.mps.lang.slanguage",
+    "concepts": [
+        {
+            "uid": "mps:69b8a993-9b87-4d96-bf0c-3559f4bb0c63/6171083915388330090",
+            "name": "AspectModelRefExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "69b8a993-9b87-4d96-bf0c-3559f4bb0c63/6171083915388330090/6171083915388330091",
+                    "name": "lang",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "69b8a993-9b87-4d96-bf0c-3559f4bb0c63/6171083915388330090/6171083915388597767",
+                    "name": "aspect",
+                    "type": "jetbrains.mps.lang.aspect.SimpleLanguageAspectDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:69b8a993-9b87-4d96-bf0c-3559f4bb0c63/2030416617761226491",
+            "name": "Model_IsAspectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "69b8a993-9b87-4d96-bf0c-3559f4bb0c63/2030416617761226491/2030416617761226680",
+                    "name": "aspect",
+                    "type": "jetbrains.mps.lang.aspect.SimpleLanguageAspectDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:69b8a993-9b87-4d96-bf0c-3559f4bb0c63/5932042262275638696",
+            "name": "OfAspectOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "69b8a993-9b87-4d96-bf0c-3559f4bb0c63/5932042262275638696/8994852683961272056",
+                    "name": "requestedAspect",
+                    "type": "jetbrains.mps.lang.aspect.SimpleLanguageAspectDescriptor",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation",
+                "jetbrains.mps.lang.smodel.query.OperationHelpProvider"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.smodel.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.smodel.json
@@ -1,0 +1,3630 @@
+{
+    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1",
+    "name": "jetbrains.mps.lang.smodel",
+    "concepts": [
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698",
+            "name": "SNodeType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138055754698/1138405853777",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056022639",
+            "name": "SPropertyAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056022639/1138056395725",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562",
+            "name": "SLinkAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056143562/1138056516764",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation",
+                "jetbrains.mps.lang.smodel.ILinkAccess"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393",
+            "name": "SLinkListAccess",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138056282393/1138056546658",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation",
+                "jetbrains.mps.lang.smodel.ILinkAccess"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138411891628",
+            "name": "SNodeOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138411891628/1144104376918",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.smodel.AbstractOperationParameter",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138661924179",
+            "name": "Property_SetOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138661924179/1138662048170",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138676077309",
+            "name": "EnumMemberReference_Old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138676077309/1138676095763",
+                    "name": "enumMember",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration_Old",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138757581985",
+            "name": "Link_SetNewChildOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1138757581985/1139880128956",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139184414036",
+            "name": "LinkList_AddNewChildOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139184414036/1139877738879",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139613262185",
+            "name": "Node_GetParentOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139621453865",
+            "name": "Node_IsInstanceOfOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139621453865/1177027386292",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139858892567",
+            "name": "Node_InsertNewNextSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139858892567/1139858951584",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139867745658",
+            "name": "Node_ReplaceWithNewOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1139867745658/1139867957129",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140131837776",
+            "name": "Node_ReplaceWithAnotherOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140131837776/1140131861877",
+                    "name": "replacementNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140133623887",
+            "name": "Node_DeleteOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140137987495",
+            "name": "SNodeTypeCastExpression",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140137987495/1238684351431",
+                    "name": "asCast",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractTypeCastExpression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140725362528",
+            "name": "Link_SetTargetOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1140725362528/1140725362529",
+                    "name": "linkTarget",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143221076066",
+            "name": "Node_InsertNewPrevSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143221076066/1143221076069",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143224066846",
+            "name": "Node_InsertNextSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143224066846/1143224066849",
+                    "name": "insertedNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143224127713",
+            "name": "Node_InsertPrevSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143224127713/1143224127716",
+                    "name": "insertedNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143226024141",
+            "name": "SModelType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143234257716",
+            "name": "Node_GetModelOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143235216708",
+            "name": "Model_CreateNewNodeOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143235216708/161004399424315235",
+                    "name": "nodeId",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143235216708/1177700677986",
+                    "name": "prototypeNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143235216708/1143235391024",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143511969223",
+            "name": "Node_GetPrevSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1143512015885",
+            "name": "Node_GetNextSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144100743722",
+            "name": "AbstractOperationParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144100932627",
+            "name": "OperationParm_Inclusion",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144101597970",
+            "name": "OperationParm_Root",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144101972840",
+            "name": "OperationParm_Concept",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144101972840/1207343664468",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144146199828",
+            "name": "Node_CopyOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144195091934",
+            "name": "Node_IsRoleOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144195091934/1144195362400",
+                    "name": "conceptOfParent",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1144195091934/1144195396777",
+                    "name": "linkInParent",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145383075378",
+            "name": "SNodeListType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145383075378/1145383142433",
+                    "name": "elementConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145404486709",
+            "name": "SemanticDowncastExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145404486709/1145404616321",
+                    "name": "leftExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145567426890",
+            "name": "SNodeListCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145567426890/1145567471833",
+                    "name": "createdType",
+                    "type": "jetbrains.mps.lang.smodel.SNodeListType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145570846907",
+            "name": "Node_GetNextSiblingsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145572800087",
+            "name": "Node_GetPrevSiblingsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1145573345940",
+            "name": "Node_GetAllSiblingsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1146171026731",
+            "name": "Property_HasValue_Enum",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1146171026731/1146171026732",
+                    "name": "value",
+                    "type": "jetbrains.mps.lang.smodel.EnumMemberReference_Old",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1146253292180",
+            "name": "Property_HasValue_Simple",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1146253292180/1146253292181",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1154546920561",
+            "name": "OperationParm_ConceptList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1154546920561/1154546920563",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.smodel.ConceptReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1154546950173",
+            "name": "ConceptReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1154546950173/1154546997487",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1166648550386",
+            "name": "Model_CreateNewRootNodeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Model_CreateNewNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171305280644",
+            "name": "Node_GetDescendantsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171310072040",
+            "name": "Node_GetContainingRootOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171315804604",
+            "name": "Model_RootsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171315804604/6750920497477046361",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171315804604/1171315804605",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171323947159",
+            "name": "Model_NodesOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171323947159/1758937410080001570",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171407110247",
+            "name": "Node_GetAncestorOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171500988903",
+            "name": "Node_GetChildrenOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1171999116870",
+            "name": "Node_IsNullOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172008320231",
+            "name": "Node_IsNotNullOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172323065820",
+            "name": "Node_GetConceptOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172326502327",
+            "name": "Concept_IsExactlyOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172326502327/1206733650006",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172420572800",
+            "name": "ConceptNodeType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172420572800/1180481110358",
+                    "name": "conceptDeclaraton",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172424058054",
+            "name": "ConceptRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1172424058054/1172424100906",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1173122760281",
+            "name": "Node_GetAncestorsOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1176109685393",
+            "name": "Model_RootsIncludingImportedOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1176109685393/6750920497477143611",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1176109685393/1176109685394",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588",
+            "name": "RefConcept_Reference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1177026924588/1177026940964",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IRefConceptArg"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1179168000618",
+            "name": "Node_GetIndexInParentOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1179350041460",
+            "name": "Concept_GetDirectSuperConcepts",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1179409122411",
+            "name": "Node_ConceptMethodCall",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1179409122411/2853323645193760541",
+                    "name": "directCall",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation",
+                "jetbrains.mps.baseLanguage.IMethodCall"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180028149140",
+            "name": "Concept_IsSuperConceptOfOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180028149140/1180028346304",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180031783296",
+            "name": "Concept_IsSubConceptOfOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180031783296/1180031783297",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180457458947",
+            "name": "Concept_GetAllSuperConcepts",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180636770613",
+            "name": "SNodeCreator",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180636770613/1180636770616",
+                    "name": "createdType",
+                    "type": "jetbrains.mps.lang.smodel.SNodeType",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1180636770613/1181937442359",
+                    "name": "prototypeNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.AbstractCreator"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1181949435690",
+            "name": "Concept_NewInstance",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1181949435690/1181949561194",
+                    "name": "prototypeNode",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1181952871644",
+            "name": "Concept_GetAllSubConcepts",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1181952871644/1182506816063",
+                    "name": "smodel",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1182511038748",
+            "name": "Model_NodesIncludingImportedOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1182511038748/6750920497477143623",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1182511038748/1182511038750",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1204834851141",
+            "name": "PoundExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1204834851141/1204834868751",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IPropertyQualifier",
+                "jetbrains.mps.lang.smodel.ILinkAccessQualifier",
+                "jetbrains.mps.lang.smodel.ILinkQualifier",
+                "jetbrains.mps.lang.smodel.IRefConceptArg",
+                "jetbrains.mps.lang.smodel.INodePointerArg"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1204848879094",
+            "name": "ILinkAccessQualifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1204851882688",
+            "name": "LinkRefQualifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1204851882688/1204851882689",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.ILinkAccessQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1205861725686",
+            "name": "Node_IsAttributeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1206482823744",
+            "name": "Model_AddRootOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1206482823744/1206482823746",
+                    "name": "nodeArgument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1206659704055",
+            "name": "IRefConceptArg",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1212008292747",
+            "name": "Model_GetLongNameOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1215467301810",
+            "name": "Property_RemoveOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1219352745532",
+            "name": "NodeRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1219352745532/1219352800908",
+                    "name": "referentNode",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractNodeRefExpression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1221161909218",
+            "name": "SearchScopeType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1221170373891",
+            "name": "SearchScope_ContainsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1221170373891/1221170724607",
+                    "name": "nodeToCheck",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1226359078165",
+            "name": "LinkRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1226359078165/1226359078166",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1226359078165/1226359192215",
+                    "name": "linkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1227264722563",
+            "name": "EqualsStructurallyExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BinaryOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1228341669568",
+            "name": "Node_DetachOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240170042401",
+            "name": "SEnumerationMemberType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240170042401/1240170836027",
+                    "name": "enum",
+                    "type": "jetbrains.mps.lang.structure.IEnumeration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240171359678",
+            "name": "EnumMember_ValueOperation_Old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240173327827",
+            "name": "EnumMember_NameOperation_Old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930118027",
+            "name": "SEnumOperationInvocation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930118027/1240930317927",
+                    "name": "operation",
+                    "type": "jetbrains.mps.lang.smodel.SEnumOperation_Old",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930118027/1240930118028",
+                    "name": "enumDeclaration",
+                    "type": "jetbrains.mps.lang.structure.EnumerationDataTypeDeclaration_Old",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930395965",
+            "name": "SEnumOperation_Old",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444812",
+            "name": "SEnum_MemberForNameOperation_Old",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444812/1240930444813",
+                    "name": "nameExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.SEnumOperation_Old"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444878",
+            "name": "SEnum_MemberForValueOperation_Old",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444878/1240930444879",
+                    "name": "valueExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.SEnumOperation_Old"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444945",
+            "name": "SEnum_MemberOperation_Old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444945/1240930444946",
+                    "name": "member",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration_Old",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.SEnumOperation_Old"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1240930444980",
+            "name": "SEnum_MembersOperation_Old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.SEnumOperation_Old"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1241015185235",
+            "name": "EnumMemberOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1803469493727536395",
+            "name": "OperationParm_StopConceptList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1803469493727536395/1803469493727536396",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.smodel.ConceptReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4024382256428848843",
+            "name": "ILinkAccess",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3562215692195599741",
+            "name": "SLinkImplicitSelect",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3562215692195599741/3562215692195600259",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8758390115028452779",
+            "name": "Node_GetReferencesOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8758390115029295477",
+            "name": "SReferenceType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4124388153790980106",
+            "name": "Reference_GetTargetOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IReferenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1547759872598425067",
+            "name": "Reference_GetLinkDeclarationOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IReferenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1547759872598425074",
+            "name": "IReferenceOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5692182839349412519",
+            "name": "Reference_GetRoleOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IReferenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1960721196051541146",
+            "name": "Node_GetContainingRoleOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3609773094169249792",
+            "name": "Node_GetReferenceOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3609773094169249792/3609773094169252180",
+                    "name": "linkQualifier",
+                    "type": "jetbrains.mps.lang.smodel.OperationParm_LinkQualifier",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3542758363529077353",
+            "name": "ILinkAccessQualifierContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5168775467716640652",
+            "name": "OperationParm_LinkQualifier",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5168775467716640652/5168775467716640653",
+                    "name": "linkQualifier",
+                    "type": "jetbrains.mps.lang.smodel.ILinkAccessQualifier",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter",
+                "jetbrains.mps.lang.smodel.ILinkAccessQualifierContainer"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5708036808576088033",
+            "name": "Reference_GetResolveInfo",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IReferenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1540150895035667832",
+            "name": "OperationParm_SameMetaLevel",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractOperationParameter"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721008708",
+            "name": "IfInstanceOfStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721008708/1883223317721008710",
+                    "name": "nodeExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721008708/1883223317721008709",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721008708/1883223317721008711",
+                    "name": "variable",
+                    "type": "jetbrains.mps.lang.smodel.IfInstanceOfVariable",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721008708/1883223317721008712",
+                    "name": "nodeConcept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721008713",
+            "name": "IfInstanceOfVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1883223317721107059",
+            "name": "IfInstanceOfVarReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseVariableReference"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583031218",
+            "name": "AttributeAccess",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583031218/6407023681583036852",
+                    "name": "qualifier",
+                    "type": "jetbrains.mps.lang.smodel.AttributeQualifier",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation",
+                "jetbrains.mps.lang.smodel.ILinkAccess"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583036843",
+            "name": "AttributeQualifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583036853",
+            "name": "NodeAttributeQualifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583036853/6407023681583036854",
+                    "name": "attributeConcept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AttributeQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583036855",
+            "name": "LinkAttributeQualifier",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583036855/6407023681583038098",
+                    "name": "linkQualifier",
+                    "type": "jetbrains.mps.lang.smodel.ILinkQualifier",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583036855/6407023681583036856",
+                    "name": "attributeConcept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AttributeQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583040688",
+            "name": "AllAttributeQualifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AttributeQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583040953",
+            "name": "PropertyAttributeQualifier",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583040953/6407023681583040955",
+                    "name": "propertyQualifier",
+                    "type": "jetbrains.mps.lang.smodel.IPropertyQualifier",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6407023681583040953/6407023681583040954",
+                    "name": "attributeConcept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AttributeQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2788452359612124330",
+            "name": "ILinkQualifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2788452359612124331",
+            "name": "IPropertyQualifier",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2788452359612124332",
+            "name": "LinkQualifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2788452359612124332/2788452359612124336",
+                    "name": "link",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.ILinkQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2788452359612124333",
+            "name": "PropertyQualifier",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2788452359612124333/2788452359612124335",
+                    "name": "property",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IPropertyQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6995935425733782641",
+            "name": "Model_GetModule",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4040588429969021681",
+            "name": "ModuleReferenceExpression",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4040588429969021681/4040588429969021682",
+                    "name": "name"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4040588429969021681/4040588429969021683",
+                    "name": "moduleId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4040588429969069898",
+            "name": "LanguageReferenceExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.ModuleReferenceExpression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/559557797393017698",
+            "name": "ModelReferenceExpression",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/559557797393017698/559557797393017702",
+                    "name": "name"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/559557797393017698/559557797393021807",
+                    "name": "stereotype"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/559557797393017698/1423104411233404408",
+                    "name": "repo",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808754",
+            "name": "SubconceptCase",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808754/1163670677455",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.smodel.ConceptReference",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808754/1163670683720",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IConceptSwitchCase"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808749",
+            "name": "ConceptSwitchStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808749/5944356402132808752",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808749/5944356402132808753",
+                    "name": "case",
+                    "type": "jetbrains.mps.lang.smodel.IConceptSwitchCase",
+                    "multiple": true
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5944356402132808749/6039268229365417680",
+                    "name": "defaultBlock",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1828409047608048457",
+            "name": "NodePointerExpression_Old",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1828409047608048457/8944013247830892165",
+                    "name": "includeNonRoot",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1828409047608048457/1828409047608048458",
+                    "name": "referentNode",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8866923313515890008",
+            "name": "AsNodeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6973815483243445083",
+            "name": "EnumMemberValueRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6973815483243445083/6973815483243564601",
+                    "name": "enum",
+                    "type": "jetbrains.mps.lang.structure.EnumerationDataTypeDeclaration_Old",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6973815483243445083/6973815483243565416",
+                    "name": "member",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration_Old",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3575813534625140284",
+            "name": "AbstractNodeRefExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/597763930871270009",
+            "name": "ChildNodeRefExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/597763930871270009/597763930871272014",
+                    "name": "parent",
+                    "type": "jetbrains.mps.lang.smodel.AbstractNodeRefExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/597763930871270009/597763930871272016",
+                    "name": "targetNode",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractNodeRefExpression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4693937538533521280",
+            "name": "OfConceptOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4693937538533521280/4693937538533538124",
+                    "name": "requestedConcept",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.collections.SequenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836",
+            "name": "ConceptIdRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474300074836/2644386474300074837",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.smodel.BootstrapAwareMetaObject"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077",
+            "name": "LinkIdRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421078",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474301421077/2644386474301421079",
+                    "name": "linkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.smodel.BootstrapAwareMetaObject"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474302386080",
+            "name": "PropertyIdRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474302386080/2644386474302386081",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2644386474302386080/2644386474302386082",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.smodel.BootstrapAwareMetaObject"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/334628810661441841",
+            "name": "AsSConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6677504323281689838",
+            "name": "SConceptType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6677504323281689838/6677504323281689839",
+                    "name": "conceptDeclaraton",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/7453996997717780434",
+            "name": "Node_GetSConceptOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2565258849284146373",
+            "name": "BootstrapAwareMetaObject",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2565258849284146373/2565258849284158059",
+                    "name": "bootstrap",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6870613620389313273",
+            "name": "SConceptOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6870613620390542976",
+            "name": "ConceptAliasOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SConceptOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6870613620391345436",
+            "name": "ConceptShortDescriptionOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SConceptOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3542851458883438784",
+            "name": "LanguageId",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3542851458883438784/3542851458883439831",
+                    "name": "namespace"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3542851458883438784/3542851458883439832",
+                    "name": "languageId"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3542851458883438784/3542851458883439833",
+                    "name": "version",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.LanguageIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4497478346159780083",
+            "name": "LanguageRefExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4497478346159780083/3542851458883491298",
+                    "name": "languageId",
+                    "type": "jetbrains.mps.lang.smodel.LanguageIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3542851458883437336",
+            "name": "LanguageIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/709746936026631771",
+            "name": "ChildAttributeQualifier",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/709746936026631771/709746936026631772",
+                    "name": "linkQualifier",
+                    "type": "jetbrains.mps.lang.smodel.ILinkQualifier",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/709746936026631771/709746936026631773",
+                    "name": "attributeConcept",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AttributeQualifier"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6039268229364358244",
+            "name": "ExactConceptCase",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6039268229364358244/6039268229364358387",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.smodel.ConceptReference",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6039268229364358244/6039268229364358388",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IConceptSwitchCase"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6039268229364358294",
+            "name": "IConceptSwitchCase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5045161044515397667",
+            "name": "Node_PointerOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/427659576753752243",
+            "name": "ModulePointer",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/427659576753752243/427659576753753625",
+                    "name": "moduleName"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/427659576753752243/427659576753753627",
+                    "name": "moduleId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.ModuleIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/427659576753753630",
+            "name": "ModuleIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.modelapi.ModuleIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1678062499342629858",
+            "name": "ModuleRefExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1678062499342629858/1678062499342629861",
+                    "name": "moduleId",
+                    "type": "jetbrains.mps.lang.modelapi.ModuleIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/7835263205327057228",
+            "name": "Node_GetChildrenAndChildAttributesOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.Node_GetChildrenOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2396822768958367367",
+            "name": "AbstractTypeCastExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2396822768958367367/6733348108486823193",
+                    "name": "leftExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2396822768958367367/3906496115198199033",
+                    "name": "conceptArgument",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2396822768958367367/6733348108486823428",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.baseLanguage.IBinaryLike"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349110807",
+            "name": "PropertyIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.ConceptMemberIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349110850",
+            "name": "ConceptIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349121511",
+            "name": "ConceptId",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349121511/6911370362349121516",
+                    "name": "conceptId"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349121511/6911370362349122519",
+                    "name": "conceptName"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349121511/6911370362349133804",
+                    "name": "isInterface",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349121511/6911370362349121514",
+                    "name": "languageIdentity",
+                    "type": "jetbrains.mps.lang.smodel.LanguageIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.ConceptIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349167452",
+            "name": "PropertyId",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349167452/6911370362349167457",
+                    "name": "propertyId"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349167452/6911370362349167455",
+                    "name": "propertyName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/6911370362349167452/6911370362349167460",
+                    "name": "conceptIdentity",
+                    "type": "jetbrains.mps.lang.smodel.ConceptIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.PropertyIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1761385620274348152",
+            "name": "SConceptTypeCastExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractTypeCastExpression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8296877263936075789",
+            "name": "GeneratorModulePointer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8296877263936075789/8296877263936075892",
+                    "name": "module",
+                    "type": "jetbrains.mps.lang.smodel.ModulePointer",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.GeneratorIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8296877263936070003",
+            "name": "GeneratorIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330471",
+            "name": "ContainmentLinkId",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330471/8415841354032330473",
+                    "name": "linkId"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330471/8415841354032330474",
+                    "name": "linkName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330471/8415841354032330472",
+                    "name": "conceptIdentity",
+                    "type": "jetbrains.mps.lang.smodel.ConceptIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.AggregationIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330476",
+            "name": "ReferenceLinkId",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330476/8415841354032330478",
+                    "name": "referenceId"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330476/8415841354032330479",
+                    "name": "referenceName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330476/8415841354032330477",
+                    "name": "conceptIdentity",
+                    "type": "jetbrains.mps.lang.smodel.ConceptIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.AssociationIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330481",
+            "name": "AggregationIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.ConceptMemberIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8415841354032330482",
+            "name": "AssociationIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.ConceptMemberIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3265844182379169765",
+            "name": "ConceptMemberIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5472444609684539882",
+            "name": "SConceptTypeLiteral",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5472444609684539882/5472444609684539883",
+                    "name": "conceptDeclaraton",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/7504436213544206332",
+            "name": "Node_ContainingLinkOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2926695023085807517",
+            "name": "Reference_ContainingLinkOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IReferenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2469893808086079682",
+            "name": "LanguageIdentityBySourceModule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2469893808086079682/2469893808086079721",
+                    "name": "moduleReference",
+                    "type": "jetbrains.mps.lang.modelapi.ModuleIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.LanguageIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/7400021826771268254",
+            "name": "SNodePointerType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/7400021826771268254/7400021826771268269",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/7400021826774799413",
+            "name": "NodePointerExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/7400021826774799413/7400021826774799510",
+                    "name": "ref",
+                    "type": "jetbrains.mps.lang.modelapi.NodeIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3648723375513868532",
+            "name": "NodePointer_ResolveOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractPointerResolveOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4065387505485742666",
+            "name": "ModelPointer_ResolveOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.AbstractPointerResolveOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4065387505485742749",
+            "name": "AbstractPointerResolveOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4065387505485742749/3648723375513868575",
+                    "name": "repositoryArg",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3506770386464365589",
+            "name": "Model_PointerOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1863527487546129879",
+            "name": "ModelPointerExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1863527487546129879/1863527487546132519",
+                    "name": "modelRef",
+                    "type": "jetbrains.mps.lang.modelapi.ModelIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8222125370833354011",
+            "name": "DevkitPointer",
+            "properties": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8222125370833354011/8222125370833354012",
+                    "name": "devkitName"
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8222125370833354011/8222125370833354013",
+                    "name": "devkitId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.DevkitIdentity"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1863527487546132619",
+            "name": "SModelPointerType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8222125370833325502",
+            "name": "DevkitIdentity",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/942336824646299470",
+            "name": "Link_SetTargetPointerOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/942336824646299470/942336824646299471",
+                    "name": "linkTarget",
+                    "type": "jetbrains.mps.lang.smodel.INodePointerArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3320646261221695165",
+            "name": "NodePointerArg_Identity",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3320646261221695165/3320646261221695238",
+                    "name": "ref",
+                    "type": "jetbrains.mps.lang.modelapi.NodeIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.INodePointerArg"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3320646261221695077",
+            "name": "INodePointerArg",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/3661776679762942774",
+            "name": "Node_IsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/3661776679762942774/3661776679762942860",
+                    "name": "ref",
+                    "type": "jetbrains.mps.lang.modelapi.NodeIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6138838330738724256",
+            "name": "NodePointer_GetModelOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290083281362",
+            "name": "EnumMember_NameOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290088668405",
+            "name": "EnumOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290088668512",
+            "name": "Enum_MemberLiteral",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290088668512/1966870290088668516",
+                    "name": "memberDeclaration",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290088668519",
+            "name": "Enum_FromNameOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290088668519/1966870290088674248",
+                    "name": "nameExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/1966870290088668520",
+            "name": "Enum_MembersOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5779574625830813396",
+            "name": "EnumerationIdRefExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5779574625830813396/5779574625830813397",
+                    "name": "enumDeclaration",
+                    "type": "jetbrains.mps.lang.structure.EnumerationDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5779574625830814755",
+            "name": "SEnumerationType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5779574625832259537",
+            "name": "EnumMember_PresentationOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/5779574625832942190",
+            "name": "Enum_FromPresentationOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/5779574625832942190/7305791986891524236",
+                    "name": "presentationExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4705942098322467729",
+            "name": "EnumMemberReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4705942098322467729/4705942098322467736",
+                    "name": "decl",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/4705942098322609812",
+            "name": "EnumMember_IsOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/4705942098322609812/4705942098322609813",
+                    "name": "member",
+                    "type": "jetbrains.mps.lang.smodel.EnumMemberReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.EnumMemberOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559839",
+            "name": "EnumSwitchExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559839/2453008993612559840",
+                    "name": "enumExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559839/2453008993612714935",
+                    "name": "cases",
+                    "type": "jetbrains.mps.lang.smodel.EnumSwitchCase",
+                    "multiple": true
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559839/2453008993619909454",
+                    "name": "otherwiseBody",
+                    "type": "jetbrains.mps.lang.smodel.EnumSwitchCaseBody"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559843",
+            "name": "EnumSwitchCase",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559843/2453008993612559844",
+                    "name": "members",
+                    "type": "jetbrains.mps.lang.smodel.EnumMemberReference",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612559843/2453008993612717146",
+                    "name": "body",
+                    "type": "jetbrains.mps.lang.smodel.EnumSwitchCaseBody",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612717152",
+            "name": "EnumSwitchCaseBody",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612717253",
+            "name": "EnumSwitchCaseBody_Expression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612717253/2453008993612717254",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.EnumSwitchCaseBody"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612717257",
+            "name": "EnumSwitchCaseBody_StatementList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/2453008993612717257/2453008993612717258",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.EnumSwitchCaseBody",
+                "jetbrains.mps.baseLanguage.IStatementListContainer"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8564914671171067370",
+            "name": "PropertySerializeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8564914671171067370/8564914671171120345",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8564914671171067370/8822815258147051351",
+                    "name": "datatype",
+                    "type": "jetbrains.mps.lang.structure.DataTypeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8564914671171209694",
+            "name": "PropertyDeserializeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8564914671171209694/8564914671171209696",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7866978e-a0f0-4cc7-81bc-4d213d9375e1/8564914671171209694/6373819377346114474",
+                    "name": "datatype",
+                    "type": "jetbrains.mps.lang.structure.DataTypeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/6079722741456947163",
+            "name": "Reference_IsDynamic",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodel.IReferenceOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/7236635212850979475",
+            "name": "Node_HasNextSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7866978e-a0f0-4cc7-81bc-4d213d9375e1/8432949284911505116",
+            "name": "Node_HasPrevSiblingOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.smodel.query.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.smodel.query.json
@@ -1,0 +1,441 @@
+{
+    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a",
+    "name": "jetbrains.mps.lang.smodel.query",
+    "concepts": [
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/8483375838963816171",
+            "name": "UsagesExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/8483375838963816171/8483375838963816172",
+                    "name": "node",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryExpression"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/7738379549910147341",
+            "name": "InstancesExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/7738379549910147341/7738379549910147342",
+                    "name": "conceptArg",
+                    "type": "jetbrains.mps.lang.smodel.IRefConceptArg",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryExpression"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2822369470875160718",
+            "name": "NodesExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryExpression"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/6322385757202370749",
+            "name": "ReferencesExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryExpression"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/6864030874027862829",
+            "name": "ModelsExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryExpression"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/6864030874028745314",
+            "name": "ModulesExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryExpression"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004131544317",
+            "name": "QueryExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004131544317/4307205004132279624",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.smodel.query.QueryParameterList"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.smodel.query.ExpressionHelpProvider"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004131544565",
+            "name": "QueryParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004132277753",
+            "name": "QueryParameterList",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004132277753/4307205004141421222",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.lang.smodel.query.QueryParameter",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004132412550",
+            "name": "QueryParameterIncludeReadOnly_old",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryParameter"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004132412719",
+            "name": "QueryParameterScope_old",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004132412719/4307205004134707081",
+                    "name": "value_old",
+                    "type": "jetbrains.mps.lang.smodel.query.ScopeParameter_old",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryParameter"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4307205004134636875",
+            "name": "ScopeParameter_old",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2755216049126692157",
+            "name": "ModulesScope_old",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2755216049126692157/3492877759607928680",
+                    "name": "modules_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.ScopeParameter_old"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/3492877759608408142",
+            "name": "ModelsScope_old",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/3492877759608408142/3492877759608408143",
+                    "name": "models_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.ScopeParameter_old"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/3492877759611762121",
+            "name": "CustomScope_old",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/3492877759611762121/3492877759611770126",
+                    "name": "scope_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.ScopeParameter_old"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/7006261637496548496",
+            "name": "ExpressionHelpProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.HelpProvider"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/5932042262275648515",
+            "name": "OperationHelpProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.HelpProvider"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/473081947981012231",
+            "name": "HelpProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4234138103881610891",
+            "name": "WithStatement",
+            "properties": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4234138103881610891/192970713427626335",
+                    "name": "includeNonEditable",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4234138103881610891/4234138103881610892",
+                    "name": "stmts",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/4234138103881610891/4234138103881610935",
+                    "name": "scope",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.lang.smodel.query.QueryExpressionScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/677787792397344112",
+            "name": "QueryParameterExact",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryParameter"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/505947336487701511",
+            "name": "QueryExpressionScopeProvider",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062178",
+            "name": "ScopeParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062179",
+            "name": "QueryParameterScope",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062179/2362304834939062180",
+                    "name": "value",
+                    "type": "jetbrains.mps.lang.smodel.query.ScopeParameter",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.QueryParameter"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062181",
+            "name": "ModulesScope",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062181/2362304834939062182",
+                    "name": "modules",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.ScopeParameter"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062183",
+            "name": "ModelsScope",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062183/2362304834939062184",
+                    "name": "models",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.ScopeParameter"
+            ]
+        },
+        {
+            "uid": "mps:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062185",
+            "name": "CustomScope",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "1a8554c4-eb84-43ba-8c34-6f0d90c6e75a/2362304834939062185/2362304834939062186",
+                    "name": "scope",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.query.ScopeParameter"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.smodelTests.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.smodelTests.json
@@ -1,0 +1,255 @@
+{
+    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e",
+    "name": "jetbrains.mps.lang.smodelTests",
+    "concepts": [
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141631",
+            "name": "Child",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141631/278471160714141632",
+                    "name": "grandChild_0_1",
+                    "type": "jetbrains.mps.lang.smodelTests.GrandChild"
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141631/278471160714141633",
+                    "name": "grandChild_1",
+                    "type": "jetbrains.mps.lang.smodelTests.GrandChild",
+                    "optional": false
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141631/278471160714141634",
+                    "name": "grandChild_0_n",
+                    "type": "jetbrains.mps.lang.smodelTests.GrandChild",
+                    "multiple": true
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141631/278471160714141635",
+                    "name": "grandChild_1_n",
+                    "type": "jetbrains.mps.lang.smodelTests.GrandChild",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141636",
+            "name": "GrandChild",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141637",
+            "name": "Root",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141637/278471160714141638",
+                    "name": "child_0_n",
+                    "type": "jetbrains.mps.lang.smodelTests.Child",
+                    "multiple": true
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141637/278471160714141639",
+                    "name": "child_1_n",
+                    "type": "jetbrains.mps.lang.smodelTests.Child",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/278471160714141637/34342663958604624",
+                    "name": "childSubConcept_0_n",
+                    "type": "jetbrains.mps.lang.smodelTests.ChildSubConcept",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/34342663958604621",
+            "name": "ChildSubConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodelTests.Child"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/8758390115028851398",
+            "name": "ReferenceContainer",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/8758390115028851398/8758390115028851399",
+                    "name": "root",
+                    "type": "jetbrains.mps.lang.smodelTests.Root",
+                    "optional": false
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/8758390115028851398/8758390115028851400",
+                    "name": "leftChild",
+                    "type": "jetbrains.mps.lang.smodelTests.Child"
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/8758390115028851398/8758390115028851401",
+                    "name": "rightChild",
+                    "type": "jetbrains.mps.lang.smodelTests.Child"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/2854075155748534270",
+            "name": "ReferenceContainerSubConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodelTests.ReferenceContainer"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/535833678905714286",
+            "name": "NPTypesystem_IntA",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/535833678905714287",
+            "name": "NPTypesystem_IntB",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/535833678905839903",
+            "name": "NPTypesystem_ConceptA",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodelTests.NPTypesystem_IntA"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/535833678905839906",
+            "name": "NPTypesystem_ConceptB",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.smodelTests.NPTypesystem_IntB"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/535833678905974372",
+            "name": "NPTypesystem_RefToIntA",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/535833678905974372/535833678905974373",
+                    "name": "ref",
+                    "type": "jetbrains.mps.lang.smodelTests.NPTypesystem_IntA",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/3346087189435802739",
+            "name": "ChildSubConceptSuppressError",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodelTests.Child",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:b02ae39f-4c16-4545-8dfa-88df16804e7e/7060593544921608929",
+            "name": "TestEnum_Container",
+            "properties": [
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/7060593544921608929/7060593544921608930",
+                    "name": "enumWithDefault"
+                },
+                {
+                    "uid": "b02ae39f-4c16-4545-8dfa-88df16804e7e/7060593544921608929/7060593544921608932",
+                    "name": "enumWODefault"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.structure.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.structure.json
@@ -1,0 +1,808 @@
+{
+    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7",
+    "name": "jetbrains.mps.lang.structure",
+    "concepts": [
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298",
+            "name": "LinkDeclaration",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/1071599776563",
+                    "name": "role"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/1071599937831",
+                    "name": "metaClass"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/1071599893252",
+                    "name": "sourceCardinality"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/2395585628928459314",
+                    "name": "unordered",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/241647608299431140",
+                    "name": "linkId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/1071599698500",
+                    "name": "specializedLink",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288298/1071599976176",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable",
+                "jetbrains.mps.lang.structure.INamedStructureElement",
+                "jetbrains.mps.lang.structure.DocumentationObjective"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288299",
+            "name": "PropertyDeclaration",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288299/241647608299431129",
+                    "name": "propertyId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489288299/1082985295845",
+                    "name": "dataType",
+                    "type": "jetbrains.mps.lang.structure.DataTypeDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.lang.structure.INamedStructureElement",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable",
+                "jetbrains.mps.lang.structure.DocumentationObjective"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164218",
+            "name": "DataTypeDeclaration",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164218/7791109065626895363",
+                    "name": "datatypeId"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164218/7791109065626895364",
+                    "name": "languageId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedStructureElement",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1082978499127",
+            "name": "ConstrainedDataTypeDeclaration",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978499127/1083066089218",
+                    "name": "constraint"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.DataTypeDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1083171877298",
+            "name": "EnumerationMemberDeclaration_Old",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1083171877298/1083923523171",
+                    "name": "internalValue"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1083171877298/1083923523172",
+                    "name": "externalValue"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1083171877298/1192116978809",
+                    "name": "javaIdentifier"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1083243159079",
+            "name": "PrimitiveDataTypeDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.DataTypeDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135",
+            "name": "AbstractConceptDeclaration",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/2465654535473034588",
+                    "name": "oldHelpURL"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/5092175715804935370",
+                    "name": "conceptAlias"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/4628067390765907488",
+                    "name": "conceptShortDescription"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/4628067390765956802",
+                    "name": "abstract",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/4628067390765956807",
+                    "name": "final",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/1587916991969465369",
+                    "name": "intConceptId",
+                    "type": "INT"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/6714410169261853888",
+                    "name": "conceptId"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/9005308665739310115",
+                    "name": "languageId"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/1071489727083",
+                    "name": "linkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/1071489727084",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/1780177113170204155",
+                    "name": "helpURL",
+                    "type": "jetbrains.mps.lang.resources.HelpURL"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125787135/5023950685592517420",
+                    "name": "sourceNode",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedStructureElement",
+                "jetbrains.mps.lang.core.InterfacePart",
+                "jetbrains.mps.lang.structure.IStructureDeprecatable",
+                "jetbrains.mps.lang.structure.DocumentationObjective"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1169125989551",
+            "name": "InterfaceConceptDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169125989551/1169127546356",
+                    "name": "extends",
+                    "type": "jetbrains.mps.lang.structure.InterfaceConceptReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.AbstractConceptDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1169127622168",
+            "name": "InterfaceConceptReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1169127622168/1169127628841",
+                    "name": "intfc",
+                    "type": "jetbrains.mps.lang.structure.InterfaceConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1224240836180",
+            "name": "DeprecatedNodeAnnotation",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1224240836180/1225118929411",
+                    "name": "build"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1224240836180/1225118933224",
+                    "name": "comment"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1224848324737",
+            "name": "IStructureDeprecatable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.IDeprecatable"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/2621449412040133764",
+            "name": "IConceptAspect",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/2992811758677295509",
+            "name": "AttributeInfo",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/2992811758677295509/7588428831955550663",
+                    "name": "role"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/2992811758677295509/7588428831955550186",
+                    "name": "multiple",
+                    "type": "jetbrains.mps.lang.structure.AttributeInfo_IsMultiple"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/2992811758677295509/7588428831947959310",
+                    "name": "attributed",
+                    "type": "jetbrains.mps.lang.structure.AttributeInfo_AttributedConcept",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/6054523464626862044",
+            "name": "AttributeInfo_IsMultiple",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/6054523464626862044/6054523464626875854",
+                    "name": "value",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/6054523464627964745",
+            "name": "AttributeInfo_AttributedConcept",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/6054523464627964745/6054523464627965081",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/5717188120689018936",
+            "name": "ReferenceLinkDeclartionScopeKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/5717188120689019441",
+            "name": "AggregationLinkDeclarationScopeKind",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/7862711839422615221",
+            "name": "DocumentationObjectiveRef",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/7862711839422615221/7862711839422615222",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.structure.DocumentationObjective",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/7862711839422615214",
+            "name": "DocumentationObjective",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/7862711839422615209",
+            "name": "DocumentedNodeAnnotation",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/7862711839422615209/7862711839422615217",
+                    "name": "text"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/7862711839422615209/7862711839422615224",
+                    "name": "seeAlso",
+                    "type": "jetbrains.mps.lang.structure.DocumentationObjectiveRef",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/8842732777748207592",
+            "name": "SmartReferenceAttribute",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/8842732777748207592/8842732777748474935",
+                    "name": "refPresentationTemplate",
+                    "type": "jetbrains.mps.lang.structure.RefPresentationTemplate"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/8842732777748207592/8842732777748207597",
+                    "name": "charactersticReference",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/8842732777748464990",
+            "name": "RefPresentationTemplate",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/8842732777748464990/4307758654697524057",
+                    "name": "prefix"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/8842732777748464990/4307758654697524060",
+                    "name": "suffix"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219",
+            "name": "EnumerationDataTypeDeclaration_Old",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219/1197591154882",
+                    "name": "memberIdentifierPolicy"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219/1212080844762",
+                    "name": "hasNoDefaultMember",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219/1212087449254",
+                    "name": "noValueText"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219/1083172003582",
+                    "name": "member",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration_Old",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219/1083171729157",
+                    "name": "memberDataType",
+                    "type": "jetbrains.mps.lang.structure.PrimitiveDataTypeDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1082978164219/1083241965437",
+                    "name": "defaultMember",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration_Old"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.DataTypeDeclaration",
+                "jetbrains.mps.lang.structure.IEnumeration"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640",
+            "name": "ConceptDeclaration",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640/1096454100552",
+                    "name": "rootable",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640/1160488491229",
+                    "name": "iconPath"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640/5404671619616246344",
+                    "name": "staticScope"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640/1169129564478",
+                    "name": "implements",
+                    "type": "jetbrains.mps.lang.structure.InterfaceConceptReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640/6327362524875300597",
+                    "name": "icon",
+                    "type": "jetbrains.mps.lang.resources.Icon"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1071489090640/1071489389519",
+                    "name": "extends",
+                    "type": "jetbrains.mps.lang.structure.ConceptDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                "jetbrains.mps.lang.core.ISmartReferent"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976479",
+            "name": "EnumerationDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976479/3348158742936976577",
+                    "name": "members",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976479/1075010451642646892",
+                    "name": "defaultMember",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.structure.DataTypeDeclaration",
+                "jetbrains.mps.lang.structure.IEnumeration"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976480",
+            "name": "EnumerationMemberDeclaration",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976480/672037151186491528",
+                    "name": "presentation"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976480/1421157252384165432",
+                    "name": "memberId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3348158742936976480/899069222106091871",
+                    "name": "oldMember",
+                    "type": "jetbrains.mps.lang.structure.EnumerationMemberDeclaration_Old"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedStructureElement"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1075010451653667301",
+            "name": "IEnumeration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162880629653",
+            "name": "INamedStructureElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.structure.IStructureElement"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162880706270",
+            "name": "IStructureElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162884797030",
+            "name": "EnumMigrationInfo",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162884797030/6491077959634650670",
+                    "name": "nameOpMigration"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162884797030/6491077959634662372",
+                    "name": "valueOpMigration"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/1588368162884797030/6491077959632451996",
+                    "name": "oldEnum",
+                    "type": "jetbrains.mps.lang.structure.EnumerationDataTypeDeclaration_Old",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/6491077959632463275",
+            "name": "EnumPropertyMigrationInfo",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/6491077959632463275/6491077959632463286",
+                    "name": "oldProperty",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/3355805929432017219",
+            "name": "EnumCustomMethodReplacementInfo",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3355805929432017219/3355805929432017222",
+                    "name": "kind"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/3355805929432017219/3355805929432017224",
+                    "name": "enum",
+                    "type": "jetbrains.mps.lang.structure.EnumerationDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/418049251856799813",
+            "name": "ExperimentalAPINodeAttribute",
+            "properties": [
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/418049251856799813/418049251856799816",
+                    "name": "build"
+                },
+                {
+                    "uid": "c72da2b9-7cce-4447-8389-f407dc1158b7/418049251856799813/418049251856799817",
+                    "name": "comment"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:c72da2b9-7cce-4447-8389-f407dc1158b7/7954147563045283296",
+            "name": "INamedAspect",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.test.generator.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.test.generator.json
@@ -1,0 +1,165 @@
+{
+    "uid": "68015e26-cc4d-49db-8715-b643faea1769",
+    "name": "jetbrains.mps.lang.test.generator",
+    "concepts": [
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/554465258093187774",
+            "name": "GeneratorTest",
+            "properties": [
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093187774/554465258093190244",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093187774/554465258093190247",
+                    "name": "arguments",
+                    "type": "jetbrains.mps.lang.test.generator.TestArgument",
+                    "multiple": true
+                },
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093187774/554465258093203559",
+                    "name": "tests",
+                    "type": "jetbrains.mps.lang.test.generator.TestAssertion",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.structure.INamedAspect"
+            ]
+        },
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/554465258093190250",
+            "name": "TestArgument",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/554465258093190254",
+            "name": "ModelArgument",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093190254/554465258093190258",
+                    "name": "param",
+                    "type": "jetbrains.mps.lang.modelapi.ModelIdentity",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.generator.TestArgument"
+            ]
+        },
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/554465258093203543",
+            "name": "TransformationMatchAssertion",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093203543/554465258093203550",
+                    "name": "inputModel",
+                    "type": "jetbrains.mps.lang.test.generator.ArgumentReference",
+                    "optional": false
+                },
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093203543/554465258093203552",
+                    "name": "referenceModel",
+                    "type": "jetbrains.mps.lang.test.generator.ArgumentReference",
+                    "optional": false
+                },
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093203543/554465258093203555",
+                    "name": "transformationPlan",
+                    "type": "jetbrains.mps.lang.test.generator.ArgumentReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.generator.TestAssertion"
+            ]
+        },
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/554465258093203544",
+            "name": "TestAssertion",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/554465258093203547",
+            "name": "ArgumentReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/554465258093203547/554465258093203548",
+                    "name": "arg",
+                    "type": "jetbrains.mps.lang.test.generator.TestArgument",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:68015e26-cc4d-49db-8715-b643faea1769/6346338635721157081",
+            "name": "TransformationMatchManyAssertion",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/6346338635721157081/554465258093203550",
+                    "name": "inputModel",
+                    "type": "jetbrains.mps.lang.test.generator.ArgumentReference",
+                    "optional": false
+                },
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/6346338635721157081/554465258093203552",
+                    "name": "referenceModels",
+                    "type": "jetbrains.mps.lang.test.generator.ArgumentReference",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "68015e26-cc4d-49db-8715-b643faea1769/6346338635721157081/554465258093203555",
+                    "name": "transformationPlan",
+                    "type": "jetbrains.mps.lang.test.generator.ArgumentReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.generator.TestAssertion"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.test.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.test.json
@@ -1,0 +1,1607 @@
+{
+    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c",
+    "name": "jetbrains.mps.lang.test",
+    "concepts": [
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1210673684636",
+            "name": "TestNodeAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractTestNodeAnnotation",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1210674524691",
+            "name": "TestNodeReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1210674524691/1210674534086",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.test.TestNodeAnnotation",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1211979288880",
+            "name": "AssertMatch",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1211979288880/1211979305365",
+                    "name": "before",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1211979288880/1211979322383",
+                    "name": "after",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.unitTest.MessageHolder"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1214846310980",
+            "name": "AbstractNodeAssert",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1214846310980/1214846370530",
+                    "name": "nodeToCheck",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215075719096",
+            "name": "CheckNodeForErrors",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215075719096/3743352646565670841",
+                    "name": "includeSelf",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeAssert"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215507671101",
+            "name": "NodeErrorCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215507671101/8489045168660938517",
+                    "name": "errorRef",
+                    "type": "jetbrains.mps.lang.test.ReportErrorStatementReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeErrorCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215511704609",
+            "name": "NodeWarningCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215511704609/8489045168660938635",
+                    "name": "warningRef",
+                    "type": "jetbrains.mps.lang.test.WarningStatementReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeWarningCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215525678776",
+            "name": "NodeReachable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215526290564",
+            "name": "NodeTypeCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215526290564/1215526393912",
+                    "name": "type",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215601147424",
+            "name": "NodeCheckOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.INodesTestMethod",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215603922101",
+            "name": "NodeOperationsContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215603922101/1215604436604",
+                    "name": "nodeOperations",
+                    "type": "jetbrains.mps.lang.test.NodeCheckOperation",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractTestNodeAnnotation",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215607067978",
+            "name": "CheckNodeForErrorMessagesOperation",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215607067978/852155438140865197",
+                    "name": "allowErrors",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215607067978/852155438140865198",
+                    "name": "allowWarnings",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215607067978/3743352646565420194",
+                    "name": "includeSelf",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215611834554",
+            "name": "CheckDataFlowOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215612918969",
+            "name": "NodeUnreachable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215614394933",
+            "name": "VariableInitialized",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215614394933/1215614415465",
+                    "name": "var",
+                    "type": "jetbrains.mps.baseLanguage.VariableReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1215616993394",
+            "name": "VariableAlive",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1215616993394/1215617010458",
+                    "name": "var",
+                    "type": "jetbrains.mps.baseLanguage.VariableReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126",
+            "name": "NodesTestCase",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126/6339244025081158986",
+                    "name": "needsNoWriteAction",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126/1217501822150",
+                    "name": "nodesToCheck",
+                    "type": "jetbrains.mps.lang.test.TestNode",
+                    "multiple": true
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126/2325284917965993569",
+                    "name": "beforeTests",
+                    "type": "jetbrains.mps.lang.test.BeforeTestsMethod"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126/2325284917965993580",
+                    "name": "afterTests",
+                    "type": "jetbrains.mps.lang.test.AfterTestsMethod"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126/1217501895093",
+                    "name": "testMethods",
+                    "type": "jetbrains.mps.lang.test.NodesTestMethod",
+                    "multiple": true
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216913645126/1216993439383",
+                    "name": "methods",
+                    "type": "jetbrains.mps.baseLanguage.classifiers.DefaultClassifierMethodDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.unitTest.ITestCase",
+                "jetbrains.mps.baseLanguage.classifiers.IClassifier",
+                "jetbrains.mps.lang.test.TestProjectAware",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1216913689992",
+            "name": "NodesTestMethod",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.unitTest.ITestMethod"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1216989428737",
+            "name": "TestNode",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1216989428737/1216989461394",
+                    "name": "nodeToCheck",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.ITestAnnotationsContainer",
+                "jetbrains.mps.lang.core.ICanSuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1217425837708",
+            "name": "CheckNodeDataflow",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeAssert"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1225467090849",
+            "name": "ProjectExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1225469856668",
+            "name": "ModelExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1225978065297",
+            "name": "SimpleNodeTest",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodesTestMethod"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1225989773458",
+            "name": "InvokeIntentionStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1225989773458/8933192351751916178",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1225989773458/1225989811227",
+                    "name": "intention",
+                    "type": "jetbrains.mps.lang.intentions.IntentionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1227003183644",
+            "name": "EditorOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1228584180295",
+            "name": "AbstractTestNodeAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1227182079811",
+            "name": "TypeKeyStatement",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1227182079811/1227184461946",
+                    "name": "keys"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1228934484974",
+            "name": "PressKeyStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1228934484974/1228934507814",
+                    "name": "keyStrokes",
+                    "type": "jetbrains.mps.lang.plugin.KeyMapKeystroke",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856",
+            "name": "EditorTestCase",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/1883175908513350760",
+                    "name": "description"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/3143335925185262946",
+                    "name": "testNodeBefore",
+                    "type": "jetbrains.mps.lang.test.TestNode"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/3143335925185262981",
+                    "name": "testNodeResult",
+                    "type": "jetbrains.mps.lang.test.TestNode"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/1229187676388",
+                    "name": "nodeToEdit",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/1229187707859",
+                    "name": "result",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/1229187755283",
+                    "name": "code",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229187653856/5219531754069547112",
+                    "name": "logEvents",
+                    "type": "jetbrains.mps.lang.test.LogEvent",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.unitTest.ITestMethod",
+                "jetbrains.mps.baseLanguage.unitTest.ITestCase",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.ICanSuppressErrors",
+                "jetbrains.mps.lang.core.ImplementationPart",
+                "jetbrains.mps.baseLanguage.IStatementListContainer",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.lang.test.TestProjectAware"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594",
+            "name": "AnonymousCellAnnotation",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1229194968595",
+                    "name": "cellId"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1229194968596",
+                    "name": "caretPosition",
+                    "type": "INT"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1229432188737",
+                    "name": "isLastPosition",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1932269937152561478",
+                    "name": "useLabelSelection",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/6268941039745498163",
+                    "name": "selectionStart",
+                    "type": "INT"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/6268941039745498165",
+                    "name": "selectionEnd",
+                    "type": "INT"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1977980803835239937",
+                    "name": "isInInspector",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1932269937152203468",
+                    "name": "nodeRangeSelectionStart",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1229194968594/1932269937152203469",
+                    "name": "nodeRangeSelectionEnd",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractTestNodeAnnotation",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1230224281548",
+            "name": "MockAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractTestNodeAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/95706764259116183",
+            "name": "NodeTypeSetCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/95706764259116183/95706764259116184",
+                    "name": "type",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2685915532175039858",
+            "name": "ExpressionContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2685915532175039858/2685915532175039859",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5773579205429617809",
+            "name": "SwitchToInspector",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5773579205429866751",
+            "name": "EditorComponentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5097124989038916362",
+            "name": "TestInfo",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5097124989038916362/5097124989038916363",
+                    "name": "projectPath"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5097124989038916362/1031873601093404121",
+                    "name": "reOpenProject",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/7011073693661765739",
+            "name": "InvokeActionStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/7011073693661765739/1101347953350127927",
+                    "name": "actionReference",
+                    "type": "jetbrains.mps.lang.test.ActionReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1101347953350122484",
+            "name": "ActionReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1101347953350122758",
+            "name": "BootstrapActionReference",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1101347953350122758/1101347953350127918",
+                    "name": "actionId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.ActionReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/4239542196496927193",
+            "name": "MPSActionReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/4239542196496927193/4239542196496929559",
+                    "name": "action",
+                    "type": "jetbrains.mps.lang.plugin.ActionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.ActionReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/4395293866213195846",
+            "name": "NodeExpectedTypeCheckOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeTypeCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/511191073233700873",
+            "name": "ScopesTest",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/511191073233700873/3655334166513314307",
+                    "name": "nodes",
+                    "type": "jetbrains.mps.lang.test.ScopesExpectedNode",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/511191073233700873/5449224527592117654",
+                    "name": "checkingReference",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractTestNodeAnnotation",
+                "jetbrains.mps.lang.test.INodesTestMethod"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/3655334166513314291",
+            "name": "ScopesExpectedNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/3655334166513314291/4052780437578824735",
+                    "name": "ref",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/4307182653741890820",
+            "name": "NodeRuleCheckOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeRuleCheckOperation",
+                "jetbrains.mps.lang.test.IReferenceAttachable"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/4531408400484511853",
+            "name": "ReportErrorStatementReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.IRuleReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/4531408400486526326",
+            "name": "WarningStatementReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.IRuleReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/428590876651279930",
+            "name": "NodeTypeSystemErrorCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/428590876651279930/4649457259824818099",
+                    "name": "equationRef",
+                    "type": "jetbrains.mps.lang.test.TypesystemEquationReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeTypeSystemRuleCheckOperation",
+                "jetbrains.mps.lang.test.IReferenceAttachable"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8578280453507219248",
+            "name": "ICheckForExpectedRule",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8578280453509464010",
+            "name": "NodeTypeSystemWarningCheckOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeTypeSystemRuleCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5348336190815082969",
+            "name": "NodeTypeSystemRuleCheckOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeRuleCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2893471348147803052",
+            "name": "IReferenceAttachable",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/7691029917083831655",
+            "name": "UnknownRuleReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.IRuleReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/7691029917083872157",
+            "name": "IRuleReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/7691029917083872157/8333855927540250453",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/7835233914436786109",
+            "name": "NodeUnknownErrorCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/7835233914436786109/8333855927540028958",
+                    "name": "errorRef",
+                    "type": "jetbrains.mps.lang.test.UnknownRuleReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeErrorCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/7835233914436803226",
+            "name": "AbstractNodeErrorCheckOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeRuleCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/7835233914439520906",
+            "name": "AbstractNodeRuleCheckOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/7835233914439520906/710597951278798299",
+                    "name": "expectedMessage",
+                    "type": "jetbrains.mps.lang.test.ExpectedMessageContainer"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeCheckOperation",
+                "jetbrains.mps.lang.test.ICheckForExpectedRule"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927540283103",
+            "name": "NodeConstraintsErrorCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927540283103/8333855927548182241",
+                    "name": "errorRef",
+                    "type": "jetbrains.mps.lang.test.UnknownRuleReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeErrorCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927564181193",
+            "name": "AbstractNodeWarningCheckOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeRuleCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927564208813",
+            "name": "NodeConstraintsWarningCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927564208813/8333855927564209217",
+                    "name": "warningRef",
+                    "type": "jetbrains.mps.lang.test.UnknownRuleReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeWarningCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927564286208",
+            "name": "NodeUnknownWarningCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/8333855927564286208/8333855927564310179",
+                    "name": "warningRef",
+                    "type": "jetbrains.mps.lang.test.UnknownRuleReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.AbstractNodeWarningCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/210559400605421433",
+            "name": "PressMouseStatement",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/210559400605421433/210559400606080743",
+                    "name": "x",
+                    "type": "INT"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/210559400605421433/210559400606080744",
+                    "name": "y",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/210559400605421433/1082485599096",
+                    "name": "statementList",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/210559400608047267",
+            "name": "DragMouseStatement",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/210559400608047267/210559400608047600",
+                    "name": "x",
+                    "type": "INT"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/210559400608047267/210559400608047601",
+                    "name": "y",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/8101092317677916964",
+            "name": "UntypedExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5219531754069546544",
+            "name": "LogEvent",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5219531754069546544/5219531754070085220",
+                    "name": "level"
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5219531754069546544/5219531754070085223",
+                    "name": "message"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993334166130",
+            "name": "NodeInfoCheckOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993334166130/2153278993334179757",
+                    "name": "statementRef",
+                    "type": "jetbrains.mps.lang.test.InfoStatementReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.NodeRuleCheckOperation"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993334181113",
+            "name": "InfoStatementReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.IRuleReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333631257",
+            "name": "MockScopeProvider",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333631257/2153278993333648147",
+                    "name": "entries",
+                    "type": "jetbrains.mps.lang.test.ScopeEntry",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333631257/2153278993334044549",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.core.BaseConcept",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333648098",
+            "name": "ScopeEntry",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333648098/2153278993333648101",
+                    "name": "nodes",
+                    "type": "jetbrains.mps.lang.test.NamedNodeReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333648098/2153278993333851780",
+                    "name": "kind",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333862929",
+            "name": "NamedNodeReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/2153278993333862929/2153278993333862930",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.core.INamedConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1517788251554588461",
+            "name": "INodesTestMethod",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.unitTest.ITestMethod"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/592868908271422361",
+            "name": "IsIntentionApplicableExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/592868908271422361/592868908271422362",
+                    "name": "intention",
+                    "type": "jetbrains.mps.lang.intentions.IntentionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5476670926298696679",
+            "name": "MigrationTestCase",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5476670926298696679/5476670926298696680",
+                    "name": "inputNodes",
+                    "type": "jetbrains.mps.lang.test.TestNode",
+                    "multiple": true
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5476670926298696679/5476670926298698900",
+                    "name": "outputNodes",
+                    "type": "jetbrains.mps.lang.test.TestNode",
+                    "multiple": true
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5476670926298696679/6626913010124294914",
+                    "name": "migration",
+                    "type": "jetbrains.mps.lang.test.MigrationReference",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5476670926298696679/6109541130560499583",
+                    "name": "option",
+                    "type": "jetbrains.mps.lang.test.MigrationTestOption",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5476670926298696679/5476670926298698915",
+                    "name": "migration_old",
+                    "type": "jetbrains.mps.lang.migration.IMigrationUnit"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.baseLanguage.unitTest.ITestCase",
+                "jetbrains.mps.baseLanguage.unitTest.ITestMethod",
+                "jetbrains.mps.lang.test.TestProjectAware",
+                "jetbrains.mps.lang.core.ImplementationPart"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2325284917965760583",
+            "name": "BeforeTestsMethod",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2325284917965760584",
+            "name": "AfterTestsMethod",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/6626913010124185481",
+            "name": "MigrationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/6626913010124185481/6626913010124185482",
+                    "name": "migration",
+                    "type": "jetbrains.mps.lang.migration.IMigrationUnit",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/813341629406803928",
+            "name": "IsActionApplicableExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/813341629406803928/813341629406803930",
+                    "name": "actionReference",
+                    "type": "jetbrains.mps.lang.test.ActionReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1227269295333560277",
+            "name": "InvokeSurroundWithIntentionStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/1227269295333560277/1227269295333560280",
+                    "name": "intention",
+                    "type": "jetbrains.mps.lang.intentions.SurroundWithIntentionDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/6109541130559846558",
+            "name": "MigrationTestOption",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/6109541130560494643",
+            "name": "IgnoreMigrationDataOption",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.MigrationTestOption"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/1225972903834011965",
+            "name": "ITestAnnotationsContainer",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/710597951278798236",
+            "name": "ExpectedMessageContainer",
+            "properties": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/710597951278798236/710597951278798237",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/4649457259824807647",
+            "name": "TypesystemEquationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.test.IRuleReference"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/6410786926916602977",
+            "name": "StableIdOption",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.test.MigrationTestOption"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/5266358701722203952",
+            "name": "ApplyQuickFix",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "8585453e-6bfb-4d80-98de-b16074f1d86c/5266358701722203952/7668795378453884311",
+                    "name": "quickfix",
+                    "type": "jetbrains.mps.lang.typesystem.TypesystemIntention"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:8585453e-6bfb-4d80-98de-b16074f1d86c/2291269767871117666",
+            "name": "TestProjectAware",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.text.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.text.json
@@ -1,0 +1,360 @@
+{
+    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8",
+    "name": "jetbrains.mps.lang.text",
+    "concepts": [
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482919",
+            "name": "TextElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482948",
+            "name": "Word",
+            "properties": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482948/155656958578482949",
+                    "name": "value"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482948/6328114375520539774",
+                    "name": "bold",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482948/6328114375520539777",
+                    "name": "italic",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482948/6328114375520539796",
+                    "name": "underlined",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/155656958578482948/6328114375520539781",
+                    "name": "url"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.TextElement"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/2535923850359206929",
+            "name": "Text",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/2535923850359206929/9143182410139490168",
+                    "name": "paragraphs",
+                    "type": "jetbrains.mps.lang.text.Paragraph",
+                    "multiple": true
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/2535923850359206929/2535923850359210936",
+                    "name": "lines",
+                    "type": "jetbrains.mps.lang.text.Line",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.IPlaceholderContent",
+                "jetbrains.mps.lang.text.IHoldParagraphs",
+                "jetbrains.mps.lang.text.IHoldLines"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/2535923850359271782",
+            "name": "Line",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/2535923850359271782/2535923850359271783",
+                    "name": "elements",
+                    "type": "jetbrains.mps.lang.text.TextElement",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/3133179214568824809",
+            "name": "NodeWrapperElement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/3133179214568824809/3133179214568824810",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.TextElement",
+                "jetbrains.mps.lang.core.ISkipConstraintsChecking",
+                "jetbrains.mps.lang.core.IDontApplyTypesystemRules"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/7723470226553559158",
+            "name": "IHoldLines",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/3213792450771277985",
+            "name": "IHoldParagraphs",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/3213792450771274575",
+            "name": "NodeWrapperTextualElement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/3213792450771274575/3133179214568824810",
+                    "name": "node",
+                    "type": "jetbrains.mps.lang.core.BaseConcept"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.TextualElement",
+                "jetbrains.mps.lang.core.ISkipConstraintsChecking",
+                "jetbrains.mps.lang.core.IDontApplyTypesystemRules"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/1711399190456599627",
+            "name": "EmptyParagraphLetter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.TextualElement"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/3213792450771262715",
+            "name": "TextualElement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139364510",
+            "name": "Paragraph",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139364510/9143182410139364831",
+                    "name": "letters",
+                    "type": "jetbrains.mps.lang.text.TextualElement",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.text.IParagraph"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139347997",
+            "name": "Letter",
+            "properties": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139347997/9143182410139348382",
+                    "name": "value"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139347997/9189109070801631040",
+                    "name": "bold",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139347997/9189109070801631041",
+                    "name": "italic",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/9143182410139347997/9189109070801631042",
+                    "name": "underlined",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.TextualElement"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/8331485905611916945",
+            "name": "UrlTextualElement",
+            "properties": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/8331485905611916945/8331485905611918806",
+                    "name": "address"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/8331485905611916945/1491601438747373469",
+                    "name": "text",
+                    "type": "jetbrains.mps.lang.text.Paragraph",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.TextualElement",
+                "jetbrains.mps.lang.text.IHoldParagraphs"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/3129707072769384643",
+            "name": "BulletPoint",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.Paragraph",
+                "jetbrains.mps.lang.text.IndentedPoint"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/5106752179536586436",
+            "name": "IndentedPoint",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "c7fb639f-be78-4307-89b0-b5959c3fa8c8/5106752179536586436/5106752179536586491",
+                    "name": "indentation",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/6746006958027317995",
+            "name": "NumberedPoint",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.Paragraph",
+                "jetbrains.mps.lang.text.IndentedPoint"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/1709185132815339215",
+            "name": "IParagraph",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/1094247804558289146",
+            "name": "BulletLine",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.Line",
+                "jetbrains.mps.lang.text.IndentedPoint"
+            ]
+        },
+        {
+            "uid": "mps:c7fb639f-be78-4307-89b0-b5959c3fa8c8/6934061334344388674",
+            "name": "NumberedLine",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.text.Line",
+                "jetbrains.mps.lang.text.IndentedPoint"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.textGen.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.textGen.json
@@ -1,0 +1,747 @@
+{
+    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253",
+    "name": "jetbrains.mps.lang.textGen",
+    "concepts": [
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145",
+            "name": "ConceptTextGenDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/7991274449437422201",
+                    "name": "extension",
+                    "type": "jetbrains.mps.lang.textGen.ExtensionDeclaration"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/1224137887853744062",
+                    "name": "encoding",
+                    "type": "jetbrains.mps.lang.textGen.EncodingDeclarationBase"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/1233749296504",
+                    "name": "textGenBlock",
+                    "type": "jetbrains.mps.lang.textGen.GenerateTextDeclaration"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/45307784116711884",
+                    "name": "filename",
+                    "type": "jetbrains.mps.lang.textGen.FilenameFunction"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/7844911294523354450",
+                    "name": "filePath",
+                    "type": "jetbrains.mps.lang.textGen.FilePathSpec"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/3147320813467893228",
+                    "name": "layout",
+                    "type": "jetbrains.mps.lang.textGen.TextUnitLayout"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/2160817178329904672",
+                    "name": "contextObjects",
+                    "type": "jetbrains.mps.lang.textGen.UnitContextObject",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233670071145/1233670257997",
+                    "name": "conceptDeclaration",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractTextGenDeclaration",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233748055915",
+            "name": "NodeParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractTextGenParameter"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233749247888",
+            "name": "GenerateTextDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233751620748",
+            "name": "SimpleTextGenOperation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233752719417",
+            "name": "IncreaseDepthOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.SimpleTextGenOperation"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233752780875",
+            "name": "DecreaseDepthOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.SimpleTextGenOperation"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233920501193",
+            "name": "IndentBufferOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.SimpleTextGenOperation"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233921373471",
+            "name": "LanguageTextGenDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233921373471/1233922432965",
+                    "name": "operation",
+                    "type": "jetbrains.mps.lang.textGen.OperationDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233921373471/1234526822589",
+                    "name": "function",
+                    "type": "jetbrains.mps.lang.textGen.UtilityMethodDeclaration",
+                    "multiple": true
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233921373471/3996543181682114090",
+                    "name": "contextObjects",
+                    "type": "jetbrains.mps.lang.textGen.UnitContextDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233921373471/1234781160172",
+                    "name": "baseTextGen",
+                    "type": "jetbrains.mps.lang.textGen.LanguageTextGenDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractTextGenDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233922353619",
+            "name": "OperationDeclaration",
+            "properties": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233922353619/1234264079341",
+                    "name": "operationName"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration",
+                "jetbrains.mps.lang.core.ImplementationWithStubPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233924848298",
+            "name": "OperationCall",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233924848298/1234191323697",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1233924848298/1234190664409",
+                    "name": "function",
+                    "type": "jetbrains.mps.lang.textGen.OperationDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234281982537",
+            "name": "AbstractTextGenDeclaration",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234524838116",
+            "name": "UtilityMethodDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.BaseMethodDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234529062040",
+            "name": "UtilityMethodCall",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234529062040/1234529174917",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234529062040/1234529163244",
+                    "name": "function",
+                    "type": "jetbrains.mps.lang.textGen.UtilityMethodDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234794705341",
+            "name": "FoundErrorOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234794705341/1237470722868",
+                    "name": "text",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1234884991117",
+            "name": "AbstractTextGenParameter",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1236188139846",
+            "name": "WithIndentOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1236188139846/1236188238861",
+                    "name": "list",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305115734",
+            "name": "AbstractAppendPart",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305208784",
+            "name": "NewLineAppendPart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305334312",
+            "name": "NodeAppendPart",
+            "properties": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305334312/1237306318654",
+                    "name": "withIndent",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305334312/1237305790512",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305491868",
+            "name": "CollectionAppendPart",
+            "properties": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305491868/1237306003719",
+                    "name": "separator"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305491868/1237983969951",
+                    "name": "withSeparator",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305491868/1237305945551",
+                    "name": "list",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305557638",
+            "name": "ConstantStringAppendPart",
+            "properties": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305557638/1237305576108",
+                    "name": "value"
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237305557638/1237306361677",
+                    "name": "withIndent",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237306079178",
+            "name": "AppendOperation",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237306079178/1237306115446",
+                    "name": "part",
+                    "type": "jetbrains.mps.lang.textGen.AbstractAppendPart",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/1237306079178/3135747254706172356",
+                    "name": "textArea",
+                    "type": "jetbrains.mps.lang.textGen.LayoutPart"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/8931911391946696733",
+            "name": "ExtensionDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/7166719696753421196",
+            "name": "EncodingLiteral",
+            "properties": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/7166719696753421196/7166719696753421197",
+                    "name": "encoding"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.textGen.EncodingDeclarationBase"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1224137887853744019",
+            "name": "EncodingDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.textGen.EncodingDeclarationBase"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/1224137887853744059",
+            "name": "EncodingDeclarationBase",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/45307784116571022",
+            "name": "FilenameFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3147100357551177019",
+            "name": "StubOperationDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.OperationDeclaration",
+                "jetbrains.mps.lang.core.ISuppressErrors",
+                "jetbrains.mps.lang.core.IStubForAnotherConcept"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/8937790975493363649",
+            "name": "AttributedNodePart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/4357423944233036906",
+            "name": "IndentPart",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.AbstractAppendPart"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3147320813467893193",
+            "name": "TextUnitLayout",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3147320813467893193/3147320813467893195",
+                    "name": "parts",
+                    "type": "jetbrains.mps.lang.textGen.LayoutPart",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3147320813467893193/3147320813467893197",
+                    "name": "active",
+                    "type": "jetbrains.mps.lang.textGen.LayoutPart",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3147320813467893194",
+            "name": "LayoutPart",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3147320813467893194/3147320813467893202",
+                    "name": "nested",
+                    "type": "jetbrains.mps.lang.textGen.LayoutPart",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682044537",
+            "name": "UnitContextDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682044537/3996543181682044542",
+                    "name": "type",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                },
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682044537/3996543181682151544",
+                    "name": "instance",
+                    "type": "jetbrains.mps.lang.textGen.ContextInstanceSpecification",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682072193",
+            "name": "UnitContextReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682072193/3996543181682072194",
+                    "name": "context",
+                    "type": "jetbrains.mps.lang.textGen.UnitContextDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682151538",
+            "name": "ContextInstanceSpecification",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682151539",
+            "name": "ClassConceptUnitContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/3996543181682151539/3996543181682151542",
+                    "name": "classifier",
+                    "type": "jetbrains.mps.baseLanguage.ClassConcept",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.textGen.ContextInstanceSpecification"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/2160817178329904683",
+            "name": "InstancePerUnitContextObject",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.textGen.UnitContextObject"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/2160817178329904684",
+            "name": "UnitContextObject",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "b83431fe-5c8f-40bc-8a36-65e25f4dd253/2160817178329904684/2160817178329904685",
+                    "name": "context",
+                    "type": "jetbrains.mps.lang.textGen.UnitContextDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/7844911294523354449",
+            "name": "FilePathSpec",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:b83431fe-5c8f-40bc-8a36-65e25f4dd253/7844911294523361055",
+            "name": "FilePathQuery",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction",
+                "jetbrains.mps.lang.textGen.FilePathSpec"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.traceable.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.traceable.json
@@ -1,0 +1,45 @@
+{
+    "uid": "9ded098b-ad6a-4657-bfd9-48636cfe8bc3",
+    "name": "jetbrains.mps.lang.traceable",
+    "concepts": [
+        {
+            "uid": "mps:9ded098b-ad6a-4657-bfd9-48636cfe8bc3/5067982036267369890",
+            "name": "ScopeConcept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:9ded098b-ad6a-4657-bfd9-48636cfe8bc3/5067982036267369891",
+            "name": "TraceableConcept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:9ded098b-ad6a-4657-bfd9-48636cfe8bc3/5067982036267369892",
+            "name": "UnitConcept",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.typesystem.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.typesystem.json
@@ -1,0 +1,2286 @@
+{
+    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2",
+    "name": "jetbrains.mps.lang.typesystem",
+    "concepts": [
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174642743670",
+            "name": "ApplicableNodeCondition",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174642788531",
+            "name": "ConceptReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174642788531/1174642800329",
+                    "name": "concept",
+                    "type": "jetbrains.mps.lang.structure.AbstractConceptDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.ApplicableNodeCondition"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174642900584",
+            "name": "PatternCondition",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174642900584/1174642936809",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.pattern.PatternExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.ApplicableNodeCondition"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174643105530",
+            "name": "InferenceRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174643105530/7307171874933775112",
+                    "name": "supersedesFun",
+                    "type": "jetbrains.mps.lang.typesystem.SupersedeConceptFunction"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174643105530/7391008184910266275",
+                    "name": "applicableFun",
+                    "type": "jetbrains.mps.lang.typesystem.IsApplicableConceptFunction"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174643105530/422148324487088858",
+                    "name": "overridesFun",
+                    "type": "jetbrains.mps.lang.typesystem.OverridesConceptFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractCheckingRule",
+                "jetbrains.mps.lang.typesystem.IRuleWithOneNode"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174648085619",
+            "name": "AbstractRule",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174648085619/1174648101952",
+                    "name": "applicableNode",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier",
+                "jetbrains.mps.lang.structure.IConceptAspect"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174650418652",
+            "name": "ApplicableNodeReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174650418652/1174650432090",
+                    "name": "applicableNode",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174657487114",
+            "name": "TypeOfExpression",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174657487114/1195058053095",
+                    "name": "skipDependencyOnCurrent",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174657487114/1174657509053",
+                    "name": "term",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174658326157",
+            "name": "CreateEquationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractEquationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586",
+            "name": "AbstractEquationStatement",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586/1206359757216",
+                    "name": "checkOnly",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586/1174660783413",
+                    "name": "leftExpression",
+                    "type": "jetbrains.mps.lang.typesystem.TypeClause",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586/1174660783414",
+                    "name": "rightExpression",
+                    "type": "jetbrains.mps.lang.typesystem.TypeClause",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586/1174662598553",
+                    "name": "nodeToCheck",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586/1180447237840",
+                    "name": "errorString",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174660718586/1216204483513",
+                    "name": "helginsIntention",
+                    "type": "jetbrains.mps.lang.typesystem.TypesystemIntention",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.typesystem.MessageStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174663118805",
+            "name": "CreateLessThanInequationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractInequationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174663239020",
+            "name": "CreateGreaterThanInequationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractInequationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174663314467",
+            "name": "CreateComparableEquationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractComparableStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174665551739",
+            "name": "TypeVarDeclaration",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174665551739/1174665590537",
+                    "name": "nullable",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174666260556",
+            "name": "TypeVarReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174666260556/1174666276259",
+                    "name": "typeVarDeclaration",
+                    "type": "jetbrains.mps.lang.typesystem.TypeVarDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression",
+                "jetbrains.mps.lang.core.ISuppressErrors"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174989242422",
+            "name": "PatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174989242422/1174989274720",
+                    "name": "patternVarDecl",
+                    "type": "jetbrains.mps.lang.pattern.PatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174989777619",
+            "name": "LinkPatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174989777619/1174989841903",
+                    "name": "patternVarDecl",
+                    "type": "jetbrains.mps.lang.pattern.LinkPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174989799417",
+            "name": "PropertyPatternVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1174989799417/1174989822012",
+                    "name": "patternVarDecl",
+                    "type": "jetbrains.mps.lang.pattern.PropertyPatternVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175147569072",
+            "name": "AbstractSubtypingRule",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175147569072/1175607673137",
+                    "name": "isWeak",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175147569072/1175147624276",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractRule",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175147670730",
+            "name": "SubtypingRule",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractSubtypingRule",
+                "jetbrains.mps.lang.typesystem.IRuleWithOneNode"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175517400280",
+            "name": "AssertStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175517400280/1175517761460",
+                    "name": "condition",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.ReportErrorStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175517767210",
+            "name": "ReportErrorStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175517767210/1175517851849",
+                    "name": "errorString",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractReportStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1175594888091",
+            "name": "TypeCheckerAccessExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176543928247",
+            "name": "IsSubtypeExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176543928247/1176543945045",
+                    "name": "subtypeExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176543928247/1176543950311",
+                    "name": "supertypeExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176544042499",
+            "name": "Node_TypeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176558773329",
+            "name": "CoerceStatement",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176558773329/4614734314076988359",
+                    "name": "strong"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176558773329/1176558876970",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176558773329/1176558919376",
+                    "name": "nodeToCoerce",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176558773329/1176558868203",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1176558773329/1220447035659",
+                    "name": "elseClause",
+                    "type": "jetbrains.mps.baseLanguage.StatementList"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177068340529",
+            "name": "ImmediateSupertypesExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177068340529/1177068475017",
+                    "name": "subtypeExpression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177406296561",
+            "name": "IsStrongSubtypeExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.IsSubtypeExpression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514343197",
+            "name": "MatchStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514343197/1177514369598",
+                    "name": "expression",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514343197/1177514347409",
+                    "name": "item",
+                    "type": "jetbrains.mps.lang.typesystem.MatchStatementItem",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514343197/1177514345236",
+                    "name": "ifFalseStatement",
+                    "type": "jetbrains.mps.baseLanguage.Statement"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514840044",
+            "name": "MatchStatementItem",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514840044/1177514849858",
+                    "name": "condition",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1177514840044/1177514864202",
+                    "name": "ifTrue",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1178870617262",
+            "name": "CoerceExpression",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1178870617262/7739208407757214262",
+                    "name": "strong"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1178870617262/1178870894644",
+                    "name": "pattern",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1178870617262/1178870894645",
+                    "name": "nodeToCoerce",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1178871491133",
+            "name": "CoerceStrongExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.CoerceExpression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1179479408386",
+            "name": "JoinType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1179479408386/1179479418730",
+                    "name": "argument",
+                    "type": "jetbrains.mps.lang.core.IType",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.IType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1179832490862",
+            "name": "CreateStrongLessThanInequationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractInequationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1180099659756",
+            "name": "CreateComparableEquationStatementStrong",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractComparableStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185281562361",
+            "name": "RuntimeErrorType",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185281562361/1185281562362",
+                    "name": "errorText"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185281562361/1186047920810",
+                    "name": "nodeId"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185281562361/1186047931404",
+                    "name": "nodeModel"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.RuntimeTypeVariable"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185281562363",
+            "name": "RuntimeTypeVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185788561607",
+            "name": "TypeClause",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185788614172",
+            "name": "NormalTypeClause",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185788614172/1185788644032",
+                    "name": "normalType",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.TypeClause"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213",
+            "name": "WhenConcreteStatement",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213/1227279857428",
+                    "name": "isShallow",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213/1233571207619",
+                    "name": "skipsError",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213/1185805047793",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213/1185805056450",
+                    "name": "argument",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213/1205761991995",
+                    "name": "argumentRepresentator",
+                    "type": "jetbrains.mps.lang.typesystem.WhenConcreteVariableDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1185805035213/8755047172977267646",
+                    "name": "warning",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.baseLanguage.IControlFlowInterrupter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1188473524530",
+            "name": "MeetType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1188473524530/1188473537547",
+                    "name": "argument",
+                    "type": "jetbrains.mps.lang.core.IType",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.IType",
+                "jetbrains.mps.baseLanguage.IGenericType"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1188811367543",
+            "name": "ComparisonRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1188811367543/1188820750135",
+                    "name": "anotherNode",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractSubtypingRule",
+                "jetbrains.mps.lang.typesystem.IRuleWithTwoNodes"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195213580585",
+            "name": "AbstractCheckingRule",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195213580585/1195213689297",
+                    "name": "overrides",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195213580585/1195213635060",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195213580585/1766949807893591548",
+                    "name": "overridesFun_old",
+                    "type": "jetbrains.mps.lang.typesystem.OverridesConceptFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractRule",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195214364922",
+            "name": "NonTypesystemRule",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195214364922/7181286126212894140",
+                    "name": "doNotApplyOnTheFly",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1195214364922/2329696648448631592",
+                    "name": "overridenRules",
+                    "type": "jetbrains.mps.lang.typesystem.CheckingRuleReference",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractCheckingRule",
+                "jetbrains.mps.lang.typesystem.IRuleWithOneNode",
+                "jetbrains.mps.lang.core.ScopeProvider"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1201607707634",
+            "name": "InequationReplacementRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1201607707634/1201607798918",
+                    "name": "supertypeNode",
+                    "type": "jetbrains.mps.lang.typesystem.ApplicableNodeCondition",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1201607707634/3592071576955708909",
+                    "name": "isApplicableClause",
+                    "type": "jetbrains.mps.lang.typesystem.IsReplacementRuleApplicable_ConceptFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractSubtypingRule",
+                "jetbrains.mps.lang.typesystem.IRuleWithTwoNodes"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1201618299781",
+            "name": "ErrorInfoExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1203424364259",
+            "name": "RuntimeListVariable",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1205762105978",
+            "name": "WhenConcreteVariableDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.VariableDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1205762656241",
+            "name": "WhenConcreteVariableReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1205762656241/1205762683928",
+                    "name": "whenConcreteVar",
+                    "type": "jetbrains.mps.lang.typesystem.WhenConcreteVariableDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1207055528241",
+            "name": "WarningStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1207055528241/1207055552304",
+                    "name": "warningText",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractReportStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784285454",
+            "name": "TypesystemIntention",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784285454/1216127910019",
+                    "name": "applyImmediately",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784285454/1210784493590",
+                    "name": "actualArgument",
+                    "type": "jetbrains.mps.lang.typesystem.TypesystemIntentionArgument",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784285454/1216388525179",
+                    "name": "quickFix",
+                    "type": "jetbrains.mps.lang.typesystem.TypesystemQuickFix",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784384552",
+            "name": "TypesystemIntentionArgument",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784384552/1210784642750",
+                    "name": "value",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1210784384552/1216386999476",
+                    "name": "quickFixArgument",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixArgument",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426",
+            "name": "AbstractInequationStatement",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/1212056105818",
+                    "name": "inequationPriority"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/4778346850551686273",
+                    "name": "label"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/7739208407757103785",
+                    "name": "strong"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/7739208407757103786",
+                    "name": "orientation"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/4778346850551695629",
+                    "name": "afterEquations",
+                    "type": "jetbrains.mps.lang.typesystem.InequationReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/4778346850551695630",
+                    "name": "beforeEquations",
+                    "type": "jetbrains.mps.lang.typesystem.InequationReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/1320713984677672382",
+                    "name": "afterGroups",
+                    "type": "jetbrains.mps.lang.typesystem.DefaultGroupReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/1320713984677672383",
+                    "name": "beforeGroups",
+                    "type": "jetbrains.mps.lang.typesystem.DefaultGroupReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1212056081426/1320713984677695199",
+                    "name": "inequationGroup",
+                    "type": "jetbrains.mps.lang.typesystem.DefaultGroupReference"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractEquationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383170661",
+            "name": "TypesystemQuickFix",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383170661/1216383424566",
+                    "name": "executeBlock",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixExecuteBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383170661/1216391046856",
+                    "name": "descriptionBlock",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixDescriptionBlock"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383170661/3701925705266318823",
+                    "name": "setSelectionBlock",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixSetSelectionBlock"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383170661/1216383476350",
+                    "name": "quickFixArgument",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixArgument",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383170661/8090891477833133023",
+                    "name": "quickFixField",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixField",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.baseLanguage.IValidIdentifier"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383287005",
+            "name": "QuickFixExecuteBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383337216",
+            "name": "ConceptFunctionParameter_node",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383482742",
+            "name": "QuickFixArgument",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216383482742/1216383511839",
+                    "name": "argumentType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216390348809",
+            "name": "QuickFixArgumentReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216390348809/1216390348810",
+                    "name": "quickFixArgument",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixArgument",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1216390987552",
+            "name": "QuickFixDescriptionBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1220357310820",
+            "name": "AddDependencyStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1220357310820/1220357350423",
+                    "name": "dependency",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1223381117053",
+            "name": "Processed",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1224760201579",
+            "name": "InfoStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1224760201579/1224760230762",
+                    "name": "infoText",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractReportStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096479619",
+            "name": "MessageTarget",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096498176",
+            "name": "PropertyMessageTarget",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096498176/1227096521710",
+                    "name": "propertyDeclaration",
+                    "type": "jetbrains.mps.lang.structure.PropertyDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageTarget"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096620180",
+            "name": "ReferenceMessageTarget",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096620180/1227096645744",
+                    "name": "linkDeclaration",
+                    "type": "jetbrains.mps.lang.structure.LinkDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageTarget"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096774658",
+            "name": "MessageStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096774658/1227096802790",
+                    "name": "nodeToReport_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096774658/1227096802791",
+                    "name": "helginsIntention_old",
+                    "type": "jetbrains.mps.lang.typesystem.TypesystemIntention",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096774658/1227096836496",
+                    "name": "messageTarget_old",
+                    "type": "jetbrains.mps.lang.typesystem.MessageTarget"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227096774658/4008603303335354465",
+                    "name": "foreignMessageSource_old",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227107274859",
+            "name": "PropertyNameTarget",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227107274859/1227107356659",
+                    "name": "propertySpec",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageTarget"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227107461373",
+            "name": "ReferenceRoleTarget",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1227107461373/1227107481107",
+                    "name": "referenceRole",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageTarget"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228481911130",
+            "name": "VariableConverterItem",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228481911130/1228482339775",
+                    "name": "applicableBlock",
+                    "type": "jetbrains.mps.lang.typesystem.VariableConverterItem_ApplicableBlock",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228481911130/1228482335255",
+                    "name": "convertBlock",
+                    "type": "jetbrains.mps.lang.typesystem.VariableConverterItem_ConvertBlock",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228482344443",
+            "name": "VariableConverterItem_ApplicableBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228482485159",
+            "name": "ConceptFunctionParameter_var",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228482578363",
+            "name": "VariableConverterItem_ConvertBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228482838236",
+            "name": "VariableConvertersContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228482838236/1228482919686",
+                    "name": "converterItem",
+                    "type": "jetbrains.mps.lang.typesystem.VariableConverterItem",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228487409934",
+            "name": "ConceptFunctionParameter_Role",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228487445949",
+            "name": "ConceptFunctionParameter_isAggregation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1228487523202",
+            "name": "ConceptFunctionParameter_ContextNode",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1230113867585",
+            "name": "RuntimeHoleType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311",
+            "name": "OverloadedOperatorTypeRule",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311/1236771579180",
+                    "name": "leftIsExact",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311/1236771585835",
+                    "name": "rightIsExact",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311/4888149946184983007",
+                    "name": "rightIsStrong",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311/4888149946184983008",
+                    "name": "leftIsStrong",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311/1236083115043",
+                    "name": "leftOperandType",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083041311/1236083115200",
+                    "name": "rightOperandType",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractOverloadedOpsTypeRule"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083146670",
+            "name": "OverloadedOperatorTypeFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083209648",
+            "name": "LeftOperandType_parameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083245720",
+            "name": "Operation_parameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236083248858",
+            "name": "RightOperandType_parameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236163200695",
+            "name": "GetOperationType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236163200695/1236163216864",
+                    "name": "operation",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236163200695/1236163223573",
+                    "name": "leftOperandType",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236163200695/1236163223950",
+                    "name": "rightOperandType",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236165709895",
+            "name": "OverloadedOpRulesContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1236165709895/1236165725858",
+                    "name": "rule",
+                    "type": "jetbrains.mps.lang.typesystem.AbstractOverloadedOpsTypeRule",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1238776677112",
+            "name": "MeetContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1238776677112/1238776691632",
+                    "name": "meetType",
+                    "type": "jetbrains.mps.lang.typesystem.MeetType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1238776816380",
+            "name": "JoinContainer",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/1238776816380/1238776828104",
+                    "name": "joinType",
+                    "type": "jetbrains.mps.lang.typesystem.JoinType",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370766044",
+            "name": "OverloadedOpTypeRule_OneTypeSpecified",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370766044/8124453027370766045",
+                    "name": "isExact",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370766044/2885635457272624477",
+                    "name": "isStrong",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370766044/8124453027370845366",
+                    "name": "operandType",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractOverloadedOpsTypeRule"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370845339",
+            "name": "AbstractOverloadedOpsTypeRule",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370845339/8124453027370845341",
+                    "name": "operationConcept",
+                    "type": "jetbrains.mps.lang.smodel.ConceptReference",
+                    "multiple": true,
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370845339/8124453027370845343",
+                    "name": "function",
+                    "type": "jetbrains.mps.lang.typesystem.OverloadedOperatorTypeFunction",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8124453027370845339/6136676636349909553",
+                    "name": "isApplicable",
+                    "type": "jetbrains.mps.lang.typesystem.OverloadedOpIsApplicableFunction"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/3592071576955708904",
+            "name": "IsReplacementRuleApplicable_ConceptFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/4778346850551666963",
+            "name": "InequationReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/4778346850551666963/4778346850551666964",
+                    "name": "inequation",
+                    "type": "jetbrains.mps.lang.typesystem.AbstractInequationStatement",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1320713984677695202",
+            "name": "DefaultGroupReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/6359146168314178663",
+            "name": "Node_InferTypeOperation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.smodel.SNodeOperation"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/2990591960991114251",
+            "name": "OriginalNodeId",
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/2990591960991114251/2990591960991114264",
+                    "name": "nodeId"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/2990591960991114251/2990591960991114295",
+                    "name": "modelId"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/6136676636349908958",
+            "name": "OverloadedOpIsApplicableFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/3701925705266317933",
+            "name": "QuickFixSetSelectionBlock",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/3701925705266318588",
+            "name": "ConceptFunctionParameter_EditorContext",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/8090891477833017662",
+            "name": "QuickFixField",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8090891477833017662/8090891477833017663",
+                    "name": "fieldType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/8090891477833069917",
+            "name": "QuickFixFieldReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/8090891477833069917/8090891477833069918",
+                    "name": "quickFixField",
+                    "type": "jetbrains.mps.lang.typesystem.QuickFixField",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/6998169140110894792",
+            "name": "SelectionType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/6998169140110925844",
+            "name": "ConceptFunctionParameter_Selection",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/4484478261143582584",
+            "name": "IRuleWithOneNode",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/4484478261143582585",
+            "name": "IRuleWithTwoNodes",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/3585736512129529703",
+            "name": "CreateStrongGreaterThanInequationStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractInequationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/4315056782306262711",
+            "name": "AbstractComparableStatement",
+            "abstract": true,
+            "properties": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/4315056782306262711/4315056782306320180",
+                    "name": "infer",
+                    "type": "BOOLEAN"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractEquationStatement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/838715195501404652",
+            "name": "OrStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/838715195501404652/6448384028752696700",
+                    "name": "orClause",
+                    "type": "jetbrains.mps.lang.typesystem.AbstractEquationStatement",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/534601184072080872",
+            "name": "PrintToTrace",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/534601184072080872/4251858506886491408",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/3148295837107269752",
+            "name": "MessageStatementAnnotation",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.NodeAttribute",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/7992060018732187438",
+            "name": "ReportErrorStatementAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageStatementAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/7992060018732187441",
+            "name": "InfoStatementAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageStatementAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/7992060018732187444",
+            "name": "WarningStatementAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageStatementAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/6405009306797516074",
+            "name": "SubstituteTypeRule",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/6405009306797516074/7323318266641100480",
+                    "name": "body",
+                    "type": "jetbrains.mps.baseLanguage.StatementList",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.AbstractRule",
+                "jetbrains.mps.lang.typesystem.IRuleWithOneNode",
+                "jetbrains.mps.baseLanguage.IMethodLike",
+                "jetbrains.mps.lang.core.InterfacePart"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/1766949807893567867",
+            "name": "OverridesConceptFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/2401040147804061830",
+            "name": "AttributedNodeExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/7307171874933646339",
+            "name": "SupersedeConceptFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/7391008184910224767",
+            "name": "IsApplicableConceptFunction",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/2329696648445392942",
+            "name": "CheckingRuleReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/2329696648445392942/2329696648445392943",
+                    "name": "declaration",
+                    "type": "jetbrains.mps.lang.typesystem.NonTypesystemRule",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/4649457259824694112",
+            "name": "TypesystemEquationStatementAnnotation",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.typesystem.MessageStatementAnnotation"
+            ]
+        },
+        {
+            "uid": "mps:7a5dda62-9140-4668-ab76-d5ed1746f2b2/3937244445246642777",
+            "name": "AbstractReportStatement",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/3937244445246642777/3937244445246642781",
+                    "name": "nodeToReport",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/3937244445246642777/3937244445246643221",
+                    "name": "helginsIntention",
+                    "type": "jetbrains.mps.lang.typesystem.TypesystemIntention",
+                    "multiple": true
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/3937244445246642777/3937244445246643443",
+                    "name": "messageTarget",
+                    "type": "jetbrains.mps.lang.typesystem.MessageTarget"
+                },
+                {
+                    "uid": "7a5dda62-9140-4668-ab76-d5ed1746f2b2/3937244445246642777/3937244445246643666",
+                    "name": "foreignMessageSource",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement",
+                "jetbrains.mps.lang.typesystem.MessageStatement"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.util.order.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.lang.util.order.json
@@ -1,0 +1,94 @@
+{
+    "uid": "c9d137c4-3259-44f8-80ff-33ab2b506ee4",
+    "name": "jetbrains.mps.lang.util.order",
+    "concepts": [
+        {
+            "uid": "mps:c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534683975",
+            "name": "OrderDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534683975/2450897840534683977",
+                    "name": "seq",
+                    "type": "jetbrains.mps.lang.util.order.OrderParticipantReference",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.util.order.Order",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534683973",
+            "name": "Order",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534688273",
+            "name": "OrderReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534688273/2450897840534688274",
+                    "name": "order",
+                    "type": "jetbrains.mps.lang.util.order.OrderDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.util.order.Order"
+            ]
+        },
+        {
+            "uid": "mps:c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534683979",
+            "name": "OrderParticipantReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "c9d137c4-3259-44f8-80ff-33ab2b506ee4/2450897840534683979/2450897840534683980",
+                    "name": "target",
+                    "type": "jetbrains.mps.lang.util.order.OrderParticipant",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:c9d137c4-3259-44f8-80ff-33ab2b506ee4/2343319097655214556",
+            "name": "OrderParticipant",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.make.facet.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.make.facet.json
@@ -1,0 +1,413 @@
+{
+    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0",
+    "name": "jetbrains.mps.make.facet",
+    "concepts": [
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029521",
+            "name": "IFacet",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029523",
+            "name": "FacetDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029523/6447445394688422654",
+                    "name": "extended",
+                    "type": "jetbrains.mps.make.facet.ExtendsFacetReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029523/6447445394688422656",
+                    "name": "required",
+                    "type": "jetbrains.mps.make.facet.RelatedFacetReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029523/6447445394688422657",
+                    "name": "optional",
+                    "type": "jetbrains.mps.make.facet.RelatedFacetReference",
+                    "multiple": true
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029523/6418371274763146558",
+                    "name": "targetDeclaration",
+                    "type": "jetbrains.mps.make.facet.TargetDeclaration",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IWillBeClassifier"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565",
+            "name": "TargetDeclaration",
+            "properties": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/1675547159918562088",
+                    "name": "resourcesPolicy"
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/7219266275016360389",
+                    "name": "optional",
+                    "type": "BOOLEAN"
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/184542595914096177",
+                    "name": "weight",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/7320828025189219295",
+                    "name": "parameters",
+                    "type": "jetbrains.mps.make.facet.ParametersDeclaration"
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/6418371274763146553",
+                    "name": "dependency",
+                    "type": "jetbrains.mps.make.facet.TargetDependency",
+                    "multiple": true
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/2360002718792633290",
+                    "name": "job",
+                    "type": "jetbrains.mps.make.script.JobDeclaration",
+                    "optional": false
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/119022571401949664",
+                    "name": "input",
+                    "type": "jetbrains.mps.make.facet.ResourceTypeDeclaration"
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/119022571401949665",
+                    "name": "output",
+                    "type": "jetbrains.mps.make.facet.ResourceTypeDeclaration"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029565/6418371274763029589",
+                    "name": "overrides",
+                    "type": "jetbrains.mps.make.facet.TargetDeclaration"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IWillBeClassifier"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029600",
+            "name": "TargetDependency",
+            "properties": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029600/8351679702044326377",
+                    "name": "qualifier"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6418371274763029600/6418371274763029603",
+                    "name": "dependsOn",
+                    "type": "jetbrains.mps.make.facet.TargetDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/6447445394688422642",
+            "name": "FacetReference",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/6447445394688422642/6447445394688422643",
+                    "name": "facet",
+                    "type": "jetbrains.mps.make.facet.FacetDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/6447445394688555033",
+            "name": "ExtendsFacetReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.make.facet.FacetReference"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/8351679702044320297",
+            "name": "RelatedFacetReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.make.facet.FacetReference"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/7320828025189345662",
+            "name": "ParametersDeclaration",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.tuples.NamedTupleDeclaration"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/7320828025189375154",
+            "name": "LocalParametersExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/7320828025189375155",
+            "name": "LocalParametersComponentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.DotExpression",
+                "jetbrains.mps.make.facet.IPropertyExpression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/3344436107830227888",
+            "name": "ForeignParametersExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/3344436107830227888/3344436107830227902",
+                    "name": "target",
+                    "type": "jetbrains.mps.make.facet.TargetDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/3344436107830227889",
+            "name": "ForeignParametersComponentExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.DotExpression",
+                "jetbrains.mps.make.facet.IPropertyExpression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/119022571401949652",
+            "name": "ResourceTypeDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/119022571401949652/119022571401949655",
+                    "name": "resourceType",
+                    "type": "jetbrains.mps.make.facet.ResourceClassifierType",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/119022571402207412",
+            "name": "ResourceClassifierType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ClassifierType"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/7178445679340358576",
+            "name": "FacetReferenceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/7178445679340358576/7178445679340358578",
+                    "name": "reference",
+                    "type": "jetbrains.mps.make.facet.NamedFacetReference",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/1919086248986845077",
+            "name": "NamedFacetReference",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.make.facet.FacetReference"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/2191561637326275574",
+            "name": "ResourceSpecificPropertiesExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/2191561637326275574/2191561637326275575",
+                    "name": "properties",
+                    "type": "jetbrains.mps.make.facet.IPropertyExpression",
+                    "optional": false
+                },
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/2191561637326275574/2191561637326275592",
+                    "name": "resource",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/2191561637326275576",
+            "name": "IPropertyExpression",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/2191561637326275576/8170824575195151990",
+                    "name": "resource",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/8703512757937156087",
+            "name": "TargetReferenceExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/8703512757937156087/8703512757937161134",
+                    "name": "facetRef",
+                    "type": "jetbrains.mps.make.facet.FacetReferenceExpression",
+                    "optional": false
+                }
+            ],
+            "references": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/8703512757937156087/8703512757937161148",
+                    "name": "target",
+                    "type": "jetbrains.mps.make.facet.TargetDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:696c1165-4a59-463b-bc5d-902caab85dd0/1894767564088417428",
+            "name": "FacetJavaClassExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "696c1165-4a59-463b-bc5d-902caab85dd0/1894767564088417428/1894767564088417695",
+                    "name": "facet",
+                    "type": "jetbrains.mps.make.facet.FacetDeclaration",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.make.reduced.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.make.reduced.json
@@ -1,0 +1,6 @@
+{
+    "uid": "b608bb31-cbf1-4d56-a8e8-8fa2f751be68",
+    "name": "jetbrains.mps.make.reduced",
+    "concepts": [
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.make.script.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.make.script.json
@@ -1,0 +1,504 @@
+{
+    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b",
+    "name": "jetbrains.mps.make.script",
+    "concepts": [
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/7077360340906447917",
+            "name": "ResultStatement",
+            "properties": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/7077360340906447917/7077360340906447918",
+                    "name": "result"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/2360002718792446594",
+            "name": "ResourceType",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/2360002718792446594/3308693286243004242",
+                    "name": "classifierType",
+                    "type": "jetbrains.mps.baseLanguage.ClassifierType"
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/2360002718792622184",
+            "name": "OutputResources",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/2360002718792622184/2360002718792622193",
+                    "name": "resource",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/2360002718792625579",
+            "name": "JobDefinition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/2360002718792625580",
+            "name": "InputResourcesParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854368555",
+            "name": "QueryDefinition",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854368555/505095865854384068",
+                    "name": "expected",
+                    "type": "jetbrains.mps.make.script.IExpected",
+                    "optional": false
+                },
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854368555/505095865854429687",
+                    "name": "presentation",
+                    "type": "jetbrains.mps.make.script.Text",
+                    "optional": false
+                },
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854368555/3698730011374153266",
+                    "name": "title",
+                    "type": "jetbrains.mps.make.script.Text",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IWillBeClassifier"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854369479",
+            "name": "QueryParameterDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854369479/505095865854369486",
+                    "name": "parameterType",
+                    "type": "jetbrains.mps.baseLanguage.Type",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854369481",
+            "name": "Option",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854369481/505095865854369483",
+                    "name": "presentation",
+                    "type": "jetbrains.mps.make.script.Text",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.lang.core.INamedConcept"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854369482",
+            "name": "Text",
+            "properties": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854369482/505095865854436862",
+                    "name": "text"
+                }
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384050",
+            "name": "OptionExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384050/505095865854384051",
+                    "name": "option",
+                    "type": "jetbrains.mps.make.script.Option",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384053",
+            "name": "OptionType",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384053/505095865854384060",
+                    "name": "expectedOption",
+                    "type": "jetbrains.mps.make.script.ExpectedOption"
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Type",
+                "jetbrains.mps.baseLanguage.IWillBeClassifier"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384059",
+            "name": "ExpectedOption",
+            "properties": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384059/3681941909241080172",
+                    "name": "defaultOption",
+                    "type": "INT"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384059/505095865854384069",
+                    "name": "option",
+                    "type": "jetbrains.mps.make.script.Option",
+                    "multiple": true,
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.make.script.IExpected",
+                "jetbrains.mps.lang.core.INamedConcept",
+                "jetbrains.mps.baseLanguage.IWillBeClassifier"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384066",
+            "name": "Expected",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384070",
+            "name": "ExpectedInput",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept",
+                "jetbrains.mps.make.script.IExpected"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384109",
+            "name": "JobDeclaration",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384109/1977954644795396329",
+                    "name": "config",
+                    "type": "jetbrains.mps.make.script.ConfigDefinition"
+                },
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384109/505095865854384110",
+                    "name": "job",
+                    "type": "jetbrains.mps.make.script.JobDefinition",
+                    "optional": false
+                },
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854384109/505095865854384111",
+                    "name": "query",
+                    "type": "jetbrains.mps.make.script.QueryDefinition",
+                    "multiple": true
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.lang.core.BaseConcept"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/505095865854427623",
+            "name": "IExpected",
+            "abstract": true,
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/1977954644795311519",
+            "name": "RelayQueryExpression",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/1977954644795311519/1977954644795311521",
+                    "name": "parameter",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "multiple": true
+                }
+            ],
+            "references": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/1977954644795311519/1977954644795311522",
+                    "name": "query",
+                    "type": "jetbrains.mps.make.script.QueryDefinition",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/1977954644795375332",
+            "name": "ConfigDefinition",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunction"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/3668957831723333672",
+            "name": "ReportFeedbackStatement",
+            "properties": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/3668957831723333672/3668957831723333678",
+                    "name": "feedback"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/3668957831723333672/3668957831723336680",
+                    "name": "message",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683650",
+            "name": "BeginWorkStatement",
+            "properties": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683650/682890046602602769",
+                    "name": "workName"
+                }
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683650/187226666892740070",
+                    "name": "expected",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683650/187226666892740071",
+                    "name": "ofTotal",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                }
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683652",
+            "name": "AdvanceWorkStatement",
+            "properties": [
+            ],
+            "children": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683652/187226666892735700",
+                    "name": "amount",
+                    "type": "jetbrains.mps.baseLanguage.Expression",
+                    "optional": false
+                },
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683652/1906791586424011776",
+                    "name": "comment",
+                    "type": "jetbrains.mps.baseLanguage.Expression"
+                }
+            ],
+            "references": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683652/682890046602395482",
+                    "name": "workStatement",
+                    "type": "jetbrains.mps.make.script.BeginWorkStatement",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683655",
+            "name": "FinishWorkStatement",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+                {
+                    "uid": "95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/187226666892683655/682890046602397405",
+                    "name": "workStatement",
+                    "type": "jetbrains.mps.make.script.BeginWorkStatement",
+                    "optional": false
+                }
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Statement"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/3297237684108627658",
+            "name": "AllWorkLeftExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/8170824575195231721",
+            "name": "PropertiesAccessorParameter",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/4671800353872995469",
+            "name": "ConceptFunctionParameter_progressMonitor",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.ConceptFunctionParameter"
+            ]
+        },
+        {
+            "uid": "mps:95f8a3e6-f994-4ca0-a65e-763c9bae2d3b/7044091413522263180",
+            "name": "GetMakeSessionExpression",
+            "properties": [
+            ],
+            "children": [
+            ],
+            "references": [
+            ],
+            "extends": [
+                "jetbrains.mps.baseLanguage.Expression"
+            ]
+        }
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.refactoring.participant.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.refactoring.participant.json
@@ -1,0 +1,6 @@
+{
+    "uid": "d81a5f75-df55-4511-9df4-4dbac0cdcf06",
+    "name": "jetbrains.mps.refactoring.participant",
+    "concepts": [
+    ]
+}

--- a/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.tool.gentest.json
+++ b/metamodel-gradle/src/functionalTest/resources/json/jetbrains.mps.tool.gentest.json
@@ -1,0 +1,6 @@
+{
+    "uid": "3ba7b7cf-6a5a-4981-ba0b-3302e59ffef7",
+    "name": "jetbrains.mps.tool.gentest",
+    "concepts": [
+    ]
+}

--- a/metamodel-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
+++ b/metamodel-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
@@ -23,11 +23,13 @@ class MetaModelGradlePlugin: Plugin<Project> {
         val modelixCoreVersion = readModelixCoreVersion() ?: throw RuntimeException("modelix.core version not found")
         project.dependencies.add(exporterDependencies.name, "org.modelix:metamodel-export-mps:$modelixCoreVersion")
         val downloadExporterDependencies = project.tasks.register("downloadMetaModelExporter", Sync::class.java) { task ->
+            task.enabled = settings.jsonDir == null
             task.from(exporterDependencies.resolve().map { project.zipTree(it) })
             task.into(exporterDir)
         }
 
         val generateAntScriptForMpsMetaModelExport = project.tasks.register("generateAntScriptForMpsMetaModelExport", GenerateAntScriptForMpsMetaModelExport::class.java) { task ->
+            task.enabled = settings.jsonDir == null
             task.dependsOn(downloadExporterDependencies)
             task.dependsOn(*settings.taskDependencies.toTypedArray())
             task.mpsHome.set(getMpsHome())
@@ -43,6 +45,7 @@ class MetaModelGradlePlugin: Plugin<Project> {
 
         val exportedLanguagesDir = getBuildOutputDir().resolve("exported-languages")
         val exportMetaModelFromMps = project.tasks.register("exportMetaModelFromMps", JavaExec::class.java) { task ->
+            task.enabled = settings.jsonDir == null
             task.workingDir = getBuildOutputDir()
             task.mainClass.set("org.apache.tools.ant.launch.Launcher")
             task.classpath(antDependencies)
@@ -83,9 +86,14 @@ class MetaModelGradlePlugin: Plugin<Project> {
                 task.includedNamespaces.addAll(settings.includedLanguageNamespaces)
                 task.includedLanguages.addAll(settings.includedLanguages)
                 task.includedConcepts.addAll(settings.includedConcepts)
-                task.exportedLanguagesDir.set(exportedLanguagesDir)
+                if (settings.jsonDir != null) {
+                    task.exportedLanguagesDir.set(settings.jsonDir)
+                } else {
+                    task.exportedLanguagesDir.set(exportedLanguagesDir)
+                }
                 settings.registrationHelperName?.let { task.registrationHelperName.set(it) }
                 task.nameConfig.set(settings.nameConfig)
+
             }
         }
 

--- a/metamodel-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
+++ b/metamodel-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
@@ -52,8 +52,8 @@ class MetaModelGradlePlugin: Plugin<Project> {
 
             val mpsHome = getMpsHome()
             val antVariables = listOf(
-                "mps.home" to mpsHome.absolutePath,
-                "mps_home" to mpsHome.absolutePath,
+                "mps.home" to mpsHome?.absolutePath,
+                "mps_home" to mpsHome?.absolutePath,
                 "build.dir" to getBuildOutputDir().absolutePath,
             ).map { (key, value) -> "-D$key=$value" }
             task.args(antVariables)
@@ -116,11 +116,12 @@ class MetaModelGradlePlugin: Plugin<Project> {
 
     private fun getAntScriptFile() = getBuildOutputDir().resolve("export-languages.xml")
 
-    private fun getMpsHome(checkExistence: Boolean = false): File {
+    private fun getMpsHome(checkExistence: Boolean = false): File? {
         val mpsHome = this.settings.mpsHome
-        require(mpsHome != null) { "'mpsHome' is not set in the 'metamodel' settings" }
+        val jsonDir = this.settings.jsonDir
+        require(mpsHome != null || jsonDir != null) { "'mpsHome' is not set in the 'metamodel' settings" }
         if (checkExistence) {
-            require(mpsHome.exists()) { "'mpsHome' doesn't exist: ${mpsHome.absolutePath}" }
+            require(mpsHome?.exists() ?: false) { "'mpsHome' doesn't exist: ${mpsHome?.absolutePath}" }
         }
         return mpsHome
     }

--- a/metamodel-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradleSettings.kt
+++ b/metamodel-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradleSettings.kt
@@ -37,6 +37,8 @@ open class MetaModelGradleSettings {
         action.execute(nameConfig)
     }
 
+    var jsonDir: File? = null
+
     fun dependsOn(vararg dependency: Any) {
         taskDependencies.addAll(dependency)
     }


### PR DESCRIPTION
This adds functionality to the metamodel-gradle plugin.
Users can specify a directory `jsonDir` for example like this:
```gradle
metamodel {
    //...
    jsonDir = File("build/json")
}
```
Doing so will disable the export from MPS. Instead the json files inside of jsonDir will be directly used for the generation of the kotlin and typescript classes.