### PR TITLE
MODELIX-455 Transfer MPS deprecations to generated Kotlin code

### DIFF
--- a/metamodel-export/org.modelix.metamodel.export/models/org.modelix.metamodel.export.mps
+++ b/metamodel-export/org.modelix.metamodel.export/models/org.modelix.metamodel.export.mps
@@ -9,6 +9,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
   </languages>
   <imports>
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
@@ -28,6 +29,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -1274,7 +1276,7 @@
                                     <node concept="3clFbF" id="3Fg0S50exts" role="3cqZAp">
                                       <node concept="2ShNRf" id="3Fg0S50extt" role="3clFbG">
                                         <node concept="1pGfFk" id="3Fg0S50extu" role="2ShVmc">
-                                          <ref role="37wK5l" to="sgfj:~PropertyData.&lt;init&gt;(java.lang.String,java.lang.String,org.modelix.model.data.PropertyType,boolean)" resolve="PropertyData" />
+                                          <ref role="37wK5l" to="sgfj:~PropertyData.&lt;init&gt;(java.lang.String,java.lang.String,org.modelix.model.data.PropertyType,boolean,java.lang.String)" resolve="PropertyData" />
                                           <node concept="2OqwBi" id="sN$G5gkz6p" role="37wK5m">
                                             <node concept="2YIFZM" id="sN$G5gkwjt" role="2Oq$k0">
                                               <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
@@ -1300,6 +1302,12 @@
                                           </node>
                                           <node concept="3clFbT" id="7jUShhooSid" role="37wK5m">
                                             <property role="3clFbU" value="true" />
+                                          </node>
+                                          <node concept="1rXfSq" id="6leOzHDskSh" role="37wK5m">
+                                            <ref role="37wK5l" node="6leOzHDqtxp" resolve="deprecationMsg" />
+                                            <node concept="37vLTw" id="6leOzHDsn6Y" role="37wK5m">
+                                              <ref role="3cqZAo" node="3Fg0S50extz" resolve="it" />
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
@@ -1408,7 +1416,7 @@
                                     <node concept="3clFbF" id="3Fg0S50eoNA" role="3cqZAp">
                                       <node concept="2ShNRf" id="3Fg0S50eoNB" role="3clFbG">
                                         <node concept="1pGfFk" id="3Fg0S50eoNC" role="2ShVmc">
-                                          <ref role="37wK5l" to="sgfj:~ChildLinkData.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,boolean,boolean)" resolve="ChildLinkData" />
+                                          <ref role="37wK5l" to="sgfj:~ChildLinkData.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,boolean,boolean,java.lang.String)" resolve="ChildLinkData" />
                                           <node concept="2OqwBi" id="sN$G5gkB5e" role="37wK5m">
                                             <node concept="2YIFZM" id="sN$G5gkCu1" role="2Oq$k0">
                                               <ref role="1Pybhc" to="e8bb:~MetaIdByDeclaration" resolve="MetaIdByDeclaration" />
@@ -1453,6 +1461,12 @@
                                               <node concept="2qgKlT" id="3Fg0S50eoNS" role="2OqNvi">
                                                 <ref role="37wK5l" to="tpcn:2VYdUfnkjmB" resolve="isAtLeastOneCardinality" />
                                               </node>
+                                            </node>
+                                          </node>
+                                          <node concept="1rXfSq" id="6leOzHDspCB" role="37wK5m">
+                                            <ref role="37wK5l" node="6leOzHDqtxp" resolve="deprecationMsg" />
+                                            <node concept="37vLTw" id="6leOzHDss7R" role="37wK5m">
+                                              <ref role="3cqZAo" node="3Fg0S50eoNT" resolve="it" />
                                             </node>
                                           </node>
                                         </node>
@@ -1561,7 +1575,7 @@
                                     <node concept="3clFbF" id="3Fg0S50e_EG" role="3cqZAp">
                                       <node concept="2ShNRf" id="3Fg0S50e_EH" role="3clFbG">
                                         <node concept="1pGfFk" id="3Fg0S50e_EI" role="2ShVmc">
