### PR TITLE
ci: avoid duplicate builds in PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,10 @@ name: Build
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request: {}
+  # allow manual execution just in case
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Only trigger builds on PRs and not also on every push to avoid building twice.

Fixes: MODELIX-471