### PR TITLE
Increase default connection timeout

### DIFF
--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
@@ -117,7 +117,7 @@ class RestWebModelClient @JvmOverloads constructor(
     private val client = (providedClient ?: HttpClient(CIO)).config {
         this.followRedirects = false
         install(HttpTimeout) {
-            connectTimeoutMillis = 1.seconds.inWholeMilliseconds
+            connectTimeoutMillis = 30.seconds.inWholeMilliseconds
             requestTimeoutMillis = 30.seconds.inWholeMilliseconds
         }
         install(ContentNegotiation) {


### PR DESCRIPTION
The RestWebModelClient has a hard-coded 1 seconds connection timeout in its constructor. This timeout cannot be influenced from the outside, but it makes our tests fail. This PR increases the timeout to 30 seconds, which might be better.

A better fix of this problem would be if RestWebModelClient would take into consideration the timeout values coming from `providedClient`, if it makes sense.