### PR TITLE
NumberFormatException in ClientIdProcessor

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/store/ClientIdProcessor.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/ClientIdProcessor.kt
@@ -22,8 +22,11 @@ class ClientIdProcessor : EntryProcessor<String?, String?, Long> {
     @Throws(EntryProcessorException::class)
     override fun process(mutableEntry: MutableEntry<String?, String?>, vararg objects: Any): Long {
         val idStr = mutableEntry.value
-        var id = idStr?.toLong() ?: 0
-        id++
+        val id = try {
+            idStr?.toLong() ?: 0L
+        } catch (e : NumberFormatException) {
+            0L
+        } + 1L
         mutableEntry.value = id.toString()
         return id
     }


### PR DESCRIPTION
This MR fixes a NumberFormatException that may occur if the String does not represent a Long value (e.g. overflown Long, a String that has nothing to do with a Long number, etc.). The fix is the same as how String is parsed to Long in the [InMemoryStoreClient.generateId](https://github.com/modelix/modelix.core/blob/main/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt#L82) method.