### PR TITLE
fix(model-server-lib): increase websocket timeouts

### DIFF
--- a/model-server-lib/src/main/kotlin/org/modelix/model/server/light/LightModelServer.kt
+++ b/model-server-lib/src/main/kotlin/org/modelix/model/server/light/LightModelServer.kt
@@ -182,8 +182,8 @@ class LightModelServer @JvmOverloads constructor(val port: Int, val rootNodeProv
 
     fun Application.installHandlers() {
         install(WebSockets) {
-            pingPeriod = Duration.ofSeconds(15)
-            timeout = Duration.ofSeconds(15)
+            pingPeriod = Duration.ofSeconds(30)
+            timeout = Duration.ofSeconds(30)
             maxFrameSize = Long.MAX_VALUE
             masking = false
         }


### PR DESCRIPTION
The existing timeouts sometimes caused disconnects when requesting larger amounts of data despite everything being functional.