### PR TITLE
Long range safe ID generator

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/store/ClientIdProcessor.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/ClientIdProcessor.kt
@@ -21,12 +21,7 @@ import javax.cache.processor.MutableEntry
 class ClientIdProcessor : EntryProcessor<String?, String?, Long> {
     @Throws(EntryProcessorException::class)
     override fun process(mutableEntry: MutableEntry<String?, String?>, vararg objects: Any): Long {
-        val idStr = mutableEntry.value
-        val id = try {
-            idStr?.toLong() ?: 0L
-        } catch (e : NumberFormatException) {
-            0L
-        } + 1L
+        val id = generateId(mutableEntry.value)
         mutableEntry.value = id.toString()
         return id
     }

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt
@@ -22,6 +22,19 @@ import java.io.FileWriter
 import java.io.IOException
 import java.util.*
 
+fun generateId(idStr: String?): Long {
+    return try {
+        val candidate = idStr?.toLong()
+        if (candidate == null || candidate == Long.MAX_VALUE || candidate < 0L) {
+            0L
+        } else {
+            candidate
+        }
+    } catch (e : NumberFormatException) {
+        0L
+    } + 1L
+}
+
 class InMemoryStoreClient : IStoreClient {
     companion object {
         private val LOG = LoggerFactory.getLogger(InMemoryStoreClient::class.java)
@@ -79,11 +92,7 @@ class InMemoryStoreClient : IStoreClient {
 
     @Synchronized
     override fun generateId(key: String): Long {
-        val id = try {
-            get(key)?.toLong() ?: 0L
-        } catch (e : NumberFormatException) {
-            0L
-        } + 1L
+        val id = generateId(get(key))
         put(key, id.toString(), false)
         return id
     }


### PR DESCRIPTION
As a follow-up of https://github.com/modelix/modelix.core/pull/162, I implemented an ID generator that is null and Long range safe. It increments the parameter ID by one. If the input parameter is null, 0, not a Long number or equals to Long.MAX_VALUE, then it replaces it with 0L. This way, we can be sure that the resulting ID is always a positive Long number that is at most Long.MAX_VALUE.

The generator is a function that is used both in ClientIdProcessor and InMemoryStoreClient to avoid double maintenance efforts.