### PR TITLE
fix(modelql): rename zip accessor forth -> fourth

### DIFF
--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
@@ -52,7 +52,11 @@ val <T> IMonoStep<IZip2Output<*, *, T>>.second: IMonoStep<T>
     get() = ZipElementAccessStep<T>(1).also { connect(it) }
 val <T> IMonoStep<IZip3Output<*, *, *, T>>.third: IMonoStep<T>
     get() = ZipElementAccessStep<T>(2).also { connect(it) }
+
+@Deprecated("Use fourth, the version without type", ReplaceWith("fourth"))
 val <T> IMonoStep<IZip4Output<*, *, *, *, T>>.forth: IMonoStep<T>
+    get() = ZipElementAccessStep<T>(3).also { connect(it) }
+val <T> IMonoStep<IZip4Output<*, *, *, *, T>>.fourth: IMonoStep<T>
     get() = ZipElementAccessStep<T>(3).also { connect(it) }
 val <T> IMonoStep<IZip5Output<*, *, *, *, *, T>>.fifth: IMonoStep<T>
     get() = ZipElementAccessStep<T>(4).also { connect(it) }
@@ -68,7 +72,7 @@ val <T> IMonoStep<IZip9Output<*, *, *, *, *, *, *, *, *, T>>.ninth: IMonoStep<T>
 operator fun <T> IMonoStep<IZip1Output<*, T>>.component1() = first
 operator fun <T> IMonoStep<IZip2Output<*, *, T>>.component2() = second
 operator fun <T> IMonoStep<IZip3Output<*, *, *, T>>.component3() = third
-operator fun <T> IMonoStep<IZip4Output<*, *, *, *, T>>.component4() = forth
+operator fun <T> IMonoStep<IZip4Output<*, *, *, *, T>>.component4() = fourth
 operator fun <T> IMonoStep<IZip5Output<*, *, *, *, *, T>>.component5() = fifth
 operator fun <T> IMonoStep<IZip6Output<*, *, *, *, *, *, T>>.component6() = sixth
 operator fun <T> IMonoStep<IZip7Output<*, *, *, *, *, *, *, T>>.component7() = seventh

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
@@ -296,7 +296,13 @@ interface IZipOutput<out Common> { val values: List<Common> }
 interface IZip1Output<out Common, out E1> : IZipOutput<Common> { val first: E1 }
 interface IZip2Output<out Common, out E1, out E2> : IZip1Output<Common, E1> { val second: E2 }
 interface IZip3Output<out Common, out E1, out E2, out E3> : IZip2Output<Common, E1, E2> { val third: E3 }
-interface IZip4Output<out Common, out E1, out E2, out E3, out E4> : IZip3Output<Common, E1, E2, E3> { val forth: E4 }
+interface IZip4Output<out Common, out E1, out E2, out E3, out E4> : IZip3Output<Common, E1, E2, E3> {
+    val fourth: E4
+
+    @Deprecated("Use fourth, the version without typo", ReplaceWith("fourth"))
+    val forth
+        get() = fourth
+}
 interface IZip5Output<out Common, out E1, out E2, out E3, out E4, out E5> : IZip4Output<Common, E1, E2, E3, E4> { val fifth: E5 }
 interface IZip6Output<out Common, out E1, out E2, out E3, out E4, out E5, out E6> : IZip5Output<Common, E1, E2, E3, E4, E5> { val sixth: E6 }
 interface IZip7Output<out Common, out E1, out E2, out E3, out E4, out E5, out E6, out E7> : IZip6Output<Common, E1, E2, E3, E4, E5, E6> { val seventh: E7 }
@@ -306,7 +312,7 @@ interface IZip9Output<out Common, out E1, out E2, out E3, out E4, out E5, out E6
 operator fun <T> IZip1Output<*, T>.component1() = first
 operator fun <T> IZip2Output<*, *, T>.component2() = second
 operator fun <T> IZip3Output<*, *, *, T>.component3() = third
-operator fun <T> IZip4Output<*, *, *, *, T>.component4() = forth
+operator fun <T> IZip4Output<*, *, *, *, T>.component4() = fourth
 operator fun <T> IZip5Output<*, *, *, *, *, T>.component5() = fifth
 operator fun <T> IZip6Output<*, *, *, *, *, *, T>.component6() = sixth
 operator fun <T> IZip7Output<*, *, *, *, *, *, *, T>.component7() = seventh
@@ -320,7 +326,7 @@ data class ZipOutput<out Common, out E1, out E2, out E3, out E4, out E5, out E6,
     override val first: E1 get() = values[0] as E1
     override val second: E2 get() = values[1] as E2
     override val third: E3 get() = values[2] as E3
-    override val forth: E4 get() = values[3] as E4
+    override val fourth: E4 get() = values[3] as E4
     override val fifth: E5 get() = values[4] as E5
     override val sixth: E6 get() = values[5] as E6
     override val seventh: E7 get() = values[6] as E7


### PR DESCRIPTION
Remove the typo. Old methods are still available but deprecated for now.