### PR TITLE
MODELIX-465 Ordering of versions in the generated API Reference Landing Page is broken

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ import org.semver.Version
 
 buildscript {
     dependencies {
-        classpath("org.jetbrains.dokka:versioning-plugin:1.8.10")
-        classpath("org.semver:api:0.9.33")
+        classpath(libs.dokka.versioning)
+        classpath(libs.semver)
     }
 }
 
@@ -21,7 +21,7 @@ plugins {
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.tasktree)
-    id("org.jetbrains.dokka") version "1.8.20"
+    alias(libs.plugins.dokka)
 }
 
 repositories {
@@ -46,7 +46,7 @@ fun computeVersion(): Any {
 }
 
 dependencies {
-    dokkaPlugin("org.jetbrains.dokka:versioning-plugin:1.8.10")
+    dokkaPlugin(libs.dokka.versioning)
 }
 
 subprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,12 @@ import kotlinx.html.stream.createHTML
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import org.semver.Version
 
 buildscript {
     dependencies {
         classpath("org.jetbrains.dokka:versioning-plugin:1.8.10")
+        classpath("org.semver:api:0.9.33")
     }
 }
 
@@ -204,7 +206,7 @@ fun createDocsIndexPage(): String {
                             div("table") {
                                 val versionDirs = docsDir.listFiles()
                                     ?.filter { it.isDirectory }
-                                    ?.sortedByDescending { it.name }
+                                    ?.sortedByDescending { Version.parse(it.name) }
                                 if (versionDirs != null) {
                                     for (versionDir in versionDirs) {
                                         val versionIndex = versionDir.resolve("index.html")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.4.0" }
 spotless = { id = "com.diffplug.spotless", version = "6.18.0" }
 tasktree = { id = "com.dorongold.task-tree", version = "2.1.1" }
 modelix-mps-buildtools = { id = "org.modelix.mps.build-tools", version = "1.1.0" }
+dokka = {id = "org.jetbrains.dokka", version = "1.8.20"}
 
 [versions]
 
@@ -83,3 +84,6 @@ junit = { group = "junit", name = "junit", version = "4.13.2" }
 
 apache-cxf-sse = { group = "org.apache.cxf", name = "cxf-rt-rs-sse", version.ref = "apacheCxf" }
 apache-cxf-client = { group = "org.apache.cxf", name = "cxf-rt-rs-client", version.ref = "apacheCxf" }
+
+semver = { group = "org.semver", name = "api", version = "0.9.33"}
+dokka-versioning = { group = "org.jetbrains.dokka", name = "versioning-plugin", version = "1.8.20"}


### PR DESCRIPTION
After merging this and a new deployment triggered by the next minor release, the ordering will be fixed automatically.