### PR TITLE
fix(model-api): node resolution inside coroutines

### DIFF
--- a/kotlin-utils/build.gradle.kts
+++ b/kotlin-utils/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    `maven-publish`
+    id("org.jetbrains.kotlin.multiplatform")
+}
+
+kotlin {
+    jvm()
+    js(IR) {
+        browser {}
+        nodejs {
+            testTask(
+                Action {
+                    useMocha {
+                        timeout = "30s"
+                    }
+                },
+            )
+        }
+        useCommonJs()
+    }
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(libs.kotlin.coroutines.core)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlin.coroutines.test)
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+            }
+        }
+        val jsTest by getting {
+            dependencies {
+            }
+        }
+    }
+}

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ContextValue.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ContextValue.kt
@@ -11,14 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modelix.model.api
+package org.modelix.kotlin.utils
 
-@Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")
 expect class ContextValue<E> {
 
     constructor()
     constructor(defaultValue: E)
 
-    fun getValue(): E?
-    fun <T> computeWith(newValue: E, r: () -> T): T
+    fun getValue(): E
+    fun getValueOrNull(): E?
+    fun getAllValues(): List<E>
+    fun <T> computeWith(newValue: E, body: () -> T): T
+
+    suspend fun <T> runInCoroutine(newValue: E, body: suspend () -> T): T
+}
+
+fun <E, T> ContextValue<E>.offer(value: E, body: () -> T): T {
+    return if (getAllValues().isEmpty()) {
+        computeWith(value, body)
+    } else {
+        body()
+    }
 }

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ContextValue.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ContextValue.kt
@@ -13,11 +13,20 @@
  */
 package org.modelix.kotlin.utils
 
