### PR TITLE
MODELIX-402: Publish pipeline in modelix.core doesn't run on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Checkout branch
         # Pretend to semantic-release that the PR result is eligible for
         # building releases because --dry-run still filters for configured
@@ -58,6 +59,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
For authorization the checkout action uses the GITHUB_TOKEN by default.
This prevents the publish pipeline to be triggered by the tag created by semantic release.
Now the personal access token is used instead.