-                                          <ref role="37wK5l" to="sgfj:~ReferenceLinkData.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,boolean)" resolve="ReferenceLinkData" />
+                                          <ref role="37wK5l" to="sgfj:~ReferenceLinkData.&lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String)" resolve="ReferenceLinkData" />
                                           <node concept="2OqwBi" id="sN$G5gkFrP" role="37wK5m">
                                             <node concept="2YIFZM" id="sN$G5gkGsm" role="2Oq$k0">
                                               <ref role="37wK5l" to="e8bb:~MetaIdByDeclaration.getLinkId(org.jetbrains.mps.openapi.model.SNode)" resolve="getLinkId" />
@@ -1596,6 +1610,12 @@
                                               <node concept="2qgKlT" id="3Fg0S50e_EY" role="2OqNvi">
                                                 <ref role="37wK5l" to="tpcn:2VYdUfnkjmB" resolve="isAtLeastOneCardinality" />
                                               </node>
+                                            </node>
+                                          </node>
+                                          <node concept="1rXfSq" id="6leOzHDsvk5" role="37wK5m">
+                                            <ref role="37wK5l" node="6leOzHDqtxp" resolve="deprecationMsg" />
+                                            <node concept="37vLTw" id="6leOzHDsx8H" role="37wK5m">
+                                              <ref role="3cqZAo" node="3Fg0S50e_EZ" resolve="it" />
                                             </node>
                                           </node>
                                         </node>
@@ -1732,7 +1752,7 @@
                       <node concept="3clFbF" id="3Fg0S50cWJn" role="3cqZAp">
                         <node concept="2ShNRf" id="3Fg0S50cWJj" role="3clFbG">
                           <node concept="1pGfFk" id="3Fg0S50cX7i" role="2ShVmc">
-                            <ref role="37wK5l" to="sgfj:~ConceptData.&lt;init&gt;(java.lang.String,java.lang.String,boolean,java.util.List,java.util.List,java.util.List,java.util.List)" resolve="ConceptData" />
+                            <ref role="37wK5l" to="sgfj:~ConceptData.&lt;init&gt;(java.lang.String,java.lang.String,boolean,java.util.List,java.util.List,java.util.List,java.util.List,java.lang.String)" resolve="ConceptData" />
                             <node concept="3cpWs3" id="2sGJABKvA1m" role="37wK5m">
                               <node concept="Xl_RD" id="2sGJABKvBm5" role="3uHU7B">
                                 <property role="Xl_RC" value="mps:" />
@@ -1772,6 +1792,12 @@
                             </node>
                             <node concept="37vLTw" id="3Fg0S50fMQv" role="37wK5m">
                               <ref role="3cqZAo" node="3Fg0S50fId_" resolve="superConcepts" />
+                            </node>
+                            <node concept="1rXfSq" id="6leOzHDs$KP" role="37wK5m">
+                              <ref role="37wK5l" node="6leOzHDqtxp" resolve="deprecationMsg" />
+                              <node concept="37vLTw" id="6leOzHDsAcV" role="37wK5m">
+                                <ref role="3cqZAo" node="3Fg0S50cWmY" resolve="concept" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -1926,7 +1952,7 @@
                       <node concept="3clFbF" id="4zSRxm70TNt" role="3cqZAp">
                         <node concept="2ShNRf" id="4zSRxm70TNp" role="3clFbG">
                           <node concept="1pGfFk" id="4zSRxm70V1b" role="2ShVmc">
-                            <ref role="37wK5l" to="sgfj:~EnumData.&lt;init&gt;(java.lang.String,java.lang.String,java.util.List,int)" resolve="EnumData" />
+                            <ref role="37wK5l" to="sgfj:~EnumData.&lt;init&gt;(java.lang.String,java.lang.String,java.util.List,int,java.lang.String)" resolve="EnumData" />
                             <node concept="3cpWs3" id="5pDpbLMqabe" role="37wK5m">
                               <node concept="Xl_RD" id="5pDpbLMqceA" role="3uHU7B">
                                 <property role="Xl_RC" value="mps:" />
