### PR TITLE
fix(model-server): configure websockets connections to be more robust

### DIFF
--- a/model-server-lib/src/main/kotlin/org/modelix/model/server/light/LightModelServer.kt
+++ b/model-server-lib/src/main/kotlin/org/modelix/model/server/light/LightModelServer.kt
@@ -182,8 +182,8 @@ class LightModelServer @JvmOverloads constructor(val port: Int, val rootNodeProv
 
     fun Application.installHandlers() {
         install(WebSockets) {
-            pingPeriod = Duration.ofSeconds(15)
-            timeout = Duration.ofSeconds(15)
+            pingPeriod = Duration.ofSeconds(30)
+            timeout = Duration.ofSeconds(30)
             maxFrameSize = Long.MAX_VALUE
             masking = false
         }

--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -34,6 +34,8 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.pingPeriod
+import io.ktor.server.websocket.timeout
 import kotlinx.html.a
 import kotlinx.html.h1
 import kotlinx.html.li
@@ -61,6 +63,7 @@ import java.io.FileReader
 import java.io.FileWriter
 import java.io.IOException
 import java.nio.charset.StandardCharsets
+import java.time.Duration
 import javax.sql.DataSource
 
 object Main {
@@ -157,7 +160,12 @@ object Main {
                 install(Routing)
                 installAuthentication(unitTestMode = !KeycloakUtils.isEnabled())
                 install(ForwardedHeaders)
-                install(WebSockets)
+                install(WebSockets) {
+                    pingPeriod = Duration.ofSeconds(30)
+                    timeout = Duration.ofSeconds(30)
+                    maxFrameSize = Long.MAX_VALUE
+                    masking = false
+                }
                 install(ContentNegotiation) {
                     json()
                 }


### PR DESCRIPTION
> The existing timeouts sometimes caused disconnects when requesting larger amounts of data despite everything being functional.

see. #208 

Make the LightModelServer in the model server behave more robust and more alike to the LightModelServer in MPS.