### PR TITLE
Change the model-serve base image to RedHat.

### DIFF
--- a/model-server/Dockerfile
+++ b/model-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.15-1.1682059493
 WORKDIR /usr/modelix-model
 EXPOSE 28101
 COPY run-model-server.sh /usr/modelix-model/


### PR DESCRIPTION
As discussed in a meeting yesterday, in order to reduce the number of vulnerable libraries in the dockerimage, I would suggest to switch for the RedHat-based OpenJDK image. The new model-server image was working fine for our use cases.

According to [trivy](https://github.com/aquasecurity/trivy), the `openjdk:11` base image contains 323 vulnerable libs/software (UNKNOWN: 0, LOW: 123, MEDIUM: 61, HIGH: 109, CRITICAL: 30).

According to [trivy](https://github.com/aquasecurity/trivy), the RedHat-based base image contains 97 vulnerable libs/software (UNKNOWN: 0, LOW: 52, MEDIUM: 45, HIGH: 0, CRITICAL: 0).

[Trivy](https://github.com/aquasecurity/trivy) was run on the `latest` modelix-model image (image ID 3d0f0ea586e4) to obtain this result. The used command was `trivy image modelix/modelix-model:latest` .