### PR TITLE
MODELIX-429: Automatic API reference generation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,27 @@
+name: Build and Publish Docs
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.0'  # New Major or Minor Releases
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Use tag as version
+        run: echo "${GITHUB_REF#refs/*/}" > version.txt
+      - name: Generate Docs with Dokka
+        run: ./gradlew dokkaHtmlMultiModule
+      - name: Publish to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/dokka
+          keep_files: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0" apply false
     id("com.diffplug.spotless") version "5.0.0" apply false
     id("com.dorongold.task-tree") version "2.1.0"
+    id("org.jetbrains.dokka") version "1.8.10"
+}
+
+repositories {
+    mavenLocal()
+    maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
+    mavenCentral()
 }
 
 group = "org.modelix"
@@ -25,6 +32,7 @@ fun computeVersion(): Any {
 
 subprojects {
     apply(plugin = "maven-publish")
+    apply(plugin = "org.jetbrains.dokka")
     version = rootProject.version
     group = rootProject.group
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
+import org.jetbrains.dokka.base.DokkaBase
+import org.jetbrains.dokka.base.DokkaBaseConfiguration
 
 buildscript {
     dependencies {
@@ -113,9 +115,42 @@ val docsDir = buildDir.resolve("dokka")
 
 tasks.dokkaHtmlMultiModule {
     outputDirectory.set(docsDir.resolve("$version"))
+    pluginConfiguration<DokkaBase, DokkaBaseConfiguration> {
+        customAssets += file(projectDir.resolve("dokka/logo-dark.svg"))
+        customStyleSheets += file(projectDir.resolve("dokka/logo-styles.css"))
+        footerMessage = createFooterMessage()
+    }
     doLast {
         val index = file(docsDir.resolve("index.html"))
-        index.writeText(createDocsIndexPage())
+        index.writeText(createDocsIndexPage(), Charsets.ISO_8859_1)
+    }
+}
+
+fun createFooterMessage(): String {
+    return createHTML().span {
+        createFooter()
+    }
+}
+
+fun FlowContent.createFooter() {
+    p {
+        +"For more information visit "
+        a("https://modelix.org") { +"modelix.org" }
+        +", for further documentation visit "
+        a("https://docs.modelix.org") { +"docs.modelix.org" }
+        +"."
+    }
+    p {
+        +"Copyright \u00A9 2021-present by the "
+        a("https://modelix.org") { +"modelix open source project" }
+        +" and the individual contributors. All Rights reserved."
+    }
+    p {
+        +"Except where otherwise noted, "
+        a("https://api.modelix.org")  {+"api.modelix.org"}
+        +", modelix, and the modelix framework, are licensed under the "
+        a("https://www.apache.org/licenses/LICENSE-2.0.html") { +"Apache-2.0 license"}
+        +"."
     }
 }
 
@@ -123,6 +158,7 @@ fun createDocsIndexPage(): String {
     return createHTML().html {
         head {
             link(href = "./$version/styles/style.css", rel = "Stylesheet")
+            link(href = "./$version/styles/logo-styles.css", rel = "Stylesheet")
             title("modelix.core API Reference")
             style {
                 unsafe {
@@ -177,6 +213,16 @@ fun createDocsIndexPage(): String {
                                     }
                                 }
                             }
+                        }
+                    }
+                    div("footer") {
+                        span("go-to-top-icon") {
+                            a("#content") {
+                                id = "go-to-top-link"
+                            }
+                        }
+                        span {
+                            createFooter()
                         }
                     }
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,43 +122,59 @@ tasks.dokkaHtmlMultiModule {
 fun createDocsIndexPage(): String {
     return createHTML().html {
         head {
+            link(href = "./$version/styles/style.css", rel = "Stylesheet")
+            title("modelix.core API Reference")
             style {
-            +"""
-                body { 
-                    font-family: sans-serif; 
+                unsafe {
+                    +"""
+                    .library-name {
+                        padding-top: 6px;
+                        padding-bottom: 6px;
+                    }
+                """.trimIndent()
                 }
-                
-                ul {
-                    list-style-type: none;
-                }
-                .wrapper {
-                    margin: auto;
-                    width: 50%;
-                    border: 1px solid;
-                    border-radius: 15px;
-                    padding: 20px;
-                    text-align: center;
-                }
-            """.trimIndent()
             }
         }
         body {
-            header {
-                h1 { +"Modelix Core API Reference" }
+            div("navigation-wrapper") {
+                id = "navigation-wrapper"
+                div("library-name") {
+                    a { +"modelix.core API Reference" }
+                }
             }
             div("wrapper") {
-
-                ul {
-                    val versionDirs = docsDir.listFiles()
-                        ?.filter { it.isDirectory }
-                        ?.sortedByDescending { it.name }
-                        ?: return@ul
-                    for (versionDir in versionDirs) {
-                        val versionIndex = versionDir.resolve("index.html")
-                        if (versionIndex.exists()) {
-                            li {
-                                a(href = versionIndex.relativeTo(docsDir).path) {
-                                    +"modelix.core ${versionDir.name}"
+                id = "container"
+                div {
+                    id ="leftColumn"
+                }
+                div {
+                    id = "main"
+                    div("main-content") {
+                        id ="content"
+                        div("breadcrumbs")
+                        div("cover") {
+                            h2 { +"Available versions:" }
+                            div("table") {
+                                val versionDirs = docsDir.listFiles()
+                                    ?.filter { it.isDirectory }
+                                    ?.sortedByDescending { it.name }
+                                if (versionDirs != null) {
+                                    for (versionDir in versionDirs) {
+                                        val versionIndex = versionDir.resolve("index.html")
+                                        if (versionIndex.exists()) {
+                                            div("table-row") {
+                                                div("main-subrow") {
+                                                    div("w-100") {
+                                                        span("inline-flex") {
+                                                            a( href = versionIndex.relativeTo(docsDir).path) {
+                                                                +"modelix.core ${versionDir.name}"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/dokka/logo-dark.svg
+++ b/dokka/logo-dark.svg
@@ -1,0 +1,27 @@
+<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg">
+ <g>
+  <line fill="none" stroke="#444" x1="425" y1="250" x2="275" y2="50" id="svg_41" stroke-width="10"/>
+  <line fill="none" stroke="#444" x1="275" y1="50" x2="325" y2="250" id="svg_40" stroke-width="10"/>
+  <line fill="none" stroke="#444" x1="275" y1="50" x2="225" y2="150" id="svg_38" stroke-width="10"/>
+  <line fill="none" stroke="#444" x1="125" y1="150" x2="275" y2="50" id="svg_35" stroke-width="10"/>
+  <ellipse fill="#444" cx="275" cy="50" id="svg_33" rx="20" ry="20"/>
+  <ellipse fill="#6290c3" cx="75" cy="350" id="svg_12" rx="20" ry="20"/>
+  <ellipse fill="#6290c3" cx="175" cy="350" id="svg_13" rx="20" ry="20"/>
+  <ellipse fill="#6290c3" cx="275" cy="350" id="svg_14" rx="20" ry="20"/>
+  <ellipse fill="#6290c3" cx="125" cy="150" id="svg_15" rx="20" ry="20"/>
+  <ellipse fill="#6290c3" cx="225" cy="150" id="svg_16" rx="20" ry="20"/>
+  <line fill="none" stroke="#6290c3" x1="75" y1="350" x2="125" y2="150" id="svg_17" stroke-width="10"/>
+  <line fill="none" stroke="#6290c3" stroke-width="10" x1="125" y1="150" x2="175" y2="350" id="svg_18"/>
+  <line fill="none" stroke="#6290c3" stroke-width="10" x1="225" y1="150" x2="175" y2="350" id="svg_19"/>
+  <line fill="none" stroke="#6290c3" stroke-width="10" x1="275" y1="350" x2="225" y2="150" id="svg_20"/>
+  <ellipse fill="#adeee3" cx="375" cy="350" id="svg_23" rx="20" ry="20"/>
+  <ellipse fill="#adeee3" cx="325" cy="250" id="svg_24" rx="20" ry="20"/>
+  <ellipse fill="#adeee3" cx="425" cy="250" id="svg_25" rx="20" ry="20"/>
+  <ellipse fill="#adeee3" cx="325" cy="450" id="svg_26" rx="20" ry="20"/>
+  <ellipse fill="#adeee3" cx="425" cy="450" id="svg_27" rx="20" ry="20"/>
+  <line fill="none" stroke="#adeee3" x1="325" y1="250" x2="375" y2="350" id="svg_28" stroke-width="10"/>
+  <line fill="none" stroke="#adeee3" x1="425" y1="250" x2="375" y2="350" id="svg_29" stroke-width="10"/>
+  <line fill="none" stroke="#adeee3" x1="325" y1="450" x2="375" y2="350" id="svg_30" stroke-width="10"/>
+  <line fill="none" stroke="#adeee3" x1="425" y1="450" x2="375" y2="350" id="svg_31" stroke-width="10"/>
+ </g>
+</svg>

--- a/dokka/logo-styles.css
+++ b/dokka/logo-styles.css
@@ -1,0 +1,15 @@
+.library-name a {
+    position: relative;
+    margin-left: 55px;
+}
+
+.library-name a::before {
+    content: '';
+    background: url('../images/logo-dark.svg') center no-repeat;
+    background-size: contain;
+    position: absolute;
+    width: 50px;
+    height: 50px;
+    top: -18px;
+    left: -55px;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.jvmargs=-Xmx512m "-XX:MaxMetaspaceSize=2g"
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.daemon.jvmargs=-Xmx2G
 


### PR DESCRIPTION
This sets up automatic api reference generation using Dokka.
The docs are generated and published to GitHub pages in a GitHub workflow, which is triggered by new major and minor releases.
Additionally docs can be generated locally by running `./gradlew dokkaHtmlMultiModule` in the root directory of the project. 