### PR TITLE
mps-model-adapters: fixed incompatibility with MPS 2021.2

### DIFF
--- a/.github/workflows/mps-model-adapters.yaml
+++ b/.github/workflows/mps-model-adapters.yaml
@@ -1,0 +1,34 @@
+name: MPS compatibility
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+  # allow manual execution just in case
+  workflow_dispatch:
+
+jobs:
+  build-mps-model-adapters:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Build with MPS 2020.3.6
+        run: ./gradlew :mps-model-adapters:build -Pmps.version=2020.3.6
+      - name: Build with MPS 2021.1.4
+        run: ./gradlew :mps-model-adapters:build -Pmps.version=2021.1.4
+      - name: Build with MPS 2021.2.6
+        run: ./gradlew :mps-model-adapters:build -Pmps.version=2021.2.6
+      - name: Build with MPS 2021.3.3
+        run: ./gradlew :mps-model-adapters:build -Pmps.version=2021.3.3
+      - name: Build with MPS 2022.2
+        run: ./gradlew :mps-model-adapters:build -Pmps.version=2022.2
+      - name: Build with MPS 2022.3
+        run: ./gradlew :mps-model-adapters:build -Pmps.version=2022.3

--- a/.github/workflows/mps-model-adapters.yaml
+++ b/.github/workflows/mps-model-adapters.yaml
@@ -3,7 +3,7 @@ name: MPS compatibility
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request: {}
   # allow manual execution just in case
   workflow_dispatch:

--- a/mps-model-adapters/build.gradle.kts
+++ b/mps-model-adapters/build.gradle.kts
@@ -4,12 +4,14 @@ plugins {
     alias(libs.plugins.ktlint)
 }
 
+val mpsVersion = project.findProperty("mps.version")?.toString().takeIf { !it.isNullOrBlank() } ?: "2020.3.6"
+
 dependencies {
     api(project(":model-api"))
 
-    compileOnly("com.jetbrains:mps-openapi:2021.1.4")
-    compileOnly("com.jetbrains:mps-core:2021.1.4")
-    compileOnly("com.jetbrains:mps-environment:2021.1.4")
+    compileOnly("com.jetbrains:mps-openapi:$mpsVersion")
+    compileOnly("com.jetbrains:mps-core:$mpsVersion")
+    compileOnly("com.jetbrains:mps-environment:$mpsVersion")
 
     implementation(kotlin("stdlib"))
     implementation(libs.kotlin.logging)

--- a/mps-model-adapters/src/main/java/org/modelix/model/mpsadapters/ConceptWorkaround.java
+++ b/mps-model-adapters/src/main/java/org/modelix/model/mpsadapters/ConceptWorkaround.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.mpsadapters;
+
+import org.jetbrains.mps.openapi.language.SAbstractConcept;
+import org.jetbrains.mps.openapi.language.SConcept;
+import org.jetbrains.mps.openapi.language.SInterfaceConcept;
+
+/**
+ * The Kotlin compiler cannot disambiguate the call to getSuperConcept/getSuperInterfaces
+ * that where moved to SAbstractConcept in MPS 2021.2, but still exist in SConcept/SInterfaceConcept.
+ */
+public class ConceptWorkaround {
+    public SAbstractConcept concept;
+
+    public ConceptWorkaround(SAbstractConcept concept) {
+        this.concept = concept;
+    }
+
+    public SConcept getSuperConcept() {
+        return ((SConcept) concept).getSuperConcept();
+    }
+
+    public Iterable<SInterfaceConcept> getSuperInterfaces() {
+        if (concept instanceof SConcept) {
+            return ((SConcept) concept).getSuperInterfaces();
+        } else {
+            return ((SInterfaceConcept) concept).getSuperInterfaces();
+        }
+    }
+}

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
@@ -65,9 +65,10 @@ data class MPSConcept(val concept: SAbstractConceptAdapter) : IConcept {
 
     override fun getDirectSuperConcepts(): List<IConcept> {
         return when (concept) {
-            is SConcept -> listOfNotNull<SAbstractConcept>(concept.superConcept) + concept.superInterfaces
-            is SInterfaceConcept -> concept.superInterfaces
-            else -> emptyList()
+            is SConcept -> listOfNotNull<SAbstractConcept>(ConceptWorkaround(concept).superConcept) +
+                ConceptWorkaround(concept).superInterfaces
+            is SInterfaceConcept -> ConceptWorkaround(concept).superInterfaces
+            else -> emptyList<SAbstractConcept>()
         }.map { MPSConcept(it) }
     }
 


### PR DESCRIPTION
It's actually just an issue of the Kotlin compiler and the bytecode would have been compatible.
It's still good to have the workflow that detects possible incompatibilities.