@@ -1957,6 +1983,12 @@
                             </node>
                             <node concept="37vLTw" id="3lhG7y_rl7q" role="37wK5m">
                               <ref role="3cqZAo" node="5IyBvLCgrR0" resolve="defaultIndex" />
+                            </node>
+                            <node concept="1rXfSq" id="6leOzHDsENP" role="37wK5m">
+                              <ref role="37wK5l" node="6leOzHDqtxp" resolve="deprecationMsg" />
+                              <node concept="37vLTw" id="6leOzHDsGa8" role="37wK5m">
+                                <ref role="3cqZAo" node="4zSRxm6ZEdl" resolve="it" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2283,6 +2315,66 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="6leOzHDqtxp" role="jymVt">
+      <property role="TrG5h" value="deprecationMsg" />
+      <node concept="3clFbS" id="6leOzHDqtxs" role="3clF47">
+        <node concept="3clFbJ" id="6leOzHDqC9S" role="3cqZAp">
+          <node concept="3fqX7Q" id="6leOzHDr_RD" role="3clFbw">
+            <node concept="2OqwBi" id="6leOzHDr_RF" role="3fr31v">
+              <node concept="37vLTw" id="6leOzHDr_RG" role="2Oq$k0">
+                <ref role="3cqZAo" node="6leOzHDq_Eo" resolve="node" />
+              </node>
+              <node concept="2qgKlT" id="6leOzHDr_RH" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hOwoPtR" resolve="isDeprecated" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="6leOzHDqC9U" role="3clFbx">
+            <node concept="3cpWs6" id="6leOzHDrBbR" role="3cqZAp">
+              <node concept="10Nm6u" id="6leOzHDrDBv" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6leOzHDrI5Q" role="3cqZAp">
+          <node concept="3cpWsn" id="6leOzHDrI5T" role="3cpWs9">
+            <property role="TrG5h" value="msg" />
+            <node concept="17QB3L" id="6leOzHDrI5O" role="1tU5fm" />
+            <node concept="2OqwBi" id="6leOzHDrS2E" role="33vP2m">
+              <node concept="37vLTw" id="6leOzHDrQxZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="6leOzHDq_Eo" resolve="node" />
+              </node>
+              <node concept="2qgKlT" id="6leOzHDrToO" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hP43_8K" resolve="getMessage" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6leOzHDrWAo" role="3cqZAp">
+          <node concept="3K4zz7" id="6leOzHDs4b0" role="3cqZAk">
+            <node concept="37vLTw" id="6leOzHDs5vt" role="3K4E3e">
+              <ref role="3cqZAo" node="6leOzHDrI5T" resolve="msg" />
+            </node>
+            <node concept="Xl_RD" id="6leOzHDs7Ht" role="3K4GZi">
+              <property role="Xl_RC" value="" />
+            </node>
+            <node concept="3y3z36" id="6leOzHDs0lI" role="3K4Cdx">
+              <node concept="10Nm6u" id="6leOzHDs2_M" role="3uHU7w" />
+              <node concept="37vLTw" id="6leOzHDrYOq" role="3uHU7B">
+                <ref role="3cqZAo" node="6leOzHDrI5T" resolve="msg" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6leOzHDqs7t" role="1B3o_S" />
+      <node concept="17QB3L" id="6leOzHDqtlk" role="3clF45" />
+      <node concept="37vLTG" id="6leOzHDq_Eo" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6leOzHDq_En" role="1tU5fm">
+          <ref role="ehGHo" to="tpck:hOwnYed" resolve="IDeprecatable" />
         </node>
       </node>
     </node>

