### PR TITLE
MODELIX-419 Add documentation for model api reference

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ConceptUtil.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ConceptUtil.kt
@@ -13,6 +13,11 @@
  */
 package org.modelix.model.api
 
+/**
+ * Returns this concept and all of its super-concepts.
+ *
+ * @return list of this concept and all its super-concepts
+ */
 fun IConcept.getAllConcepts(): List<IConcept> {
     val acc = LinkedHashSet<IConcept>()
     collectConcepts(this, acc)

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranch.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranch.kt
@@ -15,35 +15,140 @@
 
 package org.modelix.model.api
 
+/**
+ * Representation of a branch.
+ */
 interface IBranch {
+    /**
+     * Returns the id of this branch.
+     *
+     * @return branch id
+     */
     fun getId(): String
+
+    /**
+     * Performs a read operation on this branch.
+     *
+     * @param runnable read operation to be performed
+     */
     fun runRead(runnable: () -> Unit)
+
+    /**
+     * Performs a function in a read transaction on this branch.
+     *
+     * @param f function to be performed
+     */
     fun runReadT(f: (IReadTransaction) -> Unit) {
         runRead { f(readTransaction) }
     }
+
+    /**
+     * Performs a computable read operation, which returns a value, on this branch.
+     *
+     * @param computable operation to be performed
+     */
     fun <T> computeRead(computable: () -> T): T
+
+    /**
+     * Performs a computable read operation, which returns a value, in a read transaction on this branch.
+     */
     fun <T> computeReadT(computable: (IReadTransaction) -> T): T {
         return computeRead { computable(readTransaction) }
     }
+
+    /**
+     * Performs a write operation on this branch.
+     *
+     * @param runnable operation to be performed
+     */
     fun runWrite(runnable: () -> Unit)
+
+    /**
+     * Performs a function in a write transaction on this branch.
+     *
+     * @param f function to be performed
+     */
     fun runWriteT(f: (IWriteTransaction) -> Unit) {
         runWrite { f(writeTransaction) }
     }
+
+    /**
+     * Performs a computable write operation, which returns a value, on this branch.
+     *
+     * @param computable operation to be performed
+     */
     fun <T> computeWrite(computable: () -> T): T
+
+    /**
+     * Performs a computable write operation, which returns a value, in a write transaction on this branch.
+     */
     fun <T> computeWriteT(computable: (IWriteTransaction) -> T): T {
         return computeWrite { computable(writeTransaction) }
     }
+
+    /**
+     * Checks if read operations can be performed on this branch.
+     *
+     * @return true if read operations can be performed, false otherwise
+     */
     fun canRead(): Boolean
+
+    /**
+     * Checks if write operations can be performed on this branch.
+     *
+     * @return true if write operations can be performed, false otherwise
+     */
     fun canWrite(): Boolean
+
+    /**
+     * Transaction for this branch.
+     */
     val transaction: ITransaction
+
+    /**
+     * Read transaction for this branch.
+     */
     val readTransaction: IReadTransaction
+
+    /**
+     * Write transaction for this branch.
+     */
     val writeTransaction: IWriteTransaction
+
+    /**
+     * Adds the given branch listener to this branch.
+     *
+     * The branch listener will listen to changes on this branch.
+     *
+     * @param l branch listener to be added
+     */
     fun addListener(l: IBranchListener)
+
+    /**
+     * Removes the given branch listener from this branch.
+     *
+     * @param l branch listener to be removed
+     */
     fun removeListener(l: IBranchListener)
 }
 
+/**
+ * Wrapper for [IBranch]
+ */
 interface IBranchWrapper : IBranch {
+    /**
+     * Unwraps the branch.
+     *
+     * @return unwrapped branch
+     */
     fun unwrapBranch(): IBranch
 }
 
+/**
+ * Recursively unwraps a branch.
+ *
+ * If the receiver is an [IBranchWrapper] it will be unwrapped else the branch will be returned.
+ *
+ * @return deep unwrapped branch
+ */
 fun IBranch.deepUnwrap(): IBranch = if (this is IBranchWrapper) unwrapBranch().deepUnwrap() else this

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranchListener.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranchListener.kt
@@ -15,6 +15,15 @@
 
 package org.modelix.model.api
 
+/**
+ * Listener, that listens for changes on a branch.
+ */
 interface IBranchListener {
+    /**
+     * Informs the branch listener about tree changes.
+     *
+     * @param oldTree the original tree state
+     * @param newTree the new tree state
+     */
     fun treeChanged(oldTree: ITree?, newTree: ITree)
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
@@ -15,7 +15,13 @@
 
 package org.modelix.model.api
 
+/**
+ * Representation of a parent-child relationship between [IConcept]s.
+ */
 interface IChildLink : ILink {
+    /**
+     * Specifies if the parent-child relation ship is 1:n.
+     */
     val isMultiple: Boolean
 
     @Deprecated("use .targetConcept")

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IConcept.kt
@@ -15,30 +15,162 @@
 
 package org.modelix.model.api
 
+/**
+ * Representation of a language concept.
+ */
 interface IConcept {
+
+    /**
+     * Returns a reference to this concept.
+     *
+     * @return concept reference
+     */
     fun getReference(): IConceptReference
+
+    /**
+     * The language this concept is part of.
+     */
     val language: ILanguage?
 
+    /**
+     * Returns unique concept id of this concept.
+     *
+     * @return unique concept id
+     */
     fun getUID(): String
+
+    /**
+     * Returns the name of this concept.
+     *
+     * @return short concept name
+     */
     fun getShortName(): String
+
+    /**
+     * Returns the name of this concept prefixed by the language name.
+     *
+     * @return long concept name
+     */
     fun getLongName(): String
+
+    /**
+     * Checks if this concept is abstract.
+     *
+     * @return true if the concept is abstract, false otherwise
+     */
     fun isAbstract(): Boolean
 
+    /**
+     * Checks if this concept is a sub-concept of the given concept.
+     *
+     * @param superConcept the potential super-concept
+     * @return true if the given concept is a super-concept of this concept, false otherwise
+     */
     fun isSubConceptOf(superConcept: IConcept?): Boolean
+
+    /**
+     * Returns the direct super concepts of this concept.
+     *
+     * @return list of direct super concepts
+     */
     fun getDirectSuperConcepts(): List<IConcept>
+
+    /**
+     * Checks if the given concept is equal to this concept.
+     *
+     * @return true if this concept is equal to the given concept, false otherwise
+     */
     fun isExactly(concept: IConcept?): Boolean
 
+    /**
+     * Returns the properties, which are directly defined in this concept.
+     *
+     * @return list of own properties
+     *
+     * @see getAllProperties
+     */
     fun getOwnProperties(): List<IProperty>
+
+    /**
+     * Returns the child links, which are directly defined in this concept.
+     *
+     * @return list of own child links
+     *
+     * @see getAllChildLinks
+     */
     fun getOwnChildLinks(): List<IChildLink>
+
+    /**
+     * Returns the reference links, which are directly defined in this concept.
+     *
+     * @return list of reference links
+     *
+     * @see getAllChildLinks
+     */
     fun getOwnReferenceLinks(): List<IReferenceLink>
 
+    /**
+     * Returns all properties of this concept.
+     *
+     * This includes properties, that are directly defined in the concept itself,
+     * and properties, which are defined in the super-concepts of this concept.
+     *
+     * @return list of all properties
+     *
+     * @see getOwnProperties
+     */
     fun getAllProperties(): List<IProperty>
+
+    /**
+     * Returns all child links of this concept.
+     *
+     * This includes child links, that are directly defined in the concept itself,
+     * and child links, which are defined in the super-concepts of this concept.
+     *
+     * @return list of all child links
+     *
+     * @see getOwnChildLinks
+     */
     fun getAllChildLinks(): List<IChildLink>
+
+    /**
+     * Returns all reference links of this concepts.
+     *
+     * This includes reference links, that are directly defined in the concept itself,
+     * and reference links, which are defined in the super-concepts of this concept.
+     *
+     * @return list of all reference links
+     *
+     * @see getOwnReferenceLinks
+     */
     fun getAllReferenceLinks(): List<IReferenceLink>
 
+    /**
+     * Returns the property with the given name.
+     *
+     * @param name name of the property
+     * @return property
+     */
     fun getProperty(name: String): IProperty
+
+    /**
+     * Returns the child link with the given name.
+     *
+     * @param name name of the child link
+     * @return child link
+     */
     fun getChildLink(name: String): IChildLink
+
+    /**
+     * Returns the reference link with the given name.
+     *
+     * @param name name of the reference link
+     * @return reference link
+     */
     fun getReferenceLink(name: String): IReferenceLink
 }
 
+/**
+ * @see IConcept.isSubConceptOf
+ */
 fun IConcept?.isSubConceptOf(superConcept: IConcept?) = this?.isSubConceptOf(superConcept) == true

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IConceptReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IConceptReference.kt
@@ -15,6 +15,9 @@ package org.modelix.model.api
 
 import org.modelix.model.area.IArea
 
+/**
+ * Reference to an [IConcept].
+ */
 interface IConceptReference {
     companion object {
         private var deserializers: Map<Any, ((String) -> IConceptReference?)> = LinkedHashMap()
@@ -41,6 +44,11 @@ interface IConceptReference {
         }
     }
 
+    /**
+     * Returns the unique id of this concept reference.
+     *
+     * @return uid of this concept reference
+     */
     fun getUID(): String
 
     @Deprecated("use ILanguageRepository.resolveConcept")
@@ -50,5 +58,25 @@ interface IConceptReference {
     fun serialize(): String
 }
 
+/**
+ * Resolves the receiver concept reference within all registered language repositories.
+ *
+ * @receiver concept reference to be resolved
+ * @return resolved concept
+ * @throws RuntimeException if the concept could not be found
+ *          or multiple concepts were found for this concept reference
+ *
+ * @see ILanguageRepository.resolveConcept
+ */
 fun IConceptReference.resolve(): IConcept = ILanguageRepository.resolveConcept(this)
+
+/**
+ * Tries to resolve the receiver concept reference within all registered language repositories.
+ *
+ * @receiver concept reference to be resolved
+ * @return resolved concept or null, if the concept could not be found
+ * @throws RuntimeException if multiple concepts were found for this concept reference
+ *
+ * @see ILanguageRepository.tryResolveConcept
+ */
 fun IConceptReference.tryResolve(): IConcept? = ILanguageRepository.tryResolveConcept(this)

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IIdGenerator.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IIdGenerator.kt
@@ -15,6 +15,14 @@
 
 package org.modelix.model.api
 
+/**
+ * Generator for IDs.
+ */
 interface IIdGenerator {
+    /**
+     * Generates an id.
+     *
+     * @return generated id
+     */
     fun generate(): Long
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ILanguage.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ILanguage.kt
@@ -13,8 +13,28 @@
  */
 package org.modelix.model.api
 
+/**
+ * Representation of a language.
+ */
 interface ILanguage {
+    /**
+     * Returns the unique id of this language.
+     *
+     * @return unique language id
+     */
     fun getUID(): String
+
+    /**
+     * Returns the name of this language.
+     *
+     * @return language name
+     */
     fun getName(): String
+
+    /**
+     * Returns all the concepts defined in this language.
+     *
+     * @return list of all concepts
+     */
     fun getConcepts(): List<IConcept>
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ILink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ILink.kt
@@ -1,5 +1,13 @@
 package org.modelix.model.api
 
+/**
+ * Representation of a link between two [IConcept]s.
+ * A link belongs to one concept and targets another.
+ * It can be an [IChildLink] or an [IReferenceLink].
+ */
 interface ILink : IRole {
+    /**
+     * The concept targeted by this link.
+     */
     val targetConcept: IConcept
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -17,37 +17,167 @@ package org.modelix.model.api
 
 import org.modelix.model.area.IArea
 
+/**
+ * Representation of a model element.
+ */
 interface INode {
+
+    /**
+     * Returns the area of which this node is part of.
+     */
     fun getArea(): IArea
     val isValid: Boolean
+
+    /**
+     * Reference targeting this node.
+     */
     val reference: INodeReference
+
+    /**
+     * Concept, of which this node is instance of, or null if the node is not instance of any concept.
+     */
     val concept: IConcept?
+
+    /**
+     * Role of this node in its parent node if it exists,or null otherwise.
+     */
     val roleInParent: String?
+
+    /**
+     * Parent node of this node if it exists, or null if this node has no parent node.
+     */
     val parent: INode?
+
+    /**
+     * Returns a concept reference to the concept of which this node is instance of.
+     *
+     * @return concept reference or null if this node is not instance of any concept.
+     */
     fun getConceptReference(): IConceptReference?
 
+    /**
+     * Returns children of this node for the given role.
+     *
+     * @param role the desired role
+     * @return iterable over the child nodes
+     */
     fun getChildren(role: String?): Iterable<INode>
+
+    /**
+     * Iterable over all child nodes of this node.
+     */
     val allChildren: Iterable<INode>
+
+    /**
+     * Moves a child node to the given role and index.
+     *
+     * @param role target role
+     * @param index target index
+     * @param child child node to be moved
+     */
     fun moveChild(role: String?, index: Int, child: INode)
+
+    /**
+     * Adds a new child node to this node.
+     *
+     * Creates and adds a new child node to this node at the specified index.
+     *
+     * @param role role, where the node should be added
+     * @param index index, where the node should be added
+     * @param concept concept, of which the new node is instance of
+     * @return new child node
+     *
+     * @see addNewChild
+     */
     fun addNewChild(role: String?, index: Int, concept: IConcept?): INode
+
+    /**
+     * Adds a new child node to this node.
+     *
+     * Creates and adds a new child node to this node at the specified index.
+     *
+     * @param role role, where the node should be added
+     * @param index index, where the node should be added
+     * @param concept reference to a concept, of which the new node is instance of
+     * @return new child node
+     */
     fun addNewChild(role: String?, index: Int, concept: IConceptReference?): INode {
         return addNewChild(role, index, concept?.resolve())
     }
+
+    /**
+     * Removes the given node from this node's children.
+     *
+     * @param child node to be removed
+     */
     fun removeChild(child: INode)
 
+    /**
+     * Returns the target of the given reference role for this node.
+     *
+     * @param role the desired reference role
+     * @return target node, or null if the target could not be found
+     */
     fun getReferenceTarget(role: String): INode?
+
+    /**
+     * Returns a node reference to the target of the reference.
+     *
+     * @param role the desired reference role
+     * @return node reference to the target, or null if the target could not be found
+     */
     fun getReferenceTargetRef(role: String): INodeReference? {
         return getReferenceTarget(role)?.reference
     }
+
+    /**
+     * Sets the target of the given role reference for this node to the specified target node.
+     *
+     * @param role the desired reference role
+     * @param target new target for this node's reference
+     */
     fun setReferenceTarget(role: String, target: INode?)
+
+    /**
+     * Sets the target of the given role reference for this node
+     * to the node referenced by the specified target reference.
+     *
+     * @param role the desired reference role
+     * @param target reference to the new target for this node's reference
+     */
     fun setReferenceTarget(role: String, target: INodeReference?) {
         // Default implementation for backward compatibility only.
         setReferenceTarget(role, target?.resolveNode(getArea()))
     }
 
+    /**
+     * Returns the value of the given property role for this node.
+     *
+     * @param role the desired property role
+     * @return property value, or null if there is no value
+     */
     fun getPropertyValue(role: String): String?
+
+    /**
+     * Sets the value of the given property role for this node to the specified role.
+     *
+     * @param role the desired property role
+     * @param value the new property value
+     */
     fun setPropertyValue(role: String, value: String?)
+
+    /**
+     * Returns all property roles of this node.
+     *
+     * @return list of all property roles
+     */
     fun getPropertyRoles(): List<String>
+
+    /**
+     * Returns all reference roles of this node.
+     *
+     * @return list of all reference roles
+     */
     fun getReferenceRoles(): List<String>
 }
 

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReference.kt
@@ -18,9 +18,17 @@ package org.modelix.model.api
 import org.modelix.model.area.IArea
 
 /**
- * The relation between an INodeReference and an INode is n to 1.
- * Two INodeReferences that are not equal can resolve to the same INode.
+ * Reference to an [INode]-
+ *
+ * The relation between an [INodeReference] and an [INode] is n to 1.
+ * Two [INodeReference]s that are not equal can resolve to the same [INode].
  */
 interface INodeReference {
+    /**
+     * Tries to find the referenced node in the given [IArea].
+     *
+     * @param area area to be searched in
+     * @return the node, or null if the node could not be found
+     */
     fun resolveNode(area: IArea?): INode?
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReferenceSerializer.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReferenceSerializer.kt
@@ -2,9 +2,25 @@ package org.modelix.model.api
 
 import kotlin.reflect.KClass
 
+/**
+ * Serializer for [INodeReference]s.
+ */
 interface INodeReferenceSerializer {
 
+    /**
+     * Serializes the given node reference.
+     *
+     * @param ref the node reference to be serialized
+     * @return node reference as serialized string
+     */
     fun serialize(ref: INodeReference): String?
+
+    /**
+     * Deserializes the given string, which represents a serialized node reference.
+     *
+     * @param string the node reference in serialized form
+     * @return deserialized node reference
+     */
     fun deserialize(serialized: String): INodeReference?
 
     companion object {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeWrapper.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeWrapper.kt
@@ -13,6 +13,14 @@
  */
 package org.modelix.model.api
 
+/**
+ * Wrapper for [INode]
+ */
 interface INodeWrapper : INode {
+    /**
+     * Returns the wrapped node.
+     *
+     * @return node wrapped by this wrapper
+     */
     fun getWrappedNode(): INode
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IProperty.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IProperty.kt
@@ -15,4 +15,7 @@
 
 package org.modelix.model.api
 
+/**
+ * Representation of a property within an [IConcept].
+ */
 interface IProperty : IRole

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IReadTransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IReadTransaction.kt
@@ -15,4 +15,7 @@
 
 package org.modelix.model.api
 
+/**
+ * Provides transactional read access to nodes.
+ */
 interface IReadTransaction : ITransaction

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IReferenceLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IReferenceLink.kt
@@ -15,4 +15,7 @@
 
 package org.modelix.model.api
 
+/**
+ * Representation of a non-containment reference link between [IConcept]s.
+ */
 interface IReferenceLink : ILink

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IRole.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IRole.kt
@@ -1,12 +1,39 @@
 package org.modelix.model.api
 
+/**
+ * An [IRole] is a structural feature of a concept.
+ * It can either be an [IProperty] or an [ILink].
+ */
 interface IRole {
+    /**
+     * Returns the concept this role belongs to.
+     *
+     * @return concept
+     */
     fun getConcept(): IConcept
+
+    /**
+     * Returns the uid of this role.
+     *
+     * @return uid
+     */
     fun getUID(): String
+
+    /**
+     * Returns the unqualified name of this role.
+     *
+     * @return simple name
+     */
     fun getSimpleName(): String
 
     @Deprecated("Use getSimpleName() when showing it to the user or when accessing the model use the INode functions that accept an IRole or use IRole.key(...)")
     val name: String get() = RoleAccessContext.getKey(this)
+
+    /**
+     * Returns whether this role's value has to be set or not.
+     *
+     * @return true if this role's value is optional, false otherwise
+     */
     val isOptional: Boolean
 }
 

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransaction.kt
@@ -15,22 +15,126 @@
 
 package org.modelix.model.api
 
+/**
+ * Provides transactional access to nodes in the tree of this transaction.
+ */
 interface ITransaction {
     val branch: IBranch
     val tree: ITree
+
+    /**
+     * Checks if the given node is contained in the tree of this transaction.
+     *
+     * @param nodeId id of the desired node
+     * @return true, if the node is contained in the tree, or false, otherwise
+     */
     fun containsNode(nodeId: Long): Boolean
+
+    /**
+     * Returns the concept of the given node in the tree of this transaction.
+     *
+     * @param nodeId id of the desired node
+     * @return concept of the node or null, if the concept could not be found
+     */
     fun getConcept(nodeId: Long): IConcept?
+
+    /**
+     * Returns a reference to the concept of the given node in the tree of this transaction.
+     *
+     * @param nodeId id of the desired node
+     * @return reference to the concept of the node or null, if the concept could not be found
+     */
     fun getConceptReference(nodeId: Long): IConceptReference?
+
+    /**
+     * Returns the id of the parent node of the given node in the tree of this transaction.
+     *
+     * @param nodeId id of the desired node
+     * @return node id of the parent node
+     */
     fun getParent(nodeId: Long): Long
+
+    /**
+     * Returns the role of the given node within its parent node in the tree of this transaction.
+     *
+     * @param nodeId id of the desired node
+     * @return name of the role
+     */
     fun getRole(nodeId: Long): String?
+
+    /**
+     * Returns the property value of the given property role for the given node in the tree of this transaction.
+     *
+     * @param nodeId id of the desired node
+     * @param role name of the property role
+     * @return value of the property for the given node
+     */
     fun getProperty(nodeId: Long, role: String): String?
+
+    /**
+     * Returns the target of the given reference role for the given node in the tree of this transaction.
+     *
+     * @param sourceId id of the source node
+     * @param role name of the reference role
+     * @return node reference to the target
+     */
     fun getReferenceTarget(sourceId: Long, role: String): INodeReference?
+
+    /**
+     * Returns the children of the child link for the given node in the tree of this transaction
+     *
+     * @param parentId id of the desired node
+     * @param role name of the child link
+     * @return iterable over the child ids
+     */
     fun getChildren(parentId: Long, role: String?): Iterable<Long>
+
+    /**
+     * Returns all children of the given node in the tree of this transaction.
+     *
+     * @param parentId id of the desired node
+     * @return iterable over the child ids
+     */
     fun getAllChildren(parentId: Long): Iterable<Long>
+
+    /**
+     * Returns all reference roles for the given node in the tree of this transaction.
+     *
+     * @param sourceId id of the desired node
+     * @return iterable over the reference role names
+     */
     fun getReferenceRoles(sourceId: Long): Iterable<String>
+
+    /**
+     * Returns all property roles for the given node in the tree of this transaction.
+     *
+     * @param sourceId id of the desired node
+     * @return iterable over the property role names
+     */
     fun getPropertyRoles(sourceId: Long): Iterable<String>
+
+    /**
+     * Returns the user object with the given key.
+     *
+     * @param key of the desired user object
+     * @return user object or null, if the key does not exist or the user object is null
+     */
     fun getUserObject(key: Any): Any?
+
+    /**
+     * Stores a user object by using the specified key.
+     *
+     * @param key key to be used
+     * @param value the user object to be stored
+     */
     fun putUserObject(key: Any, value: Any?)
 }
 
+/**
+ * Returns the key of the receiver role for the given transaction.
+ *
+ * @param t the desired transaction
+ * @return uid of the role, if the tree of the transaction uses role ids, or
+ *          the role name otherwise
+ */
 fun IRole.key(t: ITransaction): String = if (t.tree.usesRoleIds()) getUID() else getSimpleName()

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITree.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITree.kt
@@ -15,30 +15,232 @@
 
 package org.modelix.model.api
 
+/**
+ * Consists of [INode]s.
+ */
 interface ITree {
+    /**
+     * Checks whether this tree uses uids or names for roles.
+     *
+     * @return true, if the tree uses uids for roles, or
+     *         false, if the tree uses names for roles
+     */
     fun usesRoleIds(): Boolean
+
+    /**
+     * Returns the id of this tree.
+     *
+     * @return id of the tree
+     */
     fun getId(): String?
+
+    /**
+     * Propagates changes to the given visitor.
+     *
+     * @param oldVersion the old state of the tree
+     * @param visitor the given visitor
+     */
     fun visitChanges(oldVersion: ITree, visitor: ITreeChangeVisitor)
+
+    /**
+     * Checks if the given node is contained in this tree.
+     *
+     * @param nodeId id of the desired node
+     * @return true, if the node is contained in this tree, or false, otherwise
+     */
     fun containsNode(nodeId: Long): Boolean
+
+    /**
+     * Returns the property value of the given property role for the given node in this tree.
+     *
+     * @param nodeId id of the desired node
+     * @param role name or id of the property role
+     * @return value of the property for the given node
+     */
     fun getProperty(nodeId: Long, role: String): String?
+
+    /**
+     * Returns the children of the child link for the given node in this tree.
+     *
+     * @param parentId id of the desired node
+     * @param role name or id of the child link
+     * @return iterable over the child ids
+     */
     fun getChildren(parentId: Long, role: String?): Iterable<Long>
+
+    /**
+     * Returns the concept of the given node in this tree.
+     *
+     * @param nodeId id of the desired node
+     * @return concept of the node or null, if the concept could not be found
+     */
     fun getConcept(nodeId: Long): IConcept?
+
+    /**
+     * Returns a reference to the concept of the given node in this tree.
+     *
+     * @param nodeId id of the desired node
+     * @return reference to the concept of the node or null, if the concept could not be found
+     */
     fun getConceptReference(nodeId: Long): IConceptReference?
+
+    /**
+     * Returns the id of the parent node of the given node in this.
+     *
+     * @param nodeId id of the desired node
+     * @return node id of the parent node
+     */
     fun getParent(nodeId: Long): Long
+
+    /**
+     * Returns the role of the given node within its parent node in this tree.
+     *
+     * @param nodeId id of the desired node
+     * @return name of the role
+     */
     fun getRole(nodeId: Long): String?
+
+    /**
+     * Sets the value of the given node for the given property role to the specified value.
+     *
+     * @param nodeId id of the desired node
+     * @param role property role, for which the value should be set
+     * @param value the new property value
+     *
+     * @return tree with changes
+     */
     fun setProperty(nodeId: Long, role: String, value: String?): ITree
+
+    /**
+     * Returns the target of the given reference role for the given node in this tree.
+     *
+     * @param sourceId id of the source node
+     * @param role name or id of the reference role
+     * @return node reference to the target
+     */
     fun getReferenceTarget(sourceId: Long, role: String): INodeReference?
+
+    /**
+     * Sets the reference target of the given node for the given reference role to the specified target.
+     *
+     * @param sourceId id of the source node
+     * @param role reference role, for which the target should be set
+     * @param target the new reference target
+     *
+     * @return tree with changes
+     */
     fun setReferenceTarget(sourceId: Long, role: String, target: INodeReference?): ITree
+
+    /**
+     * Returns all reference roles for the given node in this tree.
+     *
+     * @param sourceId id of the desired node
+     * @return iterable over the reference role names or ids
+     */
     fun getReferenceRoles(sourceId: Long): Iterable<String>
+
+    /**
+     * Returns all property roles for the given node in this tree.
+     *
+     * @param sourceId id of the desired node
+     * @return iterable over the property role names or ids
+     */
     fun getPropertyRoles(sourceId: Long): Iterable<String>
+
+    /**
+     * Returns all child link roles for the given node in this tree.
+     *
+     * @param sourceId id of the desired node
+     * @return iterable over the child link names or ids
+     */
     fun getChildRoles(sourceId: Long): Iterable<String?>
+
+    /**
+     * Returns all children of the given node in this tree.
+     *
+     * @param parentId id of the desired node
+     * @return iterable over the child ids
+     */
     fun getAllChildren(parentId: Long): Iterable<Long>
+
+    /**
+     * Moves a node within this tree.
+     *
+     * @param newParentId id of the new parent node
+     * @param newRole new role within the parent node
+     * @param newIndex index within the role
+     * @param childId id of the node to be moved
+     *
+     * @throws RuntimeException when trying to move the root node
+     *                          or if the node specified by newParentID is a descendant of the node specified by childId
+     */
     fun moveChild(newParentId: Long, newRole: String?, newIndex: Int, childId: Long): ITree
+
+    /**
+     * Creates and adds a new child of the given concept to this tree.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param childId the id to be used for creation
+     * @param concept the concept of the new node
+     * @return tree with changes
+     *
+     * @throws [RuntimeException] if the childId already exists
+     */
     fun addNewChild(parentId: Long, role: String?, index: Int, childId: Long, concept: IConcept?): ITree
+
+    /**
+     * Creates and adds a new child of the given concept to this tree.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param concept concept reference to the concept of the new node
+     * @return tree with changes
+     */
     fun addNewChild(parentId: Long, role: String?, index: Int, childId: Long, concept: IConceptReference?): ITree
+
+    /**
+     * Creates and adds multiple new children of the given concepts to this tree.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param newIds the ids to be used for creation
+     * @param concepts the concepts of the new nodes
+     * @return tree with changes
+     *
+     * @throws [RuntimeException] if the childId already exists
+     */
     fun addNewChildren(parentId: Long, role: String?, index: Int, newIds: LongArray, concepts: Array<IConcept?>): ITree
+
+    /**
+     * Creates and adds multiple new children of the given concepts to this tree.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param newIds the ids to be used for creation
+     * @param concepts concept references to the concepts of the new nodes
+     * @return tree with changes
+     *
+     * @throws [RuntimeException] if the childId already exists
+     */
     fun addNewChildren(parentId: Long, role: String?, index: Int, newIds: LongArray, concepts: Array<IConceptReference?>): ITree
+
+    /**
+     * Deletes the given node.
+     *
+     * @param nodeId id of the node to be deleted
+     */
     fun deleteNode(nodeId: Long): ITree
+
+    /**
+     * Deletes the given nodes.
+     *
+     * @param nodeIds array of node ids to be deleted
+     */
     fun deleteNodes(nodeIds: LongArray): ITree
 
     companion object {
@@ -47,4 +249,11 @@ interface ITree {
     }
 }
 
+/**
+ * Returns the key of the receiver role for the given tree.
+ *
+ * @param tree the desired tree
+ * @return uid of the role, if the tree uses role ids, or
+ *          the role name otherwise
+ */
 fun IRole.key(tree: ITree): String = if (tree.usesRoleIds()) getUID() else getSimpleName()

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitor.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitor.kt
@@ -15,9 +15,38 @@
 
 package org.modelix.model.api
 
+/**
+ * Interface to handle changes within an [ITree].
+ */
 interface ITreeChangeVisitor {
+    /**
+     * Called when the containment of a node has changed.
+     *
+     * @param nodeId id of the affected node
+     */
     fun containmentChanged(nodeId: Long)
+
+    /**
+     * Called when the children of a node have changed.
+     *
+     * @param nodeId id of the affected parent
+     * @param role the affected child link role
+     */
     fun childrenChanged(nodeId: Long, role: String?)
+
+    /**
+     * Called when a reference of a node has changed.
+     *
+     * @param nodeId id of the affected node
+     * @param role the affected reference role
+     */
     fun referenceChanged(nodeId: Long, role: String)
+
+    /**
+     * Called when a property of a node has changed.
+     *
+     * @param nodeId id of the affected node
+     * @param role the affected property role
+     */
     fun propertyChanged(nodeId: Long, role: String)
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitorEx.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitorEx.kt
@@ -15,7 +15,21 @@
 
 package org.modelix.model.api
 
+/**
+ * Extension of [ITreeChangeVisitor], which can also handle removed and added nodes.
+ */
 interface ITreeChangeVisitorEx : ITreeChangeVisitor {
+    /**
+     * Called when a node has been removed.
+     *
+     * @param nodeId id of the deleted node
+     */
     fun nodeRemoved(nodeId: Long)
+
+    /**
+     * Called when a node has been added.
+     *
+     * @param nodeId id of the added node
+     */
     fun nodeAdded(nodeId: Long)
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IWriteTransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IWriteTransaction.kt
@@ -15,14 +15,97 @@
 
 package org.modelix.model.api
 
+/**
+ * Provides transactional read and write access to nodes.
+ */
 interface IWriteTransaction : ITransaction {
     override var tree: ITree
+
+    /**
+     * Sets the value of the given node for the given property role to the specified value.
+     *
+     * @param nodeId id of the desired node
+     * @param role property role, for which the value should be set
+     * @param value the new property value
+     */
     fun setProperty(nodeId: Long, role: String, value: String?)
+
+    /**
+     * Sets the reference target of the given node for the given reference role to the specified target.
+     *
+     * @param sourceId id of the source node
+     * @param role reference role, for which the target should be set
+     * @param target the new reference target
+     */
     fun setReferenceTarget(sourceId: Long, role: String, target: INodeReference?)
+
+    /**
+     * Moves a node within the tree of this transaction.
+     *
+     * @param newParentId id of the new parent node
+     * @param newRole new role within the parent node
+     * @param newIndex index within the role
+     * @param childId id of the node to be moved
+     *
+     * @throws RuntimeException when trying to move the root node
+     *                          or if the node specified by newParentID is a descendant of the node specified by childId
+     */
     fun moveChild(newParentId: Long, newRole: String?, newIndex: Int, childId: Long)
+
+    /**
+     * Creates and adds a new child of the given concept to the tree of this transaction.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param concept concept of the new node
+     *
+     * @return id of the newly created node
+     */
     fun addNewChild(parentId: Long, role: String?, index: Int, concept: IConcept?): Long
+
+    /**
+     * Creates and adds a new child of the given concept to the tree of this transaction.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param concept concept reference to the concept of the new node
+     *
+     * @return id of the newly created node
+     */
     fun addNewChild(parentId: Long, role: String?, index: Int, concept: IConceptReference?): Long
+
+    /**
+     * Creates and adds a new child of the given concept to the tree of this transaction.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param childId the id to be used for creation
+     * @param concept the concept of the new node
+     *
+     * @throws [RuntimeException] if the childId already exists
+     */
     fun addNewChild(parentId: Long, role: String?, index: Int, childId: Long, concept: IConcept?)
+
+    /**
+     * Creates and adds a new child of the given concept to the tree of this transaction.
+     *
+     * @param parentId id of the parent node
+     * @param role child link role within the parent node
+     * @param index index within the child link role
+     * @param childId the id to be used for creation
+     * @param concept concept reference to the concept of the new node
+     *
+     * @throws [RuntimeException] if the childId already exists
+     */
     fun addNewChild(parentId: Long, role: String?, index: Int, childId: Long, concept: IConceptReference?)
+
+    /**
+     * Deletes the given node.
+     *
+     * @param nodeId id of the node to be deleted
+     */
     fun deleteNode(nodeId: Long)
 }


### PR DESCRIPTION
This adds basic documentation to the interfaces of the model api.
It should be considered as a starting point and the information should be verified before merging.