### PR TITLE
Ensure new releaes trigger artifact publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '**'
+  workflow_dispatch:
 
 jobs:
   newRelease:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm ci
       - name: Dry-run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         # We need to convince semantic-release to not pick up some
         # configuration from the CI environment by removing the variable that
         # is used for CI detection.
@@ -71,5 +71,5 @@ jobs:
         run: npm ci
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This PR migrates the release steps to a personal access token to ensure that the publish pipeline is triggered on new release tags as discussed in: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

The ci changes are marked as a `fix` commit to trigger a functional release once.