### PR TITLE
model-server-api has to be an api dependency in model-client

### DIFF
--- a/metamodel-generator/build.gradle.kts
+++ b/metamodel-generator/build.gradle.kts
@@ -3,10 +3,13 @@ plugins {
     kotlin("plugin.serialization")
 }
 
+val kotlinxSerializationVersion: String by rootProject
+val kotlinCollectionsImmutableVersion: String by rootProject
+
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:$kotlinCollectionsImmutableVersion")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
     implementation("com.charleskorn.kaml:kaml:0.40.0")
     implementation(project(":metamodel-runtime"))
     implementation("com.squareup:kotlinpoet:1.12.0")

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 api(project(":model-api"))
-                implementation(project(":model-server-api"))
+                api(project(":model-server-api"))
                 kotlin("stdlib-common")
                 implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.4")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion")


### PR DESCRIPTION
IModelClientV2 uses ModelQuery as a parameter which requires this dependency to be of type 'api'.