### PR TITLE
MODELIX-361 models can store role UIDs instead of names

### DIFF
--- a/light-model-client/src/commonMain/kotlin/org/modelix/client/light/LightModelClient.kt
+++ b/light-model-client/src/commonMain/kotlin/org/modelix/client/light/LightModelClient.kt
@@ -24,6 +24,7 @@ class LightModelClient(val connection: IConnection, val debugName: String = "") 
     private var lastMergedVersionHash: String? = null
     private val pendingOperations: MutableList<OperationData> = ArrayList()
     private var rootNodeId: NodeId? = null
+    private var usesRoleIds: Boolean = true
     private var temporaryIdsSequence: Long = 0
     private var changeSetIdSequence: Int = 0
     private val nodesReferencingTemporaryIds = HashSet<NodeId>()
@@ -269,6 +270,7 @@ class LightModelClient(val connection: IConnection, val debugName: String = "") 
             if (version.rootNodeId != null && version.rootNodeId != rootNodeId) {
                 rootNodeId = version.rootNodeId
             }
+            usesRoleIds = version.usesRoleIds
             lastMergedVersionHash = version.versionHash
 
             val oldChildNodes: Set<NodeId> = version.nodes.mapNotNull { nodes[it.nodeId] }.flatMap { it.children.values.flatten() }.toSet()
@@ -350,8 +352,10 @@ class LightModelClient(val connection: IConnection, val debugName: String = "") 
         }
     }
 
