### PR TITLE
feat(modelql): support destructing zip output

### DIFF
--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
@@ -64,3 +64,13 @@ val <T> IMonoStep<IZip8Output<*, *, *, *, *, *, *, *, T>>.eighth: IMonoStep<T>
     get() = ZipElementAccessStep<T>(7).also { connect(it) }
 val <T> IMonoStep<IZip9Output<*, *, *, *, *, *, *, *, *, T>>.ninth: IMonoStep<T>
     get() = ZipElementAccessStep<T>(8).also { connect(it) }
+
+operator fun <T> IMonoStep<IZip1Output<*, T>>.component1() = first
+operator fun <T> IMonoStep<IZip2Output<*, *, T>>.component2() = second
+operator fun <T> IMonoStep<IZip3Output<*, *, *, T>>.component3() = third
+operator fun <T> IMonoStep<IZip4Output<*, *, *, *, T>>.component4() = forth
+operator fun <T> IMonoStep<IZip5Output<*, *, *, *, *, T>>.component5() = fifth
+operator fun <T> IMonoStep<IZip6Output<*, *, *, *, *, *, T>>.component6() = sixth
+operator fun <T> IMonoStep<IZip7Output<*, *, *, *, *, *, *, T>>.component7() = seventh
+operator fun <T> IMonoStep<IZip8Output<*, *, *, *, *, *, *, *, T>>.component8() = eighth
+operator fun <T> IMonoStep<IZip9Output<*, *, *, *, *, *, *, *, *, T>>.component9() = ninth

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
@@ -303,6 +303,16 @@ interface IZip7Output<out Common, out E1, out E2, out E3, out E4, out E5, out E6
 interface IZip8Output<out Common, out E1, out E2, out E3, out E4, out E5, out E6, out E7, out E8> : IZip7Output<Common, E1, E2, E3, E4, E5, E6, E7> { val eighth: E8 }
 interface IZip9Output<out Common, out E1, out E2, out E3, out E4, out E5, out E6, out E7, out E8, out E9> : IZip8Output<Common, E1, E2, E3, E4, E5, E6, E7, E8> { val ninth: E9 }
 
+operator fun <T> IZip1Output<*, T>.component1() = first
+operator fun <T> IZip2Output<*, *, T>.component2() = second
+operator fun <T> IZip3Output<*, *, *, T>.component3() = third
+operator fun <T> IZip4Output<*, *, *, *, T>.component4() = forth
+operator fun <T> IZip5Output<*, *, *, *, *, T>.component5() = fifth
+operator fun <T> IZip6Output<*, *, *, *, *, *, T>.component6() = sixth
+operator fun <T> IZip7Output<*, *, *, *, *, *, *, T>.component7() = seventh
+operator fun <T> IZip8Output<*, *, *, *, *, *, *, *, T>.component8() = eighth
+operator fun <T> IZip9Output<*, *, *, *, *, *, *, *, *, T>.component9() = ninth
+
 @Serializable
 @SerialName("modelix.modelql.zip.output")
 data class ZipOutput<out Common, out E1, out E2, out E3, out E4, out E5, out E6, out E7, out E8, out E9>(override val values: List<Common>) : IZip9Output<Common, E1, E2, E3, E4, E5, E6, E7, E8, E9> {

--- a/modelql-core/src/commonTest/kotlin/org/modelix/modelql/core/ModelQLTest.kt
+++ b/modelql-core/src/commonTest/kotlin/org/modelix/modelql/core/ModelQLTest.kt
@@ -223,6 +223,32 @@ class ModelQLTest {
     }
 
     @Test
+    fun zipDestructingMap() = runTestWithTimeout {
+        val result = remoteProductDatabaseQuery { db ->
+            db.products.filter { it.title.equalTo("iPhone 9") }.map {
+                it.title.zip(it.category).map { (_, category) ->
+                    category
+                }
+            }.first()
+        }
+
+        assertEquals("smartphones", result)
+    }
+
+    @Test
+    fun zipDestructingMapLocal() = runTestWithTimeout {
+        val result = remoteProductDatabaseQuery { db ->
+            db.products.filter { it.title.equalTo("iPhone 9") }.map {
+                it.title.zip(it.category).mapLocal { (title, category) ->
+                    "$title: $category"
+                }
+            }.first()
+        }
+
+        assertEquals("iPhone 9: smartphones", result)
+    }
+
+    @Test
     fun testMapLocal2_unusedInput() = runTestWithTimeout {
         val result = remoteProductDatabaseQuery { db ->
             db.products.mapLocal2 {


### PR DESCRIPTION
With these additions, zip output can be used with kotlin destructing declarations:

```kotlin
foo.zip(bar).map { (theFoo, theBar) -> ... }
foo.zip(bar).mapLocal { (theFoo, theBar) -> ... }
```