### PR TITLE
fix: version catalog wasn't published

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,12 +24,6 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
-repositories {
-    mavenLocal()
-    maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }
-    mavenCentral()
-}
-
 group = "org.modelix"
 description = "Projectional Editor"
 version = computeVersion()
@@ -67,7 +61,9 @@ subprojects {
             freeCompilerArgs += listOf("-Xjvm-default=all-compatibility")
         }
     }
+}
 
+allprojects {
     repositories {
         mavenLocal()
         maven { url = uri("https://artifacts.itemis.cloud/repository/maven-mps/") }


### PR DESCRIPTION
The version catalog was only published to maven-local, because there was no publishing repository specified for the root project.