### PR TITLE
fix: MODELIX-481 rename docker image modelix/modelix-model to modelix/model-server

### DIFF
--- a/docker-build-model.sh
+++ b/docker-build-model.sh
@@ -8,9 +8,12 @@ TAG=$( ./modelix-version.sh )
   cd model-server
   if [ "${CI}" = "true" ]; then
     docker buildx build --platform linux/amd64,linux/arm64 --push \
+    -t modelix/model-server:latest -t "modelix/model-server:${TAG}"
     -t modelix/modelix-model:latest -t "modelix/modelix-model:${TAG}" .
   else
-    docker build -t modelix/modelix-model:latest -t "modelix/modelix-model:${TAG}" .
+    docker build \
+    -t modelix/model-server:latest -t "modelix/model-server:${TAG}" \
+    -t modelix/modelix-model:latest -t "modelix/modelix-model:${TAG}" .
   fi
 )
 


### PR DESCRIPTION
Also updated the description at
https://hub.docker.com/repository/docker/modelix/modelix-model/general

The old tag is still published to avoid breaking existing projects, but new projects should use the new name.
At least our helm chart should be updated soon: https://github.com/modelix/modelix/blob/46bf6ccb902050ae7035ef07b81bb4180213a66c/helm/modelix/templates/common/model-deployment.yaml#L31