### PR TITLE
fix(light-model-client): expose modelql-untyped as a dependency

### DIFF
--- a/light-model-client/build.gradle.kts
+++ b/light-model-client/build.gradle.kts
@@ -24,8 +24,9 @@ kotlin {
                 implementation(project(":model-api-gen-runtime"))
                 implementation(project(":model-server-api"))
                 implementation(project(":modelql-core"))
-                implementation(project(":modelql-untyped"))
                 implementation(project(":modelql-client"))
+
+                api(project(":modelql-untyped"))
 
                 implementation(libs.ktor.client.websockets)
                 implementation(libs.kotlin.stdlib.common)


### PR DESCRIPTION
Converts the implementation dependency of light-model-client on modelql-untyped into an api dependency as the base class of a LightModelClient instance is part of that package. Otherwise, downstream projects might fail to build due to being unable to resolve the base class.

Fixes: MODELIX-496