--- a/metamodel-export/org.modelix.metamodel.export/org.modelix.metamodel.export.msd
+++ b/metamodel-export/org.modelix.metamodel.export/org.modelix.metamodel.export.msd
@@ -65,6 +65,7 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/model-api-gen-gradle-test/build.gradle.kts
+++ b/model-api-gen-gradle-test/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     testImplementation(files("$buildDir/metamodel/kotlin_gen") {
         builtBy("generateMetaModelSources")
     })
+    testImplementation(kotlin("reflect"))
 }
 
 tasks.test {

--- a/model-api-gen-gradle-test/src/test/kotlin/GeneratedApiTest.kt
+++ b/model-api-gen-gradle-test/src/test/kotlin/GeneratedApiTest.kt
@@ -1,5 +1,10 @@
+import jetbrains.mps.baseLanguage.C_ClassConcept
+import jetbrains.mps.baseLanguage.jdk8.C_SuperInterfaceMethodCall_old
+import jetbrains.mps.lang.behavior.C_ConceptMethodDeclaration
 import jetbrains.mps.lang.core.L_jetbrains_mps_lang_core
 import jetbrains.mps.lang.editor.*
+import jetbrains.mps.lang.smodel.query.CustomScope_old
+import org.junit.jupiter.api.BeforeAll
 import org.modelix.metamodel.TypedLanguagesRegistry
 import org.modelix.metamodel.typed
 import org.modelix.metamodel.untyped
@@ -8,6 +13,10 @@ import org.modelix.model.api.INode
 import org.modelix.model.api.getRootNode
 import org.modelix.model.data.ModelData
 import java.io.File
+import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -29,6 +38,21 @@ class GeneratedApiTest {
             assertEquals(enumValue, node.untyped().typed(C_FontStyleStyleClassItem.getInstanceInterface()).style)
         }
     }