-    inner class NodeAdapter(var nodeId: NodeId) : INode {
+    inner class NodeAdapter(var nodeId: NodeId) : INodeEx {
         fun getData() = synchronizedRead { getNodeData(nodeId) }
+
+        override fun usesRoleIds(): Boolean = usesRoleIds
 
         override fun getArea(): IArea = area
 

--- a/light-model-server/src/main/kotlin/org/modelix/model/server/light/LightModelServer.kt
+++ b/light-model-server/src/main/kotlin/org/modelix/model/server/light/LightModelServer.kt
@@ -35,8 +35,10 @@ import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
 import org.modelix.model.api.INodeReferenceSerializer
 import org.modelix.model.api.IRole
+import org.modelix.model.api.key
 import org.modelix.model.api.remove
 import org.modelix.model.api.serialize
+import org.modelix.model.api.usesRoleIds
 import org.modelix.model.server.api.AddNewChildNodeOpData
 import org.modelix.model.server.api.ChangeSetId
 import org.modelix.model.server.api.DeleteNodeOpData
@@ -191,6 +193,7 @@ class LightModelServer(val port: Int, val rootNode: INode, val ignoredRoles: Set
                 repositoryId = null,
                 versionHash = null,
                 rootNodeId = rootNode.nodeId(),
+                usesRoleIds = rootNode.usesRoleIds(),
                 nodes = nodeDataList
             )
         }
@@ -285,9 +288,9 @@ class LightModelServer(val port: Int, val rootNode: INode, val ignoredRoles: Set
     private fun INode.toData(): NodeData {
         val conceptRef = concept?.getReference()
         val ignored = if (conceptRef == null) IgnoredRoles.EMPTY else ignoredRolesCache.getOrPut(conceptRef) {
-            val ignoredChildRoles = concept?.getAllChildLinks()?.intersect(ignoredRoles)?.map { it.name }?.toSet() ?: emptySet()
-            val ignoredPropertyRoles = concept?.getAllProperties()?.intersect(ignoredRoles)?.map { it.name }?.toSet() ?: emptySet()
-            val ignoredReferenceRoles = concept?.getAllReferenceLinks()?.intersect(ignoredRoles)?.map { it.name }?.toSet() ?: emptySet()
+            val ignoredChildRoles = concept?.getAllChildLinks()?.intersect(ignoredRoles)?.map { it.key(this) }?.toSet() ?: emptySet()
+            val ignoredPropertyRoles = concept?.getAllProperties()?.intersect(ignoredRoles)?.map { it.key(this) }?.toSet() ?: emptySet()
+            val ignoredReferenceRoles = concept?.getAllReferenceLinks()?.intersect(ignoredRoles)?.map { it.key(this) }?.toSet() ?: emptySet()
             IgnoredRoles(ignoredChildRoles, ignoredPropertyRoles, ignoredReferenceRoles).optimizeEmpty()
         }
 

--- a/metamodel-runtime/src/commonMain/kotlin/org/modelix/metamodel/GeneratedConcept.kt
+++ b/metamodel-runtime/src/commonMain/kotlin/org/modelix/metamodel/GeneratedConcept.kt
@@ -84,19 +84,19 @@ abstract class GeneratedConcept<NodeT : ITypedNode, ConceptT : ITypedConcept>(
         }
     }
 
-    override fun getChildLink(name: String): IChildLink {
-        return getAllChildLinks().find { it.name == name }
-            ?: throw IllegalArgumentException("Concept ${getLongName()} doesn't contain child link $name")
+    override fun getChildLink(roleKey: String): IChildLink {
+        return getAllChildLinks().find { RoleAccessContext.getKey(it) == roleKey }
+            ?: throw IllegalArgumentException("Concept ${getLongName()} doesn't contain child link $roleKey")
     }
 
-    override fun getProperty(name: String): IProperty {
-        return getAllProperties().find { it.name == name }
-            ?: throw IllegalArgumentException("Concept ${getLongName()} doesn't contain property $name")
+    override fun getProperty(roleKey: String): IProperty {
+        return getAllProperties().find { RoleAccessContext.getKey(it) == roleKey }
+            ?: throw IllegalArgumentException("Concept ${getLongName()} doesn't contain property $roleKey")
     }
 
-    override fun getReferenceLink(name: String): IReferenceLink {
-        return getAllReferenceLinks().find { it.name == name }
-            ?: throw IllegalArgumentException("Concept ${getLongName()} doesn't contain reference link $name")
+    override fun getReferenceLink(roleKey: String): IReferenceLink {
+        return getAllReferenceLinks().find { RoleAccessContext.getKey(it) == roleKey }
+            ?: throw IllegalArgumentException("Concept ${getLongName()} doesn't contain reference link $roleKey")
     }
 
     override fun getReference(): IConceptReference {
@@ -162,24 +162,26 @@ abstract class GeneratedConcept<NodeT : ITypedNode, ConceptT : ITypedConcept>(
 
 class GeneratedProperty<ValueT>(
     private val owner: IConcept,
-    override val name: String,
+    private val simpleName: String,
     private val uid: String?,
     override val isOptional: Boolean,
     private val serializer: IPropertyValueSerializer<ValueT>
 ) : ITypedProperty<ValueT>, IProperty {
     override fun getConcept(): IConcept = owner
-    override fun getUID(): String = uid ?: (getConcept().getUID() + "." + name)
+    override fun getUID(): String = uid ?: (getConcept().getUID() + "." + simpleName)
     override fun untyped(): IProperty = this
 
     override fun serializeValue(value: ValueT): String? = serializer.serialize(value)
 
     override fun deserializeValue(serialized: String?): ValueT = serializer.deserialize(serialized)
+
+    override fun getSimpleName(): String = simpleName
 }
 fun IProperty.typed() = this as? ITypedProperty<*>
 
 abstract class GeneratedChildLink<ChildNodeT : ITypedNode, ChildConceptT : ITypedConcept>(
     private val owner: IConcept,
-    override val name: String,
+    private val simpleName: String,
     private val uid: String?,
     override val isMultiple: Boolean,
     override val isOptional: Boolean,
@@ -191,7 +193,7 @@ abstract class GeneratedChildLink<ChildNodeT : ITypedNode, ChildConceptT : IType
 
     override fun getConcept(): IConcept = owner
 
-    override fun getUID(): String = uid ?: (getConcept().getUID() + "." + name)
+    override fun getUID(): String = uid ?: (getConcept().getUID() + "." + simpleName)
 
     override fun untyped(): IChildLink {
         return this
@@ -200,6 +202,8 @@ abstract class GeneratedChildLink<ChildNodeT : ITypedNode, ChildConceptT : IType
     override fun castChild(childNode: INode): ChildNodeT {
         return childNode.typed(childNodeInterface)
     }
+
+    override fun getSimpleName(): String = simpleName
 }
 fun IChildLink.typed() = this as? ITypedChildLink<ITypedNode>
 
@@ -227,7 +231,7 @@ class GeneratedChildListLink<ChildNodeT : ITypedNode, ChildConceptT : ITypedConc
 
 class GeneratedReferenceLink<TargetNodeT : ITypedNode, TargetConceptT : ITypedConcept>(
     private val owner: IConcept,
-    override val name: String,
+    private val simpleName: String,
     private val uid: String?,
     override val isOptional: Boolean,
     override val targetConcept: IConcept,
@@ -236,13 +240,15 @@ class GeneratedReferenceLink<TargetNodeT : ITypedNode, TargetConceptT : ITypedCo
 
     override fun getConcept(): IConcept = owner
 
-    override fun getUID(): String = uid ?: (getConcept().getUID() + "." + name)
+    override fun getUID(): String = uid ?: (getConcept().getUID() + "." + simpleName)
 
     override fun untyped(): IReferenceLink = this
 
     override fun castTarget(target: INode): TargetNodeT {
         return target.typed(targetNodeInterface)
     }
+
+    override fun getSimpleName(): String = simpleName
 }
 fun IReferenceLink.typed() = this as? ITypedReferenceLink<ITypedNode>
 

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -51,14 +51,37 @@ interface INode {
     fun getReferenceRoles(): List<String>
 }
 
-private fun IRole.key(): String = name // TODO use .getUID(), but this is a breaking change
-fun INode.getChildren(link: IChildLink): Iterable<INode> = getChildren(link.key())
-fun INode.moveChild(role: IChildLink, index: Int, child: INode): Unit = moveChild(role.key(), index, child)
-fun INode.addNewChild(role: IChildLink, index: Int, concept: IConcept?) = addNewChild(role.key(), index, concept)
-fun INode.getReferenceTarget(link: IReferenceLink): INode? = getReferenceTarget(link.key())
-fun INode.setReferenceTarget(link: IReferenceLink, target: INode?): Unit = setReferenceTarget(link.key(), target)
-fun INode.getPropertyValue(property: IProperty): String? = getPropertyValue(property.key())
-fun INode.setPropertyValue(property: IProperty, value: String?): Unit = setPropertyValue(property.key(), value)
+interface INodeEx : INode {
+    fun usesRoleIds(): Boolean
+    fun getContainmentLink(): IChildLink? = roleInParent?.let { role ->
+        parent?.concept?.getAllChildLinks()?.find { (if (usesRoleIds()) it.getUID() else it.getSimpleName()) == role }
+    }
+    fun getChildren(link: IChildLink): Iterable<INode> = getChildren(link.key(this))
+    fun moveChild(role: IChildLink, index: Int, child: INode) = moveChild(role.key(this), index, child)
+    fun addNewChild(role: IChildLink, index: Int, concept: IConcept?): INode = addNewChild(role.key(this), index, concept)
+    fun addNewChild(role: IChildLink, index: Int, concept: IConceptReference?): INode = addNewChild(role.key(this), index, concept)
+    fun getReferenceTarget(link: IReferenceLink): INode? = getReferenceTarget(link.key(this))
+    fun setReferenceTarget(link: IReferenceLink, target: INode?) = setReferenceTarget(link.key(this), target)
+    fun getReferenceTargetRef(role: IReferenceLink): INodeReference? = getReferenceTargetRef(role.key(this))
+    fun setReferenceTarget(role: IReferenceLink, target: INodeReference?) = setReferenceTarget(role.key(this), target)
+    fun getPropertyValue(property: IProperty): String? = getPropertyValue(property.key(this))
+    fun setPropertyValue(property: IProperty, value: String?) = setPropertyValue(property.key(this), value)
+}
+
+@Deprecated("Use .key(INode), .key(IBranch), .key(ITransaction) or .key(ITree)")
+fun IRole.key(): String = RoleAccessContext.getKey(this)
+fun IRole.key(node: INode): String = if (node.usesRoleIds()) getUID() else getSimpleName()
+fun INode.usesRoleIds(): Boolean = if (this is INodeEx) this.usesRoleIds() else false
+fun INode.getChildren(link: IChildLink): Iterable<INode> = if (this is INodeEx) getChildren(link) else getChildren(link.key(this))
+fun INode.moveChild(role: IChildLink, index: Int, child: INode): Unit = if (this is INodeEx) moveChild(role, index, child) else moveChild(role.key(this), index, child)
+fun INode.addNewChild(role: IChildLink, index: Int, concept: IConcept?) = if (this is INodeEx) addNewChild(role, index, concept) else addNewChild(role.key(this), index, concept)
+fun INode.getReferenceTarget(link: IReferenceLink): INode? = if (this is INodeEx) getReferenceTarget(link) else getReferenceTarget(link.key(this))
+fun INode.getReferenceTargetRef(link: IReferenceLink): INodeReference? = if (this is INodeEx) getReferenceTargetRef(link) else getReferenceTargetRef(link.key(this))
+fun INode.setReferenceTarget(link: IReferenceLink, target: INode?): Unit = if (this is INodeEx) setReferenceTarget(link, target) else setReferenceTarget(link.key(this), target)
+fun INode.setReferenceTarget(link: IReferenceLink, target: INodeReference?): Unit = if (this is INodeEx) setReferenceTarget(link, target) else setReferenceTarget(link.key(this), target)
+fun INode.getPropertyValue(property: IProperty): String? = if (this is INodeEx) getPropertyValue(property) else getPropertyValue(property.key(this))
+fun INode.setPropertyValue(property: IProperty, value: String?): Unit = if (this is INodeEx) setPropertyValue(property, value) else setPropertyValue(property.key(this), value)
+
 fun INode.getConcept(): IConcept? = getConceptReference()?.resolve()
 fun INode.getResolvedReferenceTarget(role: String): INode? = getReferenceTargetRef(role)?.resolveNode(getArea())
 fun INode.getResolvedConcept(): IConcept? = getConceptReference()?.resolve()
@@ -68,6 +91,22 @@ fun INode.addNewChild(role: String?): INode = addNewChild(role, -1, null as ICon
 fun INode.addNewChild(role: String?, concept: IConceptReference?): INode = addNewChild(role, -1, concept)
 fun INode.addNewChild(role: String?, concept: IConcept?): INode = addNewChild(role, -1, concept)
 
+fun INode.resolveChildLink(role: String): IChildLink {
+    val c = this.concept ?: throw RuntimeException("Node has no concept")
+    return c.getAllChildLinks().find { it.key(this) == role }
+        ?: throw RuntimeException("Child link '$role' not found in concept ${c.getLongName()}")
+}
+fun INode.resolveReferenceLink(role: String): IReferenceLink {
+    val c = this.concept ?: throw RuntimeException("Node has no concept")
+    return c.getAllReferenceLinks().find { it.key(this) == role }
+        ?: throw RuntimeException("Reference link '$role' not found in concept ${c.getLongName()}")
+}
+fun INode.resolveProperty(role: String): IProperty {
+    val c = this.concept ?: throw RuntimeException("Node has no concept")
+    return c.getAllProperties().find { it.key(this) == role }
+        ?: throw RuntimeException("Property '$role' not found in concept ${c.getLongName()}")
+}
+
 fun INode.remove() {
     parent?.removeChild(this)
 }
@@ -76,7 +115,13 @@ fun INode.index(): Int {
     return (parent ?: return 0).getChildren(roleInParent).indexOf(this)
 }
 
-fun INode.getContainmentLink() = roleInParent?.let { parent?.concept?.getChildLink(it) }
+fun INode.getContainmentLink() = if (this is INodeEx) {
+    getContainmentLink()
+} else {
+    roleInParent?.let { role ->
+        parent?.concept?.getAllChildLinks()?.find { (if (usesRoleIds()) it.getUID() else it.getSimpleName()) == role }
+    }
+}
 fun INode.getRoot(): INode = parent?.getRoot() ?: this
 fun INode.isInstanceOf(superConcept: IConcept?): Boolean = concept.let { it != null && it.isSubConceptOf(superConcept) }
 fun INode.isInstanceOfSafe(superConcept: IConcept): Boolean = tryGetConcept()?.isSubConceptOf(superConcept) ?: false

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IRole.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IRole.kt
@@ -3,6 +3,33 @@ package org.modelix.model.api
 interface IRole {
     fun getConcept(): IConcept
     fun getUID(): String
-    val name: String
+    fun getSimpleName(): String
+    @Deprecated("Use getSimpleName() when showing it to the user or when accessing the model use the INode functions that accept an IRole or use IRole.key(...)")
+    val name: String get() = RoleAccessContext.getKey(this)
     val isOptional: Boolean
+}
+
+@Deprecated("Will be removed after all usages of IRole.name are migrated.")
+object RoleAccessContext {
+    private val value = ContextValue<Boolean>(false)
+
+    fun <T> runWith(useRoleIds: Boolean, body: () -> T): T {
+        return value.computeWith(useRoleIds, body)
+    }
+
+    /**
+     * Depending on the context returns IRole.getSimpleName() or IRole.getUID()
+     */
+    fun getKey(role: IRole): String {
+        return if (isUsingRoleIds()) {
+            // Some implementations use the name to construct a UID. Avoid endless recursions.
+            runWith(false) { role.getUID() }
+        } else {
+            role.getSimpleName()
+        }
+    }
+
+    fun isUsingRoleIds(): Boolean {
+        return value.getValue() ?: false
+    }
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransaction.kt
@@ -32,3 +32,5 @@ interface ITransaction {
     fun getUserObject(key: Any): Any?
     fun putUserObject(key: Any, value: Any?)
 }
+
+fun IRole.key(t: ITransaction): String = if (t.tree.usesRoleIds()) getUID() else getSimpleName()

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITree.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITree.kt
@@ -16,6 +16,7 @@
 package org.modelix.model.api
 
 interface ITree {
+    fun usesRoleIds(): Boolean
     fun getId(): String?
     fun visitChanges(oldVersion: ITree, visitor: ITreeChangeVisitor)
     fun containsNode(nodeId: Long): Boolean
@@ -45,3 +46,5 @@ interface ITree {
         const val DETACHED_NODES_ROLE = "detached"
     }
 }
+
+fun IRole.key(tree: ITree): String = if (tree.usesRoleIds()) getUID() else getSimpleName()

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeAdapter.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeAdapter.kt
@@ -19,7 +19,7 @@ import org.modelix.model.area.ContextArea
 import org.modelix.model.area.IArea
 import org.modelix.model.area.PArea
 
-open class PNodeAdapter(val nodeId: Long, val branch: IBranch) : INode {
+open class PNodeAdapter(val nodeId: Long, val branch: IBranch) : INode, INodeEx {
 
     init {
         require(nodeId != 0L, { "Invalid node 0" })
@@ -44,6 +44,8 @@ open class PNodeAdapter(val nodeId: Long, val branch: IBranch) : INode {
         // TODO
 //    DependencyBroadcaster.INSTANCE.dependencyAccessed(new PNodeDependency(branch, nodeId));
     }
+
+    override fun usesRoleIds() = branch.transaction.tree.usesRoleIds()
 
     override fun moveChild(role: String?, index: Int, child: INode) {
         if (child !is PNodeAdapter)

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
@@ -14,7 +14,7 @@
 package org.modelix.model.api
 
 class SimpleChildLink(
-    override val name: String,
+    private val simpleName: String,
     override val isMultiple: Boolean,
     override val isOptional: Boolean,
     override val targetConcept: IConcept
@@ -26,6 +26,8 @@ class SimpleChildLink(
 
     override fun getUID(): String {
         val o = owner
-        return (if (o == null) name else o.getUID() + "." + name)
+        return (if (o == null) simpleName else o.getUID() + "." + simpleName)
     }
+
+    override fun getSimpleName(): String = simpleName
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
@@ -57,6 +57,7 @@ class SimpleConcept(
     }
 
     override fun getChildLink(name: String): IChildLink {
+        // This usage of .name is correct
         return getAllChildLinks().find { it.name == name } ?: throw RuntimeException("child link $conceptName.$name not found")
     }
 
@@ -66,10 +67,12 @@ class SimpleConcept(
     }
 
     override fun getProperty(name: String): IProperty {
+        // This usage of .name is correct
         return getAllProperties().find { it.name == name } ?: throw RuntimeException("property $conceptName.$name not found")
     }
 
     override fun getReferenceLink(name: String): IReferenceLink {
+        // This usage of .name is correct
         return getAllReferenceLinks().find { it.name == name } ?: throw RuntimeException("reference link $conceptName.$name not found")
     }
 

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleProperty.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleProperty.kt
@@ -13,13 +13,15 @@
  */
 package org.modelix.model.api
 
-class SimpleProperty(override val name: String, override val isOptional: Boolean = true) : IProperty {
+class SimpleProperty(private val simpleName: String, override val isOptional: Boolean = true) : IProperty {
     var owner: SimpleConcept? = null
 
     override fun getConcept(): IConcept = owner!!
 
     override fun getUID(): String {
         val o = owner
-        return (if (o == null) name else o.getUID() + "." + name)
+        return (if (o == null) simpleName else o.getUID() + "." + simpleName)
     }
+
+    override fun getSimpleName(): String = simpleName
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleReferenceLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleReferenceLink.kt
@@ -14,7 +14,7 @@
 package org.modelix.model.api
 
 class SimpleReferenceLink(
-    override val name: String,
+    private val simpleName: String,
     override val isOptional: Boolean,
     override var targetConcept: IConcept
 ) : IReferenceLink {
@@ -24,6 +24,8 @@ class SimpleReferenceLink(
 
     override fun getUID(): String {
         val o = owner
-        return (if (o == null) name else o.getUID() + "." + name)
+        return (if (o == null) simpleName else o.getUID() + "." + simpleName)
     }
+
+    override fun getSimpleName(): String = simpleName
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/TreePointer.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/TreePointer.kt
@@ -22,19 +22,19 @@ class TreePointer(private var tree_: ITree, val idGenerator: IIdGenerator = IdGe
         }
 
     override fun runRead(runnable: () -> Unit) {
-        runnable()
+        computeRead(runnable)
     }
 
     override fun <T> computeRead(computable: () -> T): T {
-        return computable()
+        return RoleAccessContext.runWith(tree.usesRoleIds()) { computable() }
     }
 
     override fun runWrite(runnable: () -> Unit) {
-        runnable()
+        computeWrite(runnable)
     }
 
     override fun <T> computeWrite(computable: () -> T): T {
-        return computable()
+        return RoleAccessContext.runWith(tree.usesRoleIds()) { computable() }
     }
 
     override fun canRead(): Boolean {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelBranch.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelBranch.kt
@@ -53,7 +53,7 @@ class MetaModelBranch(val branch: IBranch) : IBranch by branch {
         if (localConcept is PersistedConcept) {
             var uid = localConcept.uid
             if (uid == null && tree.containsNode(localConcept.id)) {
-                uid = tree.getProperty(localConcept.id, MetaMetaLanguage.property_IHasUID_uid.name)
+                uid = tree.getProperty(localConcept.id, MetaMetaLanguage.property_IHasUID_uid.key(tree))
             }
             if (uid == null) throw RuntimeException("Concept ${localConcept.id} has no UID")
             val concept = ILanguageRepository.resolveConcept(ConceptReference(uid))
@@ -69,7 +69,7 @@ class MetaModelBranch(val branch: IBranch) : IBranch by branch {
             var uid: String? = null
             val conceptNodeId = SerializationUtil.longFromHex(serialized)
             if (tree.containsNode(conceptNodeId)) {
-                uid = tree.getProperty(conceptNodeId, MetaMetaLanguage.property_IHasUID_uid.name)
+                uid = tree.getProperty(conceptNodeId, MetaMetaLanguage.property_IHasUID_uid.key(tree))
             }
             return toGlobalConcept(PersistedConcept(conceptNodeId, uid), tree)
         }
@@ -81,7 +81,7 @@ class MetaModelBranch(val branch: IBranch) : IBranch by branch {
         if (serialized matches hexLongPattern) {
             val conceptNodeId = SerializationUtil.longFromHex(serialized)
             if (tree.containsNode(conceptNodeId)) {
-                val uid = tree.getProperty(conceptNodeId, MetaMetaLanguage.property_IHasUID_uid.name)
+                val uid = tree.getProperty(conceptNodeId, MetaMetaLanguage.property_IHasUID_uid.key(tree))
                 if (uid != null) return ConceptReference(uid)
             }
             return resolveConcept(localConceptRef, tree).getReference()

--- a/model-client/src/commonMain/kotlin/org/modelix/model/persistent/CPTree.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/persistent/CPTree.kt
@@ -20,12 +20,14 @@ import kotlin.jvm.JvmStatic
 
 class CPTree(
     val id: String,
-    var idToHash: KVEntryReference<CPHamtNode>
+    var idToHash: KVEntryReference<CPHamtNode>,
+    val usesRoleIds: Boolean
 ) : IKVValue {
     override var isWritten: Boolean = false
 
     override fun serialize(): String {
-        return "$id/$PERSISTENCE_VERSION/${idToHash.getHash()}"
+        val pv = if (usesRoleIds) PERSISTENCE_VERSION else NAMED_BASED_PERSISTENCE_VERSION
+        return "$id/$pv/${idToHash.getHash()}"
     }
 
     override val hash: String by lazy(LazyThreadSafetyMode.PUBLICATION) { HashUtil.sha256(serialize()) }
@@ -35,20 +37,25 @@ class CPTree(
     override fun getReferencedEntries(): List<KVEntryReference<IKVValue>> = listOf(idToHash)
 
     companion object {
-        val PERSISTENCE_VERSION: Int = 2
+        /**
+         * Since version 3 the UID of concept members is stored instead of the name
+         */
+        val PERSISTENCE_VERSION: Int = 3
+        val NAMED_BASED_PERSISTENCE_VERSION: Int = 2
         val DESERIALIZER: (String) -> CPTree = { deserialize(it) }
         @JvmStatic
         fun deserialize(input: String): CPTree {
             val parts = input.split("/")
             val treeId = parts[0]
             val persistenceVersion = parts[1].toInt()
-            if (persistenceVersion != PERSISTENCE_VERSION) {
+            if (persistenceVersion != PERSISTENCE_VERSION && persistenceVersion != NAMED_BASED_PERSISTENCE_VERSION) {
                 throw RuntimeException(
                     "Tree $treeId has persistence version $persistenceVersion, " +
                         "but only version $PERSISTENCE_VERSION is supported"
                 )
             }
-            val data = CPTree(treeId, KVEntryReference(parts[2], CPHamtNode.DESERIALIZER))
+            val usesRoleIds = persistenceVersion == PERSISTENCE_VERSION
+            val data = CPTree(treeId, KVEntryReference(parts[2], CPHamtNode.DESERIALIZER), usesRoleIds)
             data.isWritten = true
             return data
         }

--- a/model-client/src/commonTest/kotlin/org/modelix/model/TreeSerializationTest.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/TreeSerializationTest.kt
@@ -45,14 +45,14 @@ class TreeSerializationTest {
     fun serializeAndDeserialize() {
         // the hash only ensures that JVM and JS produce the same serialized data
         // it can just be updated if the test fails
-        serializeAndDeserialize(false, "Ci8-C*weNQv09_2eGp9Mvxo8l6VtuGU3n35qP1sQYw2Y")
+        serializeAndDeserialize(false, "RfOjz*_ucNWvGVEjSlTLdLLpf9vCEfm0Ud3Q8aweKD1U")
     }
 
     @Test
     fun serializeAndDeserialize_AddNewChildSubtreeOp() {
         // the hash only ensures that JVM and JS produce the same serialized data
         // it can just be updated if the test fails
-        serializeAndDeserialize(true, "50ZVC*SITjLf3YkIUx5stSZfX8nPem80o9E2LwG0B6To")
+        serializeAndDeserialize(true, "I93pF*lmKS7ZoTHfi2dOugdeIKLGqyjmzIPc1mVUTkJ0")
     }
 
     fun serializeAndDeserialize(moreThan10ops: Boolean, expectedVersionHash: String) {

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/VersionData.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/VersionData.kt
@@ -20,6 +20,7 @@ data class VersionData(
     val repositoryId: String? = null,
     val versionHash: String? = null,
     val rootNodeId: String? = null,
+    val usesRoleIds: Boolean = false,
     val nodes: List<NodeData>,
 )
 
@@ -37,6 +38,7 @@ fun VersionData.merge(older: VersionData): VersionData {
         repositoryId = repositoryId ?: older.repositoryId,
         versionHash = versionHash,
         rootNodeId = rootNodeId ?: older.rootNodeId,
+        usesRoleIds = usesRoleIds || older.usesRoleIds,
         nodes = filteredMergedNodes.values.toList()
     )
 }

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/LightModelServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/LightModelServer.kt
@@ -320,6 +320,7 @@ class LightModelServer(val client: LocalModelClient) {
             repositoryId = version.tree.getId(),
             versionHash = version.hash,
             rootNodeId = if (oldVersion == null) ITree.ROOT_ID.toString(16) else null,
+            usesRoleIds = version.tree.usesRoleIds(),
             nodes = nodeDataList
         )
     }


### PR DESCRIPTION
First step towards using IDs instead of names when storing children/properties/references.

It's backward compatible. Existing models on the model server keep using names, new models will use IDs.

INode.name returns the name or the UID depending on the context it is executed in. Existing code will continue to work, but should be migrated eventually.