### PR TITLE
feat(model-server): add an online help for command line arguments

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/CmdLineArgs.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/CmdLineArgs.kt
@@ -39,4 +39,7 @@ internal class CmdLineArgs {
         converter = BooleanConverter::class
     )
     var schemaInit = false
+
+    @Parameter(names = ["-h", "--help"], help = true)
+    var help = false
 }

--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -54,7 +54,14 @@ object Main {
     @JvmStatic
     fun main(args: Array<String>) {
         val cmdLineArgs = CmdLineArgs()
-        JCommander(cmdLineArgs).parse(*args)
+        val commander = JCommander(cmdLineArgs)
+        commander.parse(*args)
+
+        if (cmdLineArgs.help) {
+            commander.usage()
+            return
+        }
+
         LOG.info("Max memory (bytes): " + Runtime.getRuntime().maxMemory())
         LOG.info("Server process started")
         LOG.info("In memory: " + cmdLineArgs.inmemory)


### PR DESCRIPTION
Adds -h and --help to the model-server CLI.