+
+    @Test
+    fun `propagates deprecations`() {
+        val foundDeprecatedConcept = C_SuperInterfaceMethodCall_old::class.hasDeprecationWithMessage()
+        val foundDeprecatedProperty = C_ConceptMethodDeclaration::class.members.any { it.hasDeprecationWithMessage() }
+        val foundDeprecatedChildLink = C_ClassConcept::class.members.any { it.hasDeprecationWithMessage() }
+        val foundDeprecatedReference = C_SuperInterfaceMethodCall_old::class.members.any { it.hasDeprecationWithMessage() }
+        assert(foundDeprecatedConcept)
+        assert(foundDeprecatedProperty)
+        assert(foundDeprecatedChildLink)
+        assert(foundDeprecatedReference)
+    }
+
+    private fun KAnnotatedElement.hasDeprecationWithMessage() =
+        findAnnotation<Deprecated>()?.message?.isNotEmpty() ?: false
 
     private fun findNodeWithStyleAttribute(node: INode) : INode? {
         var found = node.allChildren.find { it.getPropertyRoles().contains("style") }

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
@@ -158,7 +158,7 @@ internal class ProcessedLanguage(var name: String, var uid: String?) {
 
     fun load(dataList: List<ConceptData>) {
         for (data in dataList) {
-            addConcept(ProcessedConcept(data.name, data.uid, data.abstract, data.extends.map { ProcessedConceptReference(it) }.toMutableList()).also { concept ->
+            addConcept(ProcessedConcept(data.name, data.uid, data.abstract, data.extends.map { ProcessedConceptReference(it) }.toMutableList(), data.deprecationMessage).also { concept ->
                 concept.loadRoles(data)
             })
         }
@@ -166,7 +166,7 @@ internal class ProcessedLanguage(var name: String, var uid: String?) {
 
     fun loadEnums(dataList: List<EnumData>) {
         for (data in dataList) {
-            val enum = ProcessedEnum(data.name, data.uid, maxOf(0, data.defaultIndex))
+            val enum = ProcessedEnum(data.name, data.uid, maxOf(0, data.defaultIndex), data.deprecationMessage)
             for (memberData in data.members) {
                 val member = ProcessedEnumMember(memberData.name, memberData.uid, memberData.presentation)
                 enum.addMember(member)
@@ -184,7 +184,16 @@ internal class ProcessedConceptReference(var name: String) {
     lateinit var resolved: ProcessedConcept
 }
 
-internal class ProcessedEnum(var name: String, var uid: String?, var defaultIndex: Int) {
+internal sealed interface IProcessedDeprecatable {
+    var deprecationMessage: String?
+}
+
+internal class ProcessedEnum(
+    var name: String,
+    var uid: String?,
+    var defaultIndex: Int,
+    override var deprecationMessage: String?
+) : IProcessedDeprecatable {
     lateinit var language: ProcessedLanguage
     private val members: MutableList<ProcessedEnumMember> = ArrayList()
 
@@ -200,7 +209,13 @@ internal class ProcessedEnumMember(var name: String, var uid: String, var presen
     lateinit var enum: ProcessedEnum
 }
 
-internal class ProcessedConcept(var name: String, var uid: String?, var abstract: Boolean, val extends: MutableList<ProcessedConceptReference>) {
+internal class ProcessedConcept(
+    var name: String,
+    var uid: String?,
+    var abstract: Boolean,
+    val extends: MutableList<ProcessedConceptReference>,
+    override var deprecationMessage: String?
+) : IProcessedDeprecatable {
     lateinit var language: ProcessedLanguage
     private val roles: MutableList<ProcessedRole> = ArrayList()
 
@@ -216,9 +231,9 @@ internal class ProcessedConcept(var name: String, var uid: String?, var abstract
     fun getOwnAndDuplicateRoles(): List<ProcessedRole> = roles + getDuplicateSuperConcepts().flatMap { it.getOwnRoles() }
 
     fun loadRoles(data: ConceptData) {
-        data.properties.forEach { addRole(ProcessedProperty(it.name, it.uid, it.optional, it.type)) }
-        data.children.forEach { addRole(ProcessedChildLink(it.name, it.uid, it.optional, it.multiple, ProcessedConceptReference(it.type))) }
-        data.references.forEach { addRole(ProcessedReferenceLink(it.name, it.uid, it.optional, ProcessedConceptReference(it.type))) }
+        data.properties.forEach { addRole(ProcessedProperty(it.name, it.uid, it.optional, it.type, it.deprecationMessage)) }
+        data.children.forEach { addRole(ProcessedChildLink(it.name, it.uid, it.optional, it.multiple, ProcessedConceptReference(it.type), it.deprecationMessage)) }
+        data.references.forEach { addRole(ProcessedReferenceLink(it.name, it.uid, it.optional, ProcessedConceptReference(it.type), it.deprecationMessage)) }
     }
 
     fun visitConceptReferences(visitor: (ProcessedConceptReference) -> Unit) {
@@ -238,28 +253,29 @@ internal class ProcessedConcept(var name: String, var uid: String?, var abstract
 internal sealed class ProcessedRole(
     var originalName: String,
     var uid: String?,
-    var optional: Boolean
-) {
+    var optional: Boolean,
+    override var deprecationMessage: String?
+) : IProcessedDeprecatable {
     lateinit var concept: ProcessedConcept
     var generatedName: String = originalName
 
     abstract fun visitConceptReferences(visitor: (ProcessedConceptReference) -> Unit)
 }
 
-internal class ProcessedProperty(name: String, uid: String?, optional: Boolean, var type: PropertyType)
-    : ProcessedRole(name, uid, optional) {
+internal class ProcessedProperty(name: String, uid: String?, optional: Boolean, var type: PropertyType, deprecationMessage: String?)
+    : ProcessedRole(name, uid, optional, deprecationMessage) {
     override fun visitConceptReferences(visitor: (ProcessedConceptReference) -> Unit) {}
 }
 
-internal sealed class ProcessedLink(name: String, uid: String?, optional: Boolean, var type: ProcessedConceptReference)
-    : ProcessedRole(name, uid, optional) {
+internal sealed class ProcessedLink(name: String, uid: String?, optional: Boolean, var type: ProcessedConceptReference, deprecationMessage: String?)
+    : ProcessedRole(name, uid, optional, deprecationMessage) {
     override fun visitConceptReferences(visitor: (ProcessedConceptReference) -> Unit) {
         visitor(type)
     }
 }
 
-internal class ProcessedChildLink(name: String, uid: String?, optional: Boolean, var multiple: Boolean, type: ProcessedConceptReference)
-    : ProcessedLink(name, uid, optional, type)
+internal class ProcessedChildLink(name: String, uid: String?, optional: Boolean, var multiple: Boolean, type: ProcessedConceptReference, deprecationMessage: String?)
+    : ProcessedLink(name, uid, optional, type, deprecationMessage)
 
-internal class ProcessedReferenceLink(name: String, uid: String?, optional: Boolean, type: ProcessedConceptReference)
-    : ProcessedLink(name, uid, optional, type)
+internal class ProcessedReferenceLink(name: String, uid: String?, optional: Boolean, type: ProcessedConceptReference, deprecationMessage: String?)
+    : ProcessedLink(name, uid, optional, type, deprecationMessage)

--- a/model-api/src/commonMain/kotlin/org/modelix/model/data/MetaModelData.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/data/MetaModelData.kt
@@ -29,6 +29,10 @@ data class LanguageData(
     }
 }
 
+sealed interface IDeprecatable {
+    val deprecationMessage: String?
+}
+
 @Serializable
 data class ConceptData(
     val uid: String? = null,
@@ -37,16 +41,18 @@ data class ConceptData(
     val properties: List<PropertyData> = emptyList(),
     val children: List<ChildLinkData> = emptyList(),
     val references: List<ReferenceLinkData> = emptyList(),
-    val extends: List<String> = emptyList()
-)
+    val extends: List<String> = emptyList(),
+    override val deprecationMessage: String? = null
+) : IDeprecatable
 
 @Serializable
 data class EnumData(
     val uid: String? = null,
     val name: String,
     val members: List<EnumMemberData> = emptyList(),
-    val defaultIndex: Int
-)
+    val defaultIndex: Int,
+    override val deprecationMessage: String? = null
+) : IDeprecatable
 
 @Serializable
 data class EnumMemberData(
@@ -65,8 +71,9 @@ data class PropertyData(
     override val uid: String? = null,
     override val name: String,
     val type: PropertyType = PrimitivePropertyType(Primitive.STRING),
-    val optional: Boolean = true
-) : IConceptFeatureData
+    val optional: Boolean = true,
+    override val deprecationMessage: String? = null
+) : IConceptFeatureData, IDeprecatable
 
 class PropertyTypeSerializer : KSerializer<PropertyType> {
     override fun deserialize(decoder: Decoder): PropertyType {
@@ -109,13 +116,15 @@ data class ChildLinkData(
     override val name: String,
     val type: String,
     val multiple: Boolean = false,
-    val optional: Boolean = true
-) : IConceptFeatureData
+    val optional: Boolean = true,
+    override val deprecationMessage: String? = null
+) : IConceptFeatureData, IDeprecatable
 
 @Serializable
 data class ReferenceLinkData(
     override val uid: String? = null,
     override val name: String,
     val type: String,
-    val optional: Boolean = true
-) : IConceptFeatureData
+    val optional: Boolean = true,
+    override val deprecationMessage: String? = null
+) : IConceptFeatureData, IDeprecatable


### PR DESCRIPTION
Deprecations from MPS are propagated to the corresponding generated ConceptWrapperInterface (or its members).
The test for this might break if the referenced deprecations are removed from baseLanguage in the future.
I'm open to suggestions on how to make the test easier to maintain.