### PR TITLE
feat: use kotlin 1.8 and also bump all other dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
-    kotlin("multiplatform") version "1.7.21" apply false
-    kotlin("plugin.serialization") version "1.7.21" apply false
+    kotlin("multiplatform") apply false
+    kotlin("plugin.serialization") apply false
     `maven-publish`
     id("com.palantir.git-version") version "0.13.0"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
-kotlinVersion=1.7.21
+kotlinVersion=1.8.10
 kotlinCoroutinesVersion=1.6.4
-ktorVersion=2.0.3
-kotlinLoggingVersion=2.1.23
+ktorVersion=2.2.4
+kotlinLoggingVersion=3.0.5
 kotlinxHtmlVersion=0.8.0
-kotlinxSerializationVersion=1.4.1
-modelixIncrementalVersion=0.1.2
+kotlinxSerializationVersion=1.5.0
+modelixIncrementalVersion=0.1.4
+kotlinCollectionsImmutableVersion=0.3.5

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -307,12 +307,12 @@ acorn-walk@^8.0.2:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.1.0, acorn@^8.8.0:
+acorn@^8.1.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
-acorn@^8.4.1, acorn@^8.5.0:
+acorn@^8.5.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -750,10 +750,10 @@ engine.io@~6.2.0:
     engine.io-parser "~5.0.3"
     ws "~8.2.3"
 
-enhanced-resolve@^5.9.3:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
-  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+enhanced-resolve@^5.10.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
+  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -2117,7 +2117,7 @@ w3c-xmlserializer@^3.0.0:
   dependencies:
     xml-name-validator "^4.0.0"
 
-watchpack@^2.3.1:
+watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
@@ -2173,21 +2173,21 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.73.0:
-  version "5.73.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.73.0.tgz#bbd17738f8a53ee5760ea2f59dce7f3431d35d38"
-  integrity sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==
+webpack@5.74.0:
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
+    acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.9.3"
+    enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -2200,7 +2200,7 @@ webpack@5.73.0:
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.1"
+    watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
 whatwg-encoding@^2.0.0:

--- a/metamodel-gradle-test/build.gradle.kts
+++ b/metamodel-gradle-test/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 }
 
 plugins {
-    kotlin("jvm") version "1.7.21"
+    kotlin("jvm") version "1.8.10"
     id("base")
     id("org.modelix.metamodel.gradle")
 }

--- a/metamodel-runtime/build.gradle.kts
+++ b/metamodel-runtime/build.gradle.kts
@@ -9,7 +9,7 @@ val mpsExtensionsVersion: String by rootProject
 
 kotlin {
     jvm()
-    js(BOTH) {
+    js(IR) {
         browser {
         }
         nodejs {

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.named("check") {
 }
 
 tasks.named("sourcesJar") {
-    dependsOn("jsIrGenerateExternalsIntegrated")
+    dependsOn("jsGenerateExternalsIntegrated")
 }
 
 val kotlinLoggingVersion: String by rootProject
@@ -41,7 +41,7 @@ val kotlinxSerializationVersion: String by rootProject
 
 kotlin {
     jvm()
-    js(BOTH) {
+    js(IR) {
         nodejs {
             testTask {
                 useMocha {
@@ -90,9 +90,9 @@ kotlin {
 }
 
 tasks.named("runKtlintCheckOverJsMainSourceSet") {
-    dependsOn("jsIrGenerateExternalsIntegrated")
+    dependsOn("jsGenerateExternalsIntegrated")
 }
 
 tasks.named("jsSourcesJar") {
-    dependsOn("jsIrGenerateExternalsIntegrated")
+    dependsOn("jsGenerateExternalsIntegrated")
 }

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -37,7 +37,7 @@ val ktorVersion: String by rootProject
 
 kotlin {
     jvm()
-    js(BOTH) {
+    js(IR) {
         // browser {}
         nodejs {
             testTask {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,9 @@
 pluginManagement {
+    val kotlinVersion: String by settings
+    plugins {
+        kotlin("multiplatform") version kotlinVersion apply false
+        kotlin("plugin.serialization") version kotlinVersion apply false
+    }
     repositories {
         mavenLocal()
         gradlePluginPortal()


### PR DESCRIPTION
The Kotlin 1.7 gradle plugin throws some exception when there are failing tests, which shadows the reporting of the failed tests. Kotlin 1.8 seems to work better with Gradle 8.