### PR TITLE
fix: set Kotlin API Version to 1.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,9 +77,12 @@ subprojects {
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-        kotlinOptions {
-            jvmTarget = "11"
-            freeCompilerArgs += listOf("-Xjvm-default=all-compatibility")
+        if (!name.lowercase().contains("test")) {
+            kotlinOptions {
+                jvmTarget = "11"
+                freeCompilerArgs += listOf("-Xjvm-default=all-compatibility")
+                apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_6.version
+            }
         }
     }
 }


### PR DESCRIPTION
Ensures that the compiled code is compatible with older versions of Kotlin.
In the modelix.samples project this fixes an incompatibility with the Kotlin version used by Quarkus (1.7).