### PR TITLE
(model-api-gen): fix primitive property and reference link code generator bugs

### DIFF
--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
@@ -144,7 +144,11 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                         this.node.setReferenceTargetNode("${feature.originalName}", value?.unwrap());
                     }
                     public get ${feature.generatedName}(): $entityType | undefined {
-                        return LanguageRegistry.INSTANCE.wrapNode(this.node.getReferenceTargetNode("${feature.originalName}"));
+                        let node = this.node.getReferenceTargetNode("${feature.originalName}");
+                        if (node === undefined) {
+                           return node;
+                        }
+                        return LanguageRegistry.INSTANCE.wrapNode(node) as $entityType;
                     }
                 """.trimIndent()
                 }

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
@@ -108,10 +108,11 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                             Primitive.INT -> {
                                 """
                                 public set ${feature.generatedName}(value: number) {
-                                    this.${rawValueName} = value.toString();
+                                    let str = value.toString();
+                                    this.node.setPropertyValue("${feature.generatedName}", str);
                                 }
                                 public get ${feature.generatedName}(): number {
-                                    let str = this.${rawValueName};
+                                    let str = this.node.getPropertyValue("${feature.generatedName}");
                                     return str ? parseInt(str) : 0;
                                 }
                                 
@@ -120,10 +121,12 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                             Primitive.BOOLEAN -> {
                                 """
                                 public set ${feature.generatedName}(value: boolean) {
-                                    this.${rawValueName} = value ? "true" : "false";
+                                    let str = value ? "true" : "false";
+                                    this.node.setPropertyValue("${feature.generatedName}", str);
                                 }
                                 public get ${feature.generatedName}(): boolean {
-                                    return this.${rawValueName} === "true";
+                                    let str = this.node.getPropertyValue("${feature.generatedName}");
+                                    return str === "true";
                                 }
                                 
                             """.trimIndent()


### PR DESCRIPTION
4cbe09e fixes follow-up bugs of #144 (cc @abstraktor):
- the argument of `LanguageRegistry.INSTANCE.wrapNode` cannot be `undefined`.
- `LanguageRegistry.INSTANCE.wrapNode` returns `ITypedNode`, but we have to cast it to the return type of the method.

683e95e fixes a bug that the `raw_*` fields are not generated for primitive type fields. Instead of storing the raw string values in the `raw_*` fields, I would propose to store them as property value. This way, we do not have to declare and define the `raw_*` fields on the owner classes and interfaces, which makes the code generator simpler.