### PR TITLE
feat: publish version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
 
 plugins {
     `maven-publish`
+    `version-catalog`
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.gitVersion)
@@ -237,6 +238,22 @@ fun createDocsIndexPage(): String {
                     }
                 }
             }
+        }
+    }
+}
+
+catalog {
+    versionCatalog {
+        from(files("gradle/libs.versions.toml"))
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("versionCatalog") {
+            groupId = "org.modelix"
+            artifactId = "core-version-catalog"
+            from(components["versionCatalog"])
         }
     }
 }


### PR DESCRIPTION
Gradle supports to publish version catalogs and consume them in other projects. This might an alternative to the "platform" for aligning dependencies with the used modelix.core version.

This publishes a new artifact. We have to agree on a name for that. Suggestions are welcome.