### PR TITLE
fix(model-api-gen): Add missing parentheses for getter method declarations and definitions. Fix null-safe unwrap method call.

### DIFF
--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
@@ -138,9 +138,9 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                     val entityType = "$languagePrefix${typeRef.nodeWrapperInterfaceName()}"
                     """
                     public set ${feature.generatedName}(value: $entityType | undefined) {
-                        this.node.setReferenceTargetNode("${feature.originalName}", value.unwrap());
+                        this.node.setReferenceTargetNode("${feature.originalName}", value?.unwrap());
                     }
-                    public get ${feature.generatedName}: $entityType | undefined {
+                    public get ${feature.generatedName}(): $entityType | undefined {
                         return LanguageRegistry.INSTANCE.wrapNode(this.node.getReferenceTargetNode("${feature.originalName}"));
                     }
                 """.trimIndent()
@@ -186,7 +186,7 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                     val entityType = "$languagePrefix${typeRef.nodeWrapperInterfaceName()}"
                         """
                         set ${feature.generatedName}(value: $entityType | undefined);
-                        get ${feature.generatedName}: $entityType | undefined;
+                        get ${feature.generatedName}(): $entityType | undefined;
                     """.trimIndent()
                 }
                 is ProcessedChildLink -> {


### PR DESCRIPTION
Follow-up bugfix for https://github.com/modelix/modelix.core/pull/144 in collaboration with @abstraktor.