### PR TITLE
fix: module import for vite

### DIFF
--- a/ts-model-api/package.json
+++ b/ts-model-api/package.json
@@ -20,7 +20,6 @@
     "dist/*.d.ts"
   ],
   "main": "dist/index",
-  "module": "dist/index.mjs",
   "typings": "dist/index.d.ts",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
the provided file does not exist and consequently results in vite throwing an error