### PR TITLE
Fixes for API reference index page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,6 +17,11 @@ jobs:
           java-version: '11'
       - name: Use tag as version
         run: echo "${GITHUB_REF#refs/*/}" > version.txt
+      - name: Checkout Old Docs Versions for Index Page
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: build/dokka
       - name: Generate Docs with Dokka
         run: ./gradlew dokkaHtmlMultiModule
       - name: Publish to GitHub Pages

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,7 @@ tasks.dokkaHtmlMultiModule {
     }
     doLast {
         val index = file(docsDir.resolve("index.html"))
-        index.writeText(createDocsIndexPage(), Charsets.ISO_8859_1)
+        index.writeText(createDocsIndexPage())
     }
 }
 
@@ -157,6 +157,7 @@ fun FlowContent.createFooter() {
 fun createDocsIndexPage(): String {
     return createHTML().html {
         head {
+            meta(charset = "utf-8")
             link(href = "./$version/styles/style.css", rel = "Stylesheet")
             link(href = "./$version/styles/logo-styles.css", rel = "Stylesheet")
             title("modelix.core API Reference")


### PR DESCRIPTION
Fixes the copyright symbol not being shown on the index page.
Fixes the index page only listing the newest version.