+/**
+ * A common abstraction over ThreadLocal and CoroutineContext that integrates both worlds.
+ * Allows to set a value that can be read from everywhere on the current thread or coroutine.
+ * A suspendable function can call non suspendable functions and the value is synchronized between the CoroutineContext
+ * and the internal ThreadLocal.
+ */
 expect class ContextValue<E> {
 
     constructor()
     constructor(defaultValue: E)
 
+    /**
+     * @throws NoSuchElementException if no value is set.
+     */
     fun getValue(): E
     fun getValueOrNull(): E?
     fun getAllValues(): List<E>

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.kt
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2023.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modelix.model.api
 
-@Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")
-expect class ContextValue<E> {
+package org.modelix.kotlin.utils
 
-    constructor()
-    constructor(defaultValue: E)
-
-    fun getValue(): E?
-    fun <T> computeWith(newValue: E, r: () -> T): T
-}
+expect inline fun <R> runSynchronized(lock: Any, block: () -> R): R

--- a/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
+++ b/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
@@ -27,7 +27,10 @@ import kotlin.time.Duration.Companion.milliseconds
 class ContextValueTests {
 
     @Test
-    fun multipleCoroutines() = runTest {
+    fun testIsolation() = runTest {
+        // run multiple suspendable and non-suspendable functions in parallel to ensure they always read their own value
+        // and not a value from a different coroutine/thread.
+
         val contextValue = ContextValue<String>("a")
         assertEquals("a", contextValue.getValueOrNull())
         coroutineScope {

--- a/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
+++ b/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
@@ -26,11 +26,16 @@ import kotlin.time.Duration.Companion.milliseconds
 
 class ContextValueTests {
 
+    /*
+     * Runs multiple suspendable and non-suspendable functions in parallel to ensure they always read their own value
+     * and not a value from a different coroutine/thread.
+
+     * This test starts two coroutines and tries to run into a race-condition. A successful test doesn't proof the
+     * correctness, but a failing test proofs its incorrectness. If it ever becomes unstable, meaning it first fails
+     * and then succeeds after a second run, this shouldn't be ignored.
+     */
     @Test
     fun testIsolation() = runTest {
-        // run multiple suspendable and non-suspendable functions in parallel to ensure they always read their own value
-        // and not a value from a different coroutine/thread.
-
         val contextValue = ContextValue<String>("a")
         assertEquals("a", contextValue.getValueOrNull())
         coroutineScope {

--- a/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
+++ b/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.kotlin.utils
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+
+class ContextValueTests {
+
+    @Test
+    fun multipleCoroutines() = runTest {
+        val contextValue = ContextValue<String>("a")
+        assertEquals("a", contextValue.getValueOrNull())
+        coroutineScope {
+            launch {
+                for (i in 1..10) {
+                    contextValue.runInCoroutine("b1") {
+                        contextValue.computeWith("b11") {
+                            assertEquals("b11", contextValue.getValueOrNull())
+                        }
+                        assertEquals("b1", contextValue.getValueOrNull())
+                        contextValue.computeWith("b12") {
+                            assertEquals("b12", contextValue.getValueOrNull())
+                        }
+                        delay(1.milliseconds)
+                    }
+                }
+            }
+            launch {
+                for (i in 1..10) {
+                    contextValue.runInCoroutine("b2") {
+                        assertEquals("b2", contextValue.getValueOrNull())
+                        delay(1.milliseconds)
+                    }
+                }
+            }
+            for (i in 1..5) {
+                contextValue.runInCoroutine("c") {
+                    assertEquals("c", contextValue.getValueOrNull())
+                    delay(1.milliseconds)
+                }
+            }
+        }
+        contextValue.computeWith("d") {
+            assertEquals("d", contextValue.getValueOrNull())
+        }
+        assertEquals("a", contextValue.getValueOrNull())
+    }
+}

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/ContextValue.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/ContextValue.js.kt
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelix.kotlin.utils
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+
+actual class ContextValue<E> {
+    private val initialStack: List<E>
+    private var synchronousValueStack: List<E>? = null
+    private var stackFromCoroutine: List<E>? = null
+    private val contextElementKey = object : CoroutineContext.Key<ContextValueElement<E>> {}
+    private var isInSynchronousBlock = false
+
+    actual constructor() {
+        initialStack = emptyList()
+    }
+
+    actual constructor(defaultValue: E) {
+        initialStack = listOf(defaultValue)
+    }
+
+    actual fun getValue(): E {
+        return getAllValues().last()
+    }
+
+    actual fun getValueOrNull(): E? {
+        return getAllValues().lastOrNull()
+    }
+
+    actual fun <T> computeWith(newValue: E, body: () -> T): T {
+        val oldStack = synchronousValueStack
+        val newStack = getAllValues() + newValue
+        val wasInSynchronousBlock = isInSynchronousBlock
+        try {
+            isInSynchronousBlock = true
+            synchronousValueStack = newStack
+            return body()
+        } finally {
+            synchronousValueStack = oldStack
+            isInSynchronousBlock = wasInSynchronousBlock
+        }
+    }
+
+    actual fun getAllValues(): List<E> {
+        return (if (isInSynchronousBlock) synchronousValueStack else stackFromCoroutine) ?: initialStack
+    }
+
+    private suspend fun getAllValuesFromCoroutine(): List<E>? {
+        return currentCoroutineContext()[contextElementKey]?.stack
+    }
+
+    actual suspend fun <T> runInCoroutine(newValue: E, body: suspend () -> T): T {
+        return withContext(ContextValueElement((getAllValuesFromCoroutine() ?: initialStack) + newValue)) {
+            val parentInterceptor = checkNotNull(currentCoroutineContext()[ContinuationInterceptor]) {
+                "No ContinuationInterceptor found in the context"
+            }
+            withContext(Interceptor(parentInterceptor)) {
+                body()
+            }
+        }
+    }
+
+    private inner class Interceptor(
+        private val dispatcher: ContinuationInterceptor,
+    ) : AbstractCoroutineContextElement(ContinuationInterceptor), ContinuationInterceptor {
+        override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
+            return dispatcher.interceptContinuation(object : Continuation<T> {
+                override val context get() = continuation.context
+
+                override fun resumeWith(result: Result<T>) {
+                    stackFromCoroutine = context[contextElementKey]?.stack ?: emptyList()
+                    continuation.resumeWith(result)
+                }
+            })
+        }
+
+        override fun releaseInterceptedContinuation(continuation: Continuation<*>) {
+            super.releaseInterceptedContinuation(continuation)
+            stackFromCoroutine = null
+        }
+    }
+
+    inner class ContextValueElement<E>(val stack: List<E>) : AbstractCoroutineContextElement(contextElementKey)
+}

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.js.kt
@@ -17,5 +17,6 @@
 package org.modelix.kotlin.utils
 
 actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {
+    // This method is only required when compiling to the JVM. JS is single-threaded.
     return block()
 }

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.js.kt
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2023.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modelix.model.api
 
-@Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")
-expect class ContextValue<E> {
+package org.modelix.kotlin.utils
 
-    constructor()
-    constructor(defaultValue: E)
-
-    fun getValue(): E?
-    fun <T> computeWith(newValue: E, r: () -> T): T
+actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {
+    return block()
 }

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/ContextValue.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/ContextValue.jvm.kt
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelix.kotlin.utils
+
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.withContext
+
+actual class ContextValue<E>(private val initialStack: List<E>) {
+
+    private val valueStack = ThreadLocal.withInitial { initialStack }
+
+    actual constructor() : this(emptyList())
+
+    actual constructor(defaultValue: E) : this(listOf(defaultValue))
+
+    actual fun <T> computeWith(newValue: E, body: () -> T): T {
+        val oldStack: List<E> = valueStack.get()
+        return try {
+            valueStack.set(oldStack + newValue)
+            body()
+        } finally {
+            valueStack.set(oldStack)
+        }
+    }
+
+    actual suspend fun <T> runInCoroutine(newValue: E, body: suspend () -> T): T {
+        return withContext(valueStack.asContextElement(getAllValues() + newValue)) {
+            body()
+        }
+    }
+
+    actual fun getValue(): E {
+        return valueStack.get().last()
+    }
+
+    actual fun getValueOrNull(): E? {
+        return valueStack.get().lastOrNull()
+    }
+
+    actual fun getAllValues(): List<E> {
+        return valueStack.get()
+    }
+}

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.jvm.kt
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2023.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modelix.model.api
 
-@Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")
-expect class ContextValue<E> {
+package org.modelix.kotlin.utils
 
-    constructor()
-    constructor(defaultValue: E)
-
-    fun getValue(): E?
-    fun <T> computeWith(newValue: E, r: () -> T): T
+actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {
+    return synchronized(lock, block)
 }

--- a/light-model-client/build.gradle.kts
+++ b/light-model-client/build.gradle.kts
@@ -44,8 +44,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlin.coroutines.test)
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -55,7 +54,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
 
                 implementation(project(":authorization"))
 //                implementation(project(":model-client"))
@@ -81,7 +79,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
                 implementation(npm("jsdom-global", "3.0.2"))
                 implementation(npm("jsdom", "20.0.2"))
             }

--- a/model-api-gen-gradle-test/build.gradle.kts
+++ b/model-api-gen-gradle-test/build.gradle.kts
@@ -46,8 +46,6 @@ dependencies {
     implementation("org.modelix:modelql-typed:$modelixCoreVersion")
     implementation("org.modelix:modelql-untyped:$modelixCoreVersion")
 
-    testImplementation(kotlin("test-common"))
-    testImplementation(kotlin("test-annotations-common"))
     testImplementation(kotlin("test"))
     testImplementation(kotlin("reflect"))
 

--- a/model-api-gen-runtime/build.gradle.kts
+++ b/model-api-gen-runtime/build.gradle.kts
@@ -35,8 +35,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -46,7 +45,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -55,7 +53,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api(project(":kotlin-utils"))
                 implementation(kotlin("stdlib-common"))
                 implementation(libs.kotlin.logging)
                 implementation(libs.kotlin.serialization.json)

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -38,8 +38,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -50,7 +49,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -63,7 +61,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReference.kt
@@ -44,11 +44,16 @@ interface INodeReference {
     fun serialize(): String = INodeReferenceSerializer.serialize(this)
 }
 
+fun INodeReference.resolveInCurrentContext(): INode? {
+    return resolveIn(INodeResolutionScope.getCurrentScope())
+}
+
 fun INodeReference.resolveIn(scope: INodeResolutionScope): INode? {
     if (this is NodeReference) {
         val deserialized = INodeReferenceSerializer.tryDeserialize(serialized)
         if (deserialized != null) return deserialized.resolveIn(scope)
     }
+    @Suppress("DEPRECATION")
     return scope.resolveNode(this)
 }
 

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeResolutionScope.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeResolutionScope.kt
@@ -1,41 +1,113 @@
 package org.modelix.model.api
 
-import kotlin.coroutines.CoroutineContext
+import org.modelix.kotlin.utils.ContextValue
 
-interface INodeResolutionScope : CoroutineContext.Element {
-    override val key: CoroutineContext.Key<*>
-        get() = Key
+interface INodeResolutionScope {
 
+    /**
+     * Implementers should accept instances of NodeReference (a.k.a. SerializedNodeReference) and deserialize them
+     * into supported references if possible. This removes the need to register an INodeReferenceSerializer and also
+     * postpones the deserialization until it's actually necessary.
+     *
+     * For backwards compatability reasons this method should not be called directly, but INodeReference.resolveIn
+     * should be used, which tries to deserialize the reference first, in case an implementation of this method doesn't
+     * do the deserialization itself yet.
+     */
+    @Deprecated("Don't call this method directly. Use INodeReference.resolveIn instead.")
     fun resolveNode(ref: INodeReference): INode?
 
-    companion object Key : CoroutineContext.Key<INodeResolutionScope>
+    /**
+     * All node references inside the body are resolved against this scope. Compared to runWithAlso, the existing scopes
+     * in the current context are not used, meaning they are replaced.
+     */
+    fun <T> runWithOnly(body: () -> T): T = contextScope.computeWith(this, body)
 
-    override fun plus(context: CoroutineContext): CoroutineContext {
-        // coroutines are not compiled with -Xjvm-default=all-compatibility
-        // to not break existing IAreas implemented in Java, this override is necessary
-        return super.plus(context)
+    /**
+     * Does the same as runWithOnly, but with support for suspendable functions.
+     */
+    suspend fun <T> runWithOnlyInCoroutine(body: suspend () -> T): T = contextScope.runInCoroutine(this, body)
+
+    /**
+     * All node references inside the body are resolved against this scope and if that fails against any other scope in
+     * the current context.
+     */
+    fun <T> runWithAlso(body: () -> T): T = runWithAlso(this, body)
+
+    /**
+     * Does the same as runWithAlso, but with support for suspendable functions.
+     */
+    suspend fun <T> runWithAlsoInCoroutine(body: suspend () -> T): T = runWithAlsoInCoroutine(this, body)
+
+    companion object {
+        internal val contextScope = ContextValue<INodeResolutionScope>()
+
+        private fun combineScopes(scopeToAdd: INodeResolutionScope): List<INodeResolutionScope> {
+            return listOf(scopeToAdd) + (getCurrentScopes() - scopeToAdd)
+        }
+
+        fun <T> runWithAlso(scope: INodeResolutionScope, body: () -> T): T {
+            val newScopes = combineScopes(scope)
+            return when (newScopes.size) {
+                0 -> throw RuntimeException("Impossible case")
+                1 -> contextScope.computeWith(newScopes.single(), body)
+                else -> contextScope.computeWith(CompositeNodeResolutionScope(newScopes), body)
+            }
+        }
+
+        suspend fun <T> runWithAlsoInCoroutine(scope: INodeResolutionScope, body: suspend () -> T): T {
+            val newScopes = combineScopes(scope)
+            return when (newScopes.size) {
+                0 -> throw RuntimeException("Impossible case")
+                1 -> contextScope.runInCoroutine(newScopes.single(), body)
+                else -> contextScope.runInCoroutine(CompositeNodeResolutionScope(newScopes), body)
+            }
+        }
+
+        /**
+         * Returns the current scope that INodeReferences should be resolved in.
+         */
+        fun getCurrentScope(): INodeResolutionScope {
+            return contextScope.getValueOrNull() ?: NullNodeResolutionScope
+        }
+
+        /**
+         * All the scopes that should be used for node reference resolution. The first element of the list should be
+         * tried first.
+         */
+        fun getCurrentScopes(): List<INodeResolutionScope> {
+            return when (val current = contextScope.getValueOrNull()) {
+                null -> emptyList()
+                is CompositeNodeResolutionScope -> current.scopes
+                else -> listOf(current)
+            }
+        }
+
+        /**
+         * Like runWithAlso, but doesn't change the resolution order if it already exists in the context.
+         */
+        fun <T> ensureInContext(scope: INodeResolutionScope, body: () -> T): T {
+            val current = getCurrentScopes()
+            return if (current.contains(scope)) {
+                body()
+            } else {
+                scope.runWithAlso(body)
+            }
+        }
     }
+}
 
-    override fun <R> fold(initial: R, operation: (R, CoroutineContext.Element) -> R): R {
-        // coroutines are not compiled with -Xjvm-default=all-compatibility
-        // to not break existing IAreas implemented in Java, this override is necessary
-        return super.fold(initial, operation)
-    }
-
-    override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? {
-        // coroutines are not compiled with -Xjvm-default=all-compatibility
-        // to not break existing IAreas implemented in Java, this override is necessary
-        return super.get(key)
-    }
-
-    override fun minusKey(key: CoroutineContext.Key<*>): CoroutineContext {
-        // coroutines are not compiled with -Xjvm-default=all-compatibility
-        // to not break existing IAreas implemented in Java, this override is necessary
-        return super.minusKey(key)
+object NullNodeResolutionScope : INodeResolutionScope {
+    override fun resolveNode(ref: INodeReference): INode? {
+        throw IllegalStateException("INodeResolutionScope not set")
     }
 }
 
 class CompositeNodeResolutionScope(val scopes: List<INodeResolutionScope>) : INodeResolutionScope {
+    init {
+        require(scopes.all { it !is CompositeNodeResolutionScope }) {
+            "Nesting of CompositeNodeResolutionScope not allowed"
+        }
+    }
     override fun resolveNode(ref: INodeReference): INode? {
         return scopes.asSequence().mapNotNull { it.resolveNode(ref) }.firstOrNull()
     }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeResolutionScope.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeResolutionScope.kt
@@ -20,23 +20,23 @@ interface INodeResolutionScope {
      * All node references inside the body are resolved against this scope. Compared to runWithAlso, the existing scopes
      * in the current context are not used, meaning they are replaced.
      */
-    fun <T> runWithOnly(body: () -> T): T = contextScope.computeWith(this, body)
+    fun <T> runWith(body: () -> T): T = contextScope.computeWith(this, body)
 
     /**
      * Does the same as runWithOnly, but with support for suspendable functions.
      */
-    suspend fun <T> runWithOnlyInCoroutine(body: suspend () -> T): T = contextScope.runInCoroutine(this, body)
+    suspend fun <T> runWithInCoroutine(body: suspend () -> T): T = contextScope.runInCoroutine(this, body)
 
     /**
      * All node references inside the body are resolved against this scope and if that fails against any other scope in
      * the current context.
      */
-    fun <T> runWithAlso(body: () -> T): T = runWithAlso(this, body)
+    fun <T> runWithAdditionalScope(body: () -> T): T = runWithAdditionalScope(this, body)
 
     /**
      * Does the same as runWithAlso, but with support for suspendable functions.
      */
-    suspend fun <T> runWithAlsoInCoroutine(body: suspend () -> T): T = runWithAlsoInCoroutine(this, body)
+    suspend fun <T> runWithAdditionalScopeInCoroutine(body: suspend () -> T): T = runWithAdditionalScopeInCoroutine(this, body)
 
     companion object {
         internal val contextScope = ContextValue<INodeResolutionScope>()
@@ -45,7 +45,7 @@ interface INodeResolutionScope {
             return listOf(scopeToAdd) + (getCurrentScopes() - scopeToAdd)
         }
 
-        fun <T> runWithAlso(scope: INodeResolutionScope, body: () -> T): T {
+        fun <T> runWithAdditionalScope(scope: INodeResolutionScope, body: () -> T): T {
             val newScopes = combineScopes(scope)
             return when (newScopes.size) {
                 0 -> throw RuntimeException("Impossible case")
@@ -54,7 +54,7 @@ interface INodeResolutionScope {
             }
         }
 
-        suspend fun <T> runWithAlsoInCoroutine(scope: INodeResolutionScope, body: suspend () -> T): T {
+        suspend fun <T> runWithAdditionalScopeInCoroutine(scope: INodeResolutionScope, body: suspend () -> T): T {
             val newScopes = combineScopes(scope)
             return when (newScopes.size) {
                 0 -> throw RuntimeException("Impossible case")
@@ -90,7 +90,7 @@ interface INodeResolutionScope {
             return if (current.contains(scope)) {
                 body()
             } else {
-                scope.runWithAlso(body)
+                scope.runWithAdditionalScope(body)
             }
         }
     }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IRole.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IRole.kt
@@ -1,5 +1,7 @@
 package org.modelix.model.api
 
+import org.modelix.kotlin.utils.ContextValue
+
 /**
  * An [IRole] is a structural feature of a concept.
  * It can either be an [IProperty] or an [ILink].
@@ -58,7 +60,7 @@ object RoleAccessContext {
     }
 
     fun isUsingRoleIds(): Boolean {
-        return value.getValue() ?: false
+        return value.getValueOrNull() ?: false
     }
 }
 

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaWithMounts.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaWithMounts.kt
@@ -20,6 +20,7 @@ import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
 import org.modelix.model.api.INodeWrapper
 
+@Deprecated("not supported anymore")
 class AreaWithMounts(val rootArea: IArea, mounts: Map<INode, IArea>) : IArea {
     private val mounts: Map<INode, IArea>
     private val mountedRoot2hiddenNode: Map<INode, INode>

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/CompositeArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/CompositeArea.kt
@@ -20,6 +20,7 @@ import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
 import org.modelix.model.api.INodeWrapper
 
+@Deprecated("not supported anymore")
 class CompositeArea : IArea {
     private val areas: List<IArea>
     private val rootNode = Root()

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/ContextArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/ContextArea.kt
@@ -30,14 +30,14 @@ object ContextArea {
 
     @Deprecated("use INodeResolutionScope.runWithAdditional() or area.runWithAdditional")
     fun <T> withAdditionalContext(area: IArea, runnable: () -> T): T {
-        return INodeResolutionScope.runWithAlso(area, runnable)
+        return INodeResolutionScope.runWithAdditionalScope(area, runnable)
     }
 
     @Deprecated("use INodeResolutionScope.offer")
     fun <T> offer(area: IArea, r: () -> T): T {
         val current = getArea()
         return if (current == null || !current.collectAreas().contains(area)) {
-            area.runWithOnly(r)
+            area.runWith(r)
         } else {
             r()
         }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/ContextArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/ContextArea.kt
@@ -13,26 +13,31 @@
  */
 package org.modelix.model.area
 
-import org.modelix.model.api.ContextValue
+import org.modelix.model.api.INodeResolutionScope
 
+@Deprecated("use INodeResolutionScope")
 object ContextArea {
-    val CONTEXT_VALUE = ContextValue<IArea>()
 
-    fun getArea() = CONTEXT_VALUE.getValue()
-
-    fun <T> withAdditionalContext(area: IArea, runnable: () -> T): T {
-        val activeContext = CONTEXT_VALUE.getValue()
-        return if (activeContext == null) {
-            CONTEXT_VALUE.computeWith(area, runnable)
-        } else {
-            CONTEXT_VALUE.computeWith(CompositeArea(listOf(area, activeContext)), runnable)
+    @Deprecated("use INodeResolutionScope.getCurrentScope()")
+    fun getArea(): IArea? {
+        val scopes = INodeResolutionScope.getCurrentScopes().filterIsInstance<IArea>()
+        return when (scopes.size) {
+            0 -> null
+            1 -> scopes.single()
+            else -> CompositeArea(scopes)
         }
     }
 
+    @Deprecated("use INodeResolutionScope.runWithAdditional() or area.runWithAdditional")
+    fun <T> withAdditionalContext(area: IArea, runnable: () -> T): T {
+        return INodeResolutionScope.runWithAlso(area, runnable)
+    }
+
+    @Deprecated("use INodeResolutionScope.offer")
     fun <T> offer(area: IArea, r: () -> T): T {
-        val current = CONTEXT_VALUE.getValue()
+        val current = getArea()
         return if (current == null || !current.collectAreas().contains(area)) {
-            CONTEXT_VALUE.computeWith(area, r)
+            area.runWithOnly(r)
         } else {
             r()
         }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/PArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/PArea.kt
@@ -18,11 +18,12 @@ import org.modelix.model.api.IConcept
 import org.modelix.model.api.IConceptReference
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
+import org.modelix.model.api.INodeResolutionScope
 import org.modelix.model.api.ITree
 import org.modelix.model.api.PNodeAdapter
 import org.modelix.model.api.PNodeReference
 
-class PArea(val branch: IBranch) : IArea {
+data class PArea(val branch: IBranch) : IArea {
 
     override fun getRoot(): INode = PNodeAdapter(ITree.ROOT_ID, branch)
 
@@ -53,9 +54,9 @@ class PArea(val branch: IBranch) : IArea {
 
     fun containsNode(nodeId: Long): Boolean = branch.transaction.containsNode(nodeId)
 
-    override fun <T> executeRead(f: () -> T): T = ContextArea.offer(this) { branch.computeRead(f) }
+    override fun <T> executeRead(f: () -> T): T = INodeResolutionScope.ensureInContext(this) { branch.computeRead(f) }
 
-    override fun <T> executeWrite(f: () -> T): T = ContextArea.offer(this) { branch.computeWrite(f) }
+    override fun <T> executeWrite(f: () -> T): T = INodeResolutionScope.ensureInContext(this) { branch.computeWrite(f) }
 
     override fun canRead(): Boolean = branch.canRead()
 

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
                 api(project(":model-api"))
                 api(project(":model-datastructure"))
                 api(project(":model-server-api"))
-                kotlin("stdlib-common")
+                implementation(kotlin("stdlib-common"))
                 implementation(libs.kotlin.collections.immutable)
                 implementation(libs.kotlin.coroutines.core)
                 implementation(libs.kotlin.logging)
@@ -55,13 +55,12 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                kotlin("test-common")
-                kotlin("test-annotations-common")
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
             dependencies {
-                kotlin("stdlib-jdk8")
+                implementation(kotlin("stdlib-jdk8"))
 
                 implementation(libs.vavr)
                 implementation(libs.apache.commons.lang)
@@ -83,7 +82,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -96,7 +94,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api(project(":kotlin-utils"))
                 api(project(":model-api"))
 //                api(project(":model-server-api"))
 //                kotlin("stdlib-common")

--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -35,8 +35,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                kotlin("test-common")
-                kotlin("test-annotations-common")
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -63,7 +62,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -77,7 +75,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
@@ -14,7 +14,6 @@
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore
-import org.modelix.model.api.ContextValue
 import org.modelix.model.api.ITree
 
 /**
@@ -59,12 +58,12 @@ class PrefetchCache(private val store: IDeserializingKeyValueStore) : IDeseriali
     }
 
     companion object {
-        private val contextValue: ContextValue<PrefetchCache> = ContextValue()
+        private val contextValue: org.modelix.kotlin.utils.ContextValue<PrefetchCache> = org.modelix.kotlin.utils.ContextValue()
 
         fun <T> with(store_: IDeserializingKeyValueStore, f: () -> T): T {
             val store = if (store_ is ContextIndirectCache) store_.directStore else store_
             val unwrapped = unwrap(store)
-            val current = contextValue.getValue()
+            val current = contextValue.getValueOrNull()
             return if (current != null && current.store == unwrapped) {
                 f()
             } else {
@@ -99,7 +98,7 @@ class PrefetchCache(private val store: IDeserializingKeyValueStore) : IDeseriali
             }
 
             override fun getStore(): IDeserializingKeyValueStore {
-                return contextValue.getValue() ?: directStore
+                return contextValue.getValueOrNull() ?: directStore
             }
         }
     }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
@@ -13,6 +13,7 @@
  */
 package org.modelix.model.lazy
 
+import org.modelix.kotlin.utils.ContextValue
 import org.modelix.model.IKeyValueStore
 import org.modelix.model.api.ITree
 
@@ -58,7 +59,7 @@ class PrefetchCache(private val store: IDeserializingKeyValueStore) : IDeseriali
     }
 
     companion object {
-        private val contextValue: org.modelix.kotlin.utils.ContextValue<PrefetchCache> = org.modelix.kotlin.utils.ContextValue()
+        private val contextValue: ContextValue<PrefetchCache> = ContextValue()
 
         fun <T> with(store_: IDeserializingKeyValueStore, f: () -> T): T {
             val store = if (store_ is ContextIndirectCache) store_.directStore else store_

--- a/model-server-api/build.gradle.kts
+++ b/model-server-api/build.gradle.kts
@@ -38,8 +38,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
 //                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion")
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -48,7 +47,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -57,7 +55,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
 //                implementation(npm("jsdom-global", "3.0.2"))
 //                implementation(npm("jsdom", "20.0.2"))
             }

--- a/modelql-client/build.gradle.kts
+++ b/modelql-client/build.gradle.kts
@@ -48,8 +48,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlin.coroutines.test)
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -59,7 +58,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
 
                 implementation(project(":model-client", configuration = "jvmRuntimeElements"))
                 implementation(project(":modelql-server"))
@@ -84,7 +82,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
                 implementation(npm("jsdom-global", "3.0.2"))
                 implementation(npm("jsdom", "20.0.2"))
             }

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
@@ -58,7 +58,7 @@ class ModelQLClient(val url: String, val client: HttpClient, includedSerializers
     }
 
     protected fun <T> deserialize(serializedJson: String, query: IUnboundQuery<*, T, *>): T {
-        return ModelQLArea(this).runWithAlso {
+        return ModelQLArea(this).runWithAdditionalScope {
             VersionAndData.deserialize(
                 serializedJson,
                 query.getAggregationOutputSerializer(json.serializersModule),

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
@@ -23,7 +23,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
-import org.modelix.model.area.ContextArea
 import org.modelix.model.area.IArea
 import org.modelix.modelql.core.IMonoStep
 import org.modelix.modelql.core.IUnboundQuery
@@ -59,7 +58,7 @@ class ModelQLClient(val url: String, val client: HttpClient, includedSerializers
     }
 
     protected fun <T> deserialize(serializedJson: String, query: IUnboundQuery<*, T, *>): T {
-        return ContextArea.withAdditionalContext(ModelQLArea(this)) {
+        return ModelQLArea(this).runWithAlso {
             VersionAndData.deserialize(
                 serializedJson,
                 query.getAggregationOutputSerializer(json.serializersModule),

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                api(project(":kotlin-utils"))
                 implementation(kotlin("stdlib-common"))
                 implementation(libs.kotlin.reflect)
                 implementation(libs.kotlin.logging)

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -46,8 +46,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlin.coroutines.test)
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -56,7 +55,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -65,7 +63,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ContextValue.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ContextValue.kt
@@ -13,6 +13,7 @@
  */
 package org.modelix.modelql.core
 
+@Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")
 expect class ContextValue<E : Any>() {
     fun getStack(): List<E>
     fun getValue(): E

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStep.kt
@@ -102,7 +102,7 @@ fun IProducingStep<*>.isSingle(): Boolean = !canBeEmpty() && !canBeMultiple()
 fun <T> IProducingStep<T>.connect(consumer: IConsumingStep<T>) {
     val producer: IProducingStep<T> = this
     if (consumer.owner != this.owner && producer !is SharedStep<*>) {
-        val producerContext = QueryBuilderContext.CONTEXT_VALUE.getStack().find { it.queryReference == producer.owner }
+        val producerContext = QueryBuilderContext.CONTEXT_VALUE.getAllValues().find { it.queryReference == producer.owner }
         checkNotNull(producerContext) { "Step belongs to a different query that is already finalized: $producer" }
         producerContext.computeWith {
             with(producerContext) { producer.shared() }

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryBuilderContext.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryBuilderContext.kt
@@ -13,6 +13,8 @@
  */
 package org.modelix.modelql.core
 
+import org.modelix.kotlin.utils.ContextValue
+
 interface IStepSharingContext {
     fun <T> IMonoStep<T>.shared(): IMonoStep<T>
     fun <T> IFluxStep<T>.shared(): IFluxStep<T>
@@ -24,7 +26,7 @@ interface IQueryBuilderContext<in In, out Out> : IStepSharingContext {
 
 class QueryBuilderContext<In, Out, Q : IUnboundQuery<*, *, *>> : IQueryBuilderContext<In, Out> {
     private val childContexts = ArrayList<QueryBuilderContext<*, *, *>>()
-    private val parentContext: QueryBuilderContext<*, *, *>? = CONTEXT_VALUE.tryGetValue()?.also { it.childContexts.add(this) }
+    private val parentContext: QueryBuilderContext<*, *, *>? = CONTEXT_VALUE.getValueOrNull()?.also { it.childContexts.add(this) }
     val sharedSteps = ArrayList<SharedStep<*>>()
     val queryReference = QueryReference<Q>(null, null, null)
     val inputStep = computeWith { QueryInput<In>() }

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryDescriptor.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryDescriptor.kt
@@ -15,6 +15,7 @@ package org.modelix.modelql.core
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import org.modelix.kotlin.utils.ContextValue
 
 typealias QueryId = Long
 

--- a/modelql-html/build.gradle.kts
+++ b/modelql-html/build.gradle.kts
@@ -42,8 +42,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.kotlin.coroutines.test)
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -53,7 +52,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -62,7 +60,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
+++ b/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
@@ -22,10 +22,8 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
 import org.modelix.model.api.INode
-import org.modelix.model.api.INodeResolutionScope
 import org.modelix.model.area.IArea
 import org.modelix.modelql.core.IMonoUnboundQuery
 import org.modelix.modelql.core.IStepOutput
@@ -84,10 +82,9 @@ class ModelQLServer private constructor(val rootNodeProvider: () -> INode?, val 
                 val queryDescriptor = VersionAndData.deserialize(serializedQuery, QueryGraphDescriptor.serializer(), json).data
                 val query = queryDescriptor.createRootQuery() as IMonoUnboundQuery<INode, Any?>
                 LOG.debug { "query: $query" }
-                val nodeResolutionScope: INodeResolutionScope = area
                 val transactionBody: () -> IStepOutput<Any?> = {
                     runBlocking {
-                        withContext(nodeResolutionScope) {
+                        area.runWithAlsoInCoroutine {
                             query.bind(rootNode.createQueryExecutor()).execute()
                         }
                     }

--- a/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
+++ b/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
@@ -84,7 +84,7 @@ class ModelQLServer private constructor(val rootNodeProvider: () -> INode?, val 
                 LOG.debug { "query: $query" }
                 val transactionBody: () -> IStepOutput<Any?> = {
                     runBlocking {
-                        area.runWithAlsoInCoroutine {
+                        area.runWithAdditionalScopeInCoroutine {
                             query.bind(rootNode.createQueryExecutor()).execute()
                         }
                     }

--- a/modelql-typed/build.gradle.kts
+++ b/modelql-typed/build.gradle.kts
@@ -45,8 +45,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -55,7 +54,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -64,7 +62,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/modelql-untyped/build.gradle.kts
+++ b/modelql-untyped/build.gradle.kts
@@ -43,8 +43,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -53,7 +52,6 @@ kotlin {
         }
         val jvmTest by getting {
             dependencies {
-                implementation(kotlin("test"))
             }
         }
         val jsMain by getting {
@@ -62,7 +60,6 @@ kotlin {
         }
         val jsTest by getting {
             dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeKSerializer.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeKSerializer.kt
@@ -31,8 +31,7 @@ import kotlinx.serialization.serializer
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.INode
 import org.modelix.model.api.NodeReference
-import org.modelix.model.api.resolveIn
-import org.modelix.model.area.ContextArea
+import org.modelix.model.api.resolveInCurrentContext
 
 open class NodeKSerializer() : KSerializer<INode> {
     @OptIn(InternalSerializationApi::class)
@@ -65,7 +64,7 @@ open class NodeKSerializer() : KSerializer<INode> {
     }
 
     protected open fun createNode(ref: NodeReference): INode {
-        return ref.resolveIn(ContextArea.getArea()!!) ?: throw RuntimeException("Failed to resolve node: $ref")
+        return ref.resolveInCurrentContext() ?: throw RuntimeException("Failed to resolve node: $ref")
     }
     protected open fun createNode(ref: NodeReference, concept: ConceptReference?): INode {
         return createNode(ref)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 rootProject.name = "modelix.core"
 
 include("authorization")
+include("kotlin-utils")
 include("light-model-client")
 include("metamodel-export")
 include("model-api")


### PR DESCRIPTION
The ContextValue class was used to specify how to resolve cross model node references for the current thread. The new ModelQL API is based on coroutines and since they are executed on a thread pool, there is the CoroutineContext as an alternative for ThreadLocal.

The new implementation of ContextValue connects both worlds by keeping the values in ThreadLocal and CoroutineContext in sync. In ModelQLServer.handleCall a coroutine is started where the ContextValue is initially defined in the CoroutineContext and then synchronized with the ThreadLocal for all the non-coroutines code.

While for the JVM target Kotlin already provides the function ThreadLocal.asContextElement, for the JS target a custom solution was necessary (there are no ThreadLocals in JS).