### PR TITLE
fix(model-server-lib): don't throw exceptions for missing children

### DIFF
--- a/model-server-lib/src/main/kotlin/org/modelix/model/server/light/QueryImplementation.kt
+++ b/model-server-lib/src/main/kotlin/org/modelix/model/server/light/QueryImplementation.kt
@@ -47,7 +47,11 @@ fun RootOrSubquery.queryNodes(node: INode): Sequence<INode> {
     return when (this) {
         is QueryAllChildren -> node.allChildren.asSequence()
         is QueryAncestors -> node.getAncestors(false)
-        is QueryChildren -> node.getChildren(this.role).asSequence()
+        is QueryChildren -> try {
+            node.getChildren(this.role).asSequence()
+        } catch (e: RuntimeException) {
+            emptySequence()
+        }
         is QueryDescendants -> node.getDescendants(false)
         is QueryParent -> listOfNotNull(node.parent).asSequence()
         is QueryReference -> {


### PR DESCRIPTION
Restore the old behavior of allow to query non-existing children similar to what has been done in MODELIX-435 for references.

Fixes: #MODELIX-444