### PR TITLE
MODELIX-524 unstable ReplicatedRepositoryTest

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -17,7 +17,6 @@ import org.modelix.model.IVersion
 import org.modelix.model.api.IIdGenerator
 import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.RepositoryId
-import org.modelix.model.server.api.ModelQuery
 
 /**
  * This interface is meant exclusively for model client usage.
@@ -53,8 +52,6 @@ interface IModelClientV2 {
     suspend fun push(branch: BranchReference, version: IVersion, baseVersion: IVersion?): IVersion
 
     suspend fun pull(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
-    suspend fun pull(branch: BranchReference, lastKnownVersion: IVersion?, filter: ModelQuery): IVersion
 
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
-    suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?, filter: ModelQuery): IVersion
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -43,7 +43,6 @@ import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.lazy.computeDelta
 import org.modelix.model.persistent.HashUtil
 import org.modelix.model.persistent.MapBasedStore
-import org.modelix.model.server.api.ModelQuery
 import org.modelix.model.server.api.v2.VersionDelta
 import kotlin.time.Duration.Companion.seconds
 
@@ -181,14 +180,6 @@ class ModelClientV2(
         val receivedVersion = createVersion(lastKnownVersion, response.body())
         LOG.debug { "${clientId.toString(16)}.poll($branch, $lastKnownVersion) -> $receivedVersion" }
         return receivedVersion
-    }
-
-    override suspend fun pull(branch: BranchReference, lastKnownVersion: IVersion?, filter: ModelQuery): IVersion {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?, filter: ModelQuery): IVersion {
-        TODO("Not yet implemented")
     }
 
     override fun close() {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -42,7 +42,7 @@ import org.modelix.model.lazy.ObjectStoreCache
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.lazy.computeDelta
 import org.modelix.model.persistent.HashUtil
-import org.modelix.model.persistent.MapBaseStore
+import org.modelix.model.persistent.MapBasedStore
 import org.modelix.model.server.api.ModelQuery
 import org.modelix.model.server.api.v2.VersionDelta
 import kotlin.time.Duration.Companion.seconds
@@ -54,7 +54,7 @@ class ModelClientV2(
     private var clientId: Int = 0
     private var idGenerator: IIdGenerator = IdGeneratorDummy()
     private var userId: String? = null
-    private val kvStore = MapBaseStore()
+    private val kvStore = MapBasedStore()
     val store = ObjectStoreCache(kvStore) // TODO the store will accumulate garbage
 
     suspend fun init() {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -168,6 +168,7 @@ class ModelClientV2(
 
     override suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion {
         require(lastKnownVersion is CLVersion?)
+        LOG.debug { "${clientId.toString(16)}.poll($branch, $lastKnownVersion)" }
         val response = httpClient.get {
             url {
                 takeFrom(baseUrl)

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -63,37 +63,11 @@ class ReplicatedModel(
             }
         }
 
-        // convergence watchdog
-//        scope.launch {
-//            var nextDelayMs: Long = 1000
-//            while (state != State.Disposed) {
-//                if (nextDelayMs > 0) delay(nextDelayMs)
-//                try {
-//                    val newRemoteVersion = remoteVersion.pull()
-//                    remoteVersionReceived(newRemoteVersion)
-//                    nextDelayMs = 1000
-//                } catch (ex: CancellationException) {
-//                    break
-//                } catch (ex: Throwable) {
-//                    LOG.error(ex) { "Failed to pull branch $branchRef" }
-//                    nextDelayMs = (nextDelayMs * 3 / 2).coerceIn(1000, 30000)
-//                }
-//            }
-//        }
-
         localModel.rawBranch.addListener(object : IBranchListener {
             override fun treeChanged(oldTree: ITree?, newTree: ITree) {
                 if (isDisposed()) return
                 scope.launch {
                     pushLocalChanges()
-//                    while (state != State.Disposed) {
-//                        if (remoteVersion.getNumberOfUnconfirmed() == 0) {
-//                            pushLocalChanges()
-//                            break
-//                        } else {
-//                            delay(100.milliseconds)
-//                        }
-//                    }
                 }
             }
         })

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -20,14 +20,11 @@ import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.operations.OTBranch
-import org.modelix.model.server.api.ModelQuery
 
 class ReplicatedModel(
     val client: IModelClientV2,
     val branchRef: BranchReference,
     private val providedScope: CoroutineScope? = null,
-    @Deprecated("was never supported")
-    val query: ModelQuery? = null,
 ) {
     private val scope = providedScope ?: CoroutineScope(Dispatchers.Default)
     private var state = State.New
@@ -172,11 +169,6 @@ fun IModelClientV2.getReplicatedModel(branchRef: BranchReference): ReplicatedMod
 
 fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, scope: CoroutineScope): ReplicatedModel {
     return ReplicatedModel(this, branchRef, scope)
-}
-
-@Deprecated("ModelQuery is not supported and ignored", ReplaceWith("getReplicatedModel(branchRef)"))
-fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, query: ModelQuery?): ReplicatedModel {
-    return ReplicatedModel(this, branchRef, providedScope = null, query = query)
 }
 
 /**

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -2,68 +2,61 @@ package org.modelix.model.client2
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.modelix.model.IVersion
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.IBranchListener
+import org.modelix.model.api.IIdGenerator
 import org.modelix.model.api.ITree
 import org.modelix.model.api.PBranch
+import org.modelix.model.api.runSynchronized
 import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.operations.OTBranch
 import org.modelix.model.server.api.ModelQuery
-import kotlin.coroutines.cancellation.CancellationException
 
-class ReplicatedModel(val client: IModelClientV2, val branchRef: BranchReference, val query: ModelQuery? = null) {
-    private val scope = CoroutineScope(Dispatchers.Default)
+class ReplicatedModel(
+    val client: IModelClientV2,
+    val branchRef: BranchReference,
+    private val providedScope: CoroutineScope? = null,
+    @Deprecated("was never supported")
+    val query: ModelQuery? = null,
+) {
+    private val scope = providedScope ?: CoroutineScope(Dispatchers.Default)
     private var state = State.New
-    private lateinit var otBranch: OTBranch
-    private lateinit var rawBranch: IBranch
-
-    private lateinit var lastRemoteVersion: CLVersion
-    private lateinit var localVersion: CLVersion
-    private val mergeMutex = Mutex()
-
-    private var author: String? = null
+    private lateinit var localModel: LocalModel
+    private val remoteVersion = RemoteVersion(client, branchRef)
+    private var pollingJob: Job? = null
 
     fun getBranch(): IBranch {
         if (state != State.Started) throw IllegalStateException("state is $state")
-        return otBranch
+        return localModel.otBranch
     }
 
     suspend fun start(): IBranch {
         if (state != State.New) throw IllegalStateException("already started")
         state = State.Starting
 
-        author = client.getUserId()
+        val initialVersion = remoteVersion.pull()
+        localModel = LocalModel(initialVersion, client.getIdGenerator(), { client.getUserId() })
 
-        lastRemoteVersion = if (query == null) {
-            client.pull(branchRef, null)
-        } else {
-            client.pull(branchRef, null, query)
-        } as CLVersion
-        localVersion = lastRemoteVersion
-        rawBranch = PBranch(lastRemoteVersion.getTree(), client.getIdGenerator())
-        otBranch = OTBranch(rawBranch, client.getIdGenerator(), lastRemoteVersion.store)
-
-        scope.launch {
+        // receive changes from the server
+        pollingJob = scope.launch {
             var nextDelayMs: Long = 0
             while (state != State.Disposed) {
                 if (nextDelayMs > 0) delay(nextDelayMs)
                 try {
-                    val newRemoteVersion = if (query == null) {
-                        client.poll(branchRef, lastRemoteVersion)
-                    } else {
-                        client.poll(branchRef, lastRemoteVersion, query)
-                    } as CLVersion
+                    val newRemoteVersion = remoteVersion.poll()
                     remoteVersionReceived(newRemoteVersion)
                     nextDelayMs = 0
-                } catch (ex: CancellationException) {
+                } catch (ex: kotlinx.coroutines.CancellationException) {
                     LOG.debug { "Stop to poll branch $branchRef after disposing." }
                     throw ex
                 } catch (ex: Throwable) {
@@ -73,18 +66,50 @@ class ReplicatedModel(val client: IModelClientV2, val branchRef: BranchReference
             }
         }
 
-        rawBranch.addListener(object : IBranchListener {
+        // convergence watchdog
+//        scope.launch {
+//            var nextDelayMs: Long = 1000
+//            while (state != State.Disposed) {
+//                if (nextDelayMs > 0) delay(nextDelayMs)
+//                try {
+//                    val newRemoteVersion = remoteVersion.pull()
+//                    remoteVersionReceived(newRemoteVersion)
+//                    nextDelayMs = 1000
+//                } catch (ex: CancellationException) {
+//                    break
+//                } catch (ex: Throwable) {
+//                    LOG.error(ex) { "Failed to pull branch $branchRef" }
+//                    nextDelayMs = (nextDelayMs * 3 / 2).coerceIn(1000, 30000)
+//                }
+//            }
+//        }
+
+        localModel.rawBranch.addListener(object : IBranchListener {
             override fun treeChanged(oldTree: ITree?, newTree: ITree) {
-                checkDisposed()
+                if (isDisposed()) return
                 scope.launch {
                     pushLocalChanges()
+//                    while (state != State.Disposed) {
+//                        if (remoteVersion.getNumberOfUnconfirmed() == 0) {
+//                            pushLocalChanges()
+//                            break
+//                        } else {
+//                            delay(100.milliseconds)
+//                        }
+//                    }
                 }
             }
         })
 
         state = State.Started
-        return otBranch
+        return getBranch()
     }
+
+    suspend fun resetToServerVersion() {
+        localModel.resetToVersion(client.pull(branchRef, lastKnownVersion = null).upcast())
+    }
+
+    fun isDisposed(): Boolean = state == State.Disposed
 
     private fun checkDisposed() {
         if (state == State.Disposed) throw IllegalStateException("disposed")
@@ -92,60 +117,41 @@ class ReplicatedModel(val client: IModelClientV2, val branchRef: BranchReference
 
     fun dispose() {
         if (state == State.Disposed) return
+        pollingJob?.cancel("disposed")
         state = State.Disposed
-        scope.cancel("disposed")
+        if (providedScope == null) {
+            scope.cancel("disposed")
+        }
     }
 
     private suspend fun remoteVersionReceived(newRemoteVersion: CLVersion) {
-        checkDisposed()
-        if (lastRemoteVersion.getContentHash() == newRemoteVersion.getContentHash()) return
-        lastRemoteVersion = newRemoteVersion
-        mergeMutex.withLock {
-            if (newRemoteVersion.getContentHash() != localVersion.getContentHash()) {
-                otBranch.runWrite {
-                    applyPendingLocalChanges()
-                    try {
-                        localVersion = VersionMerger(newRemoteVersion.store, client.getIdGenerator())
-                            .mergeChange(localVersion, newRemoteVersion)
-                    } catch (ex: Exception) {
-                        LOG.warn(ex) { "Failed to merge remote version $newRemoteVersion into local version $localVersion. Resetting to remote version." }
-                        localVersion = newRemoteVersion
-                    }
-                    rawBranch.writeTransaction.tree = localVersion.tree
-                }
+        if (isDisposed()) return
+
+        val mergedVersion = try {
+            localModel.mergeRemoteVersion(newRemoteVersion)
+        } catch (ex: Exception) {
+            val currentLocalVersion = localModel.getCurrentVersion()
+            LOG.warn(ex) { "Failed to merge remote version $newRemoteVersion into local version $currentLocalVersion. Resetting to remote version." }
+            localModel.resetToVersion(newRemoteVersion)
+            newRemoteVersion
+        }
+
+        if (mergedVersion.getContentHash() != newRemoteVersion.getContentHash()) {
+            val received = remoteVersion.push(mergedVersion)
+            if (received.getContentHash() != mergedVersion.getContentHash()) {
+                remoteVersionReceived(received)
             }
         }
     }
 
     private suspend fun pushLocalChanges() {
-        checkDisposed()
-        val createdVersion: CLVersion?
-        mergeMutex.withLock {
-            createdVersion = applyPendingLocalChanges()
-        }
-        if (createdVersion != null) {
-            remoteVersionReceived(client.push(branchRef, createdVersion, baseVersion = lastRemoteVersion) as CLVersion)
-        }
-    }
+        if (isDisposed()) return
 
-    private fun applyPendingLocalChanges(): CLVersion? {
-        checkDisposed()
-        require(mergeMutex.isLocked)
-        val createdVersion = otBranch.computeRead {
-            val (ops, newTree) = otBranch.operationsAndTree
-            if (ops.isEmpty()) return@computeRead null
-            CLVersion.createRegularVersion(
-                id = client.getIdGenerator().generate(),
-                author = author,
-                tree = newTree as CLTree,
-                baseVersion = localVersion,
-                operations = ops.map { it.getOriginalOp() }.toTypedArray(),
-            )
+        val version = localModel.createNewLocalVersion() ?: localModel.getCurrentVersion()
+        val received = remoteVersion.push(version)
+        if (received.getContentHash() != version.getContentHash()) {
+            remoteVersionReceived(received)
         }
-        if (createdVersion != null) {
-            localVersion = createdVersion
-        }
-        return createdVersion
     }
 
     private enum class State {
@@ -164,7 +170,148 @@ fun IModelClientV2.getReplicatedModel(branchRef: BranchReference): ReplicatedMod
     return ReplicatedModel(this, branchRef)
 }
 
+fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, scope: CoroutineScope): ReplicatedModel {
+    return ReplicatedModel(this, branchRef, scope)
+}
+
 @Deprecated("ModelQuery is not supported and ignored", ReplaceWith("getReplicatedModel(branchRef)"))
 fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, query: ModelQuery?): ReplicatedModel {
-    return ReplicatedModel(this, branchRef, query)
+    return ReplicatedModel(this, branchRef, providedScope = null, query = query)
 }
+
+/**
+ * Manages the locks during the creation and merge of versions.
+ */
+private class LocalModel(initialVersion: CLVersion, val idGenerator: IIdGenerator, val author: () -> String?) {
+
+    /**
+     * The state of the local model is the state of localVersion.getTree() plus the pending changes in
+     * OTBranch.completedChanges.
+     *
+     * All changes done to OTBranch assume that they are applied on top of the current value of localVersion.
+     * This means, before updating localVersion ensure there are no pending changes in OTBranch and that there are no
+     * active write transactions that will contribute to the pending changes when successful.
+     */
+    private var localVersion: CLVersion = initialVersion
+        get() {
+            check(mutex.isLocked)
+            return field
+        }
+        set(value) {
+            check(mutex.isLocked)
+            check(otBranch.canWrite()) { "Write transaction required to update the localVersion field" }
+            field = value
+        }
+
+    val rawBranch: IBranch = PBranch(initialVersion.getTree(), idGenerator)
+    val otBranch = OTBranch(rawBranch, idGenerator, initialVersion.store)
+    private val merger = VersionMerger(initialVersion.store, idGenerator)
+
+    private val mutex = Mutex()
+
+    suspend fun resetToVersion(version: CLVersion) {
+        mutex.withLock {
+            otBranch.computeWrite { // write transaction ensures there are no active changes done on an outdated version
+                otBranch.getPendingChanges() // discard any pending changes
+                localVersion = version
+                rawBranch.writeTransaction.tree = version.getTree()
+            }
+        }
+    }
+
+    suspend fun getCurrentVersion() = mutex.withLock { localVersion }
+
+    suspend fun mergeRemoteVersion(remoteVersion: CLVersion): CLVersion {
+        return mutex.withLock {
+            // Avoid triggering branch listeners (causing endless loops) if there is no change.
+            if (localVersion.getContentHash() == remoteVersion.getContentHash()) return localVersion
+
+            otBranch.computeWrite {
+                // Writing to localVersion requires that there are no pending operations in OTBranch. By creating a new
+                // local version first, the pending operations become part of it.
+                // Creating it inside a write transaction, guarantees that the list of pending changes stays empty util
+                // we are done.
+                doCreateNewLocalVersion()
+
+                // Now we can merge the remote version update the localVersion field without losing local changes.
+                // TODO run the (potentially expensive) merge algorithm outside a write transaction to avoid blocking
+                //      the branch for too long. This requires to rerun the merge if new local changes were created in
+                //      the meantime.
+                val mergedVersion = merger.mergeChange(localVersion, remoteVersion)
+
+                // The mutex guarantees that the localVersion field didn't change and the write transaction guarantees
+                // that there are no local changes that would get lost. We are in a consistent state again.
+                rawBranch.writeTransaction.tree = mergedVersion.getTree()
+                localVersion = mergedVersion
+
+                // Return the new localVersion just for convenience.
+                mergedVersion
+            }
+        }
+    }
+
+    /**
+     * @return null, if there are no pending changes and no new version was created.
+     */
+    suspend fun createNewLocalVersion(): CLVersion? {
+        return mutex.withLock { otBranch.computeWrite { doCreateNewLocalVersion() } }
+    }
+
+    private fun doCreateNewLocalVersion(): CLVersion? {
+        check(mutex.isLocked)
+        val (ops, tree) = otBranch.getPendingChanges()
+        check(tree is CLTree)
+
+        val baseVersion = localVersion
+
+        if (ops.isEmpty() && baseVersion.getTree().hash == tree.hash) return null
+        val newVersion = CLVersion.createRegularVersion(
+            id = idGenerator.generate(),
+            author = author(),
+            tree = tree,
+            baseVersion = baseVersion,
+            operations = ops.map { it.getOriginalOp() }.toTypedArray(),
+        )
+        localVersion = newVersion
+        return newVersion
+    }
+}
+
+private class RemoteVersion(val client: IModelClientV2, val branchRef: BranchReference) {
+    private var lastKnownRemoteVersion: CLVersion? = null
+    private val unconfirmedVersions: MutableSet<String> = LinkedHashSet()
+
+    fun getNumberOfUnconfirmed() = runSynchronized(unconfirmedVersions) { unconfirmedVersions.size }
+
+    suspend fun pull(): CLVersion {
+        return versionReceived(client.pull(branchRef, lastKnownVersion = lastKnownRemoteVersion).upcast())
+    }
+
+    suspend fun poll(): CLVersion {
+        return versionReceived(client.poll(branchRef, lastKnownVersion = lastKnownRemoteVersion).upcast())
+    }
+
+    suspend fun push(version: CLVersion): CLVersion {
+        if (lastKnownRemoteVersion?.getContentHash() == version.getContentHash()) return version
+        runSynchronized(unconfirmedVersions) {
+            if (!unconfirmedVersions.add(version.getContentHash())) return version
+        }
+        try {
+            return versionReceived(client.push(branchRef, version, lastKnownRemoteVersion).upcast())
+        } finally {
+            runSynchronized(unconfirmedVersions) {
+                unconfirmedVersions.remove(version.getContentHash())
+            }
+        }
+    }
+
+    private fun versionReceived(v: CLVersion): CLVersion {
+        runSynchronized(unconfirmedVersions) {
+            unconfirmedVersions.remove(v.getContentHash())
+            lastKnownRemoteVersion = v
+        }
+        return v
+    }
+}
+
+private fun IVersion.upcast(): CLVersion = this as CLVersion

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
@@ -5,10 +5,6 @@ import org.modelix.model.lazy.IDeserializingKeyValueStore
 import org.modelix.model.lazy.KVEntryReference
 import org.modelix.model.persistent.CPVersion
 
-/**
- * When merging two branches there might be conflicts between operations that need to be resolved in a deterministic
- * way. This class puts them in an order that preserves the order of earlier merges.
- */
 class LinearHistory(val baseVersionHash: String?) {
 
     val version2descendants: MutableMap<Long, MutableSet<Long>> = HashMap()

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
@@ -5,6 +5,10 @@ import org.modelix.model.lazy.IDeserializingKeyValueStore
 import org.modelix.model.lazy.KVEntryReference
 import org.modelix.model.persistent.CPVersion
 
+/**
+ * When merging two branches there might be conflicts between operations that need to be resolved in a deterministic
+ * way. This class puts them in an order that preserves the order of earlier merges.
+ */
 class LinearHistory(val baseVersionHash: String?) {
 
     val version2descendants: MutableMap<Long, MutableSet<Long>> = HashMap()

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
@@ -45,11 +45,32 @@ class VersionMerger(private val storeCache: IDeserializingKeyValueStore, private
         }
     }
 
+    private fun collectLatestNonMerges(version: CLVersion?, visited: MutableSet<String>, result: MutableSet<Long>) {
+        if (version == null) return
+        if (!visited.add(version.getContentHash())) return
+        if (version.isMerge()) {
+            collectLatestNonMerges(version.getMergedVersion1(), visited, result)
+            collectLatestNonMerges(version.getMergedVersion2(), visited, result)
+        } else {
+            result.add(version.id)
+            collectLatestNonMerges(version.baseVersion, visited, result)
+        }
+    }
+
     protected fun mergeHistory(leftVersion: CLVersion, rightVersion: CLVersion): CLVersion {
         if (leftVersion.hash == rightVersion.hash) return leftVersion
         val commonBase = Companion.commonBaseVersion(leftVersion, rightVersion)
         if (commonBase?.hash == leftVersion.hash) return rightVersion
         if (commonBase?.hash == rightVersion.hash) return leftVersion
+
+        val leftNonMerges = HashSet<Long>().also { collectLatestNonMerges(leftVersion, HashSet(), it) }
+        val rightNonMerges = HashSet<Long>().also { collectLatestNonMerges(rightVersion, HashSet(), it) }
+        if (leftNonMerges == rightNonMerges) {
+            // If there is no actual change on both sides, but they just did the same merge, we have to pick one
+            // of them, otherwise both sides will continue creating merges forever.
+            return if (leftVersion.id < rightVersion.id) leftVersion else rightVersion
+        }
+
         val versionsToApply = LinearHistory(commonBase?.hash).load(leftVersion, rightVersion)
 
 //        println("merge ${getVersion(leftVersionHash).id.toString(16)} ${LinearHistory(storeCache, commonBase).load(leftVersion).map { it.id.toString(16) }} and ${getVersion(rightVersionHash).id.toString(16)} ${LinearHistory(storeCache, commonBase).load(rightVersion).map { it.id.toString(16) }}: ${commonBase?.let{getVersion(it)}?.id?.toString(16)} + ${versionsToApply.map { it.id.toString(16) }}")

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
@@ -63,21 +63,6 @@ class VersionMerger(private val storeCache: IDeserializingKeyValueStore, private
         if (commonBase?.hash == leftVersion.hash) return rightVersion
         if (commonBase?.hash == rightVersion.hash) return leftVersion
 
-//        val leftHistory = HashMap<Long, CLVersion>().also { collectVersions(leftVersion, commonBase, it) }
-//        val rightHistory = HashMap<Long, CLVersion>().also { collectVersions(leftVersion, commonBase, it) }
-//        val leftNonMerges = leftHistory.values.asSequence().filter { !it.isMerge() }.map { it.id }.toSet()
-//        val rightNonMerges = rightHistory.values.asSequence().filter { !it.isMerge() }.map { it.id }.toSet()
-//
-//        if (leftNonMerges == rightNonMerges) {
-//            // If there is no actual change on both sides, but they just did the same merge, we have to pick one
-//            // of them, otherwise both sides will continue creating merges forever.
-//            return if (leftVersion.id < rightVersion.id) leftVersion else rightVersion
-//        } else if ((leftNonMerges - rightNonMerges).isEmpty()) {
-//            return rightVersion // the right history already contains all the left history
-//        } else if ((rightNonMerges - leftNonMerges).isEmpty()) {
-//            return leftVersion // the left history already contains all the right history
-//        }
-
         val leftNonMerges = HashSet<Long>().also { collectLatestNonMerges(leftVersion, HashSet(), it) }
         val rightNonMerges = HashSet<Long>().also { collectLatestNonMerges(rightVersion, HashSet(), it) }
         if (leftNonMerges == rightNonMerges) {
@@ -88,7 +73,6 @@ class VersionMerger(private val storeCache: IDeserializingKeyValueStore, private
 
         val versionsToApply = LinearHistory(commonBase?.hash).load(leftVersion, rightVersion)
 
-//        println("merge ${getVersion(leftVersionHash).id.toString(16)} ${LinearHistory(storeCache, commonBase).load(leftVersion).map { it.id.toString(16) }} and ${getVersion(rightVersionHash).id.toString(16)} ${LinearHistory(storeCache, commonBase).load(rightVersion).map { it.id.toString(16) }}: ${commonBase?.let{getVersion(it)}?.id?.toString(16)} + ${versionsToApply.map { it.id.toString(16) }}")
         val operationsToApply = versionsToApply.flatMap { captureIntend(it) }
         var mergedVersion: CLVersion? = null
         var baseTree = commonBase?.tree ?: CLTree(storeCache)
@@ -126,7 +110,6 @@ class VersionMerger(private val storeCache: IDeserializingKeyValueStore, private
                 appliedOps.map { it.getOriginalOp() }.toTypedArray(),
                 storeCache,
             )
-//            println("result ${mergedVersion?.id?.toString(16)}")
         }
         if (mergedVersion == null) {
             throw RuntimeException("Failed to merge ${leftVersion.hash} and ${rightVersion.hash}")
@@ -189,16 +172,6 @@ class VersionMerger(private val storeCache: IDeserializingKeyValueStore, private
                 }
             }
             return null
-        }
-
-        fun collectVersions(version: CLVersion?, commonBase: CLVersion?, result: MutableMap<Long, CLVersion>) {
-            if (version == null) return
-            if (result.containsKey(version.id)) return
-            if (version.id == commonBase?.id) return
-            result.put(version.id, version)
-            collectVersions(version.baseVersion, commonBase, result)
-            collectVersions(version.getMergedVersion1(), commonBase, result)
-            collectVersions(version.getMergedVersion2(), commonBase, result)
         }
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
@@ -53,7 +53,6 @@ class VersionMerger(private val storeCache: IDeserializingKeyValueStore, private
             collectLatestNonMerges(version.getMergedVersion2(), visited, result)
         } else {
             result.add(version.id)
-            collectLatestNonMerges(version.baseVersion, visited, result)
         }
     }
 

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTBranch.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTBranch.kt
@@ -44,18 +44,7 @@ class OTBranch(
     }
 
     @Deprecated("renamed to getPendingChanges()", ReplaceWith("getPendingChanges()"))
-    val operationsAndTree: Pair<List<IAppliedOperation>, ITree>
-        get() {
-            return runSynchronized(completedChanges) {
-                val result = when (completedChanges.size) {
-                    0 -> emptyList<IAppliedOperation>() to computeReadT { it.tree }
-                    1 -> completedChanges[0]
-                    else -> completedChanges.flatMap { it.first } to completedChanges.last().second
-                }
-                completedChanges.clear()
-                result
-            }
-        }
+    val operationsAndTree: Pair<List<IAppliedOperation>, ITree> get() = getPendingChanges()
 
     /**
      * @return the operations applied to the branch since the last call of this function and the resulting ITree.

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTBranch.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTBranch.kt
@@ -85,6 +85,7 @@ class OTBranch(
     override fun <T> computeWrite(computable: () -> T): T {
         checkNotEDT()
         return if (canWrite()) {
+            // Already in a transaction. Just append changes to the active one.
             branch.computeWrite(computable)
         } else {
             branch.computeWriteT { t ->

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
@@ -18,7 +18,10 @@ package org.modelix.model.persistent
 import org.modelix.model.IKeyListener
 import org.modelix.model.IKeyValueStore
 
-open class MapBaseStore : IKeyValueStore {
+@Deprecated("Use MapBasedStore, without a typo.", ReplaceWith("MapBasedStore"))
+open class MapBaseStore : MapBasedStore()
+
+open class MapBasedStore : IKeyValueStore {
     private val map: MutableMap<String?, String?> = HashMap()
     override fun get(key: String): String? {
         return map[key]

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -107,7 +107,7 @@ val cucumber = task("cucumber") {
     }
 }
 
-tasks.named("test") {
+tasks.named("build") {
     dependsOn("cucumber")
 }
 

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -65,6 +65,10 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 val cucumberRuntime by configurations.creating {
     extendsFrom(configurations["testImplementation"])
 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.RepetitionInfo
 import org.modelix.authorization.installAuthentication
 import org.modelix.model.LinearHistory
 import org.modelix.model.ModelFacade
@@ -127,27 +129,8 @@ class ReplicatedRepositoryTest {
         }
     }
 
-    @Test fun `concurrent write 0`() = concurrentWrite(0)
-
-    @Test fun `concurrent write 1`() = concurrentWrite(1)
-
-    @Test fun `concurrent write 2`() = concurrentWrite(2)
-
-    @Test fun `concurrent write 3`() = concurrentWrite(3)
-
-    @Test fun `concurrent write 4`() = concurrentWrite(4)
-
-    @Test fun `concurrent write 5`() = concurrentWrite(5)
-
-    @Test fun `concurrent write 6`() = concurrentWrite(6)
-
-    @Test fun `concurrent write 7`() = concurrentWrite(7)
-
-    @Test fun `concurrent write 8`() = concurrentWrite(8)
-
-    @Test fun `concurrent write 9`() = concurrentWrite(9)
-
-    fun concurrentWrite(iteration: Int) = runTest { scope ->
+    @RepeatedTest(value = 10)
+    fun concurrentWrite(repetitionInfo: RepetitionInfo) = runTest { scope ->
         val url = "http://localhost/v2"
         val clients = (1..3).map {
             ModelClientV2.builder().url(url).client(client).build().also { it.init() }
@@ -175,7 +158,7 @@ class ReplicatedRepositoryTest {
                     }
                 }
                 models.forEachIndexed { index, model ->
-                    launchWriter(model, 56456 + index + iteration * 100000)
+                    launchWriter(model, 56456 + index + repetitionInfo.currentRepetition * 100000)
                     delay(200.milliseconds)
                 }
             }

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -21,22 +21,32 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.ktor.server.websocket.WebSockets
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.modelix.authorization.installAuthentication
+import org.modelix.model.LinearHistory
+import org.modelix.model.ModelFacade
+import org.modelix.model.VersionMerger
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.IConceptReference
 import org.modelix.model.api.ITree
+import org.modelix.model.api.IdGeneratorDummy
+import org.modelix.model.api.PBranch
 import org.modelix.model.api.PNodeAdapter
 import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
 import org.modelix.model.client2.ModelClientV2
 import org.modelix.model.client2.ReplicatedModel
 import org.modelix.model.client2.getReplicatedModel
 import org.modelix.model.data.asData
 import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.operations.IOperation
+import org.modelix.model.operations.OTBranch
 import org.modelix.model.server.handlers.ModelReplicationServer
 import org.modelix.model.server.store.InMemoryStoreClient
 import org.modelix.model.test.RandomModelChangeGenerator
@@ -44,17 +54,16 @@ import java.util.Collections
 import java.util.SortedSet
 import java.util.TreeSet
 import kotlin.random.Random
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
-@OptIn(ExperimentalTime::class)
 class ReplicatedRepositoryTest {
 
-    private fun runTest(block: suspend ApplicationTestBuilder.() -> Unit) = testApplication {
+    private fun runTest(block: suspend ApplicationTestBuilder.(scope: CoroutineScope) -> Unit) = testApplication {
         application {
             installAuthentication(unitTestMode = true)
             install(ContentNegotiation) {
@@ -63,7 +72,10 @@ class ReplicatedRepositoryTest {
             install(WebSockets)
             ModelReplicationServer(InMemoryStoreClient()).init(this)
         }
-        block()
+
+        coroutineScope {
+            block(this)
+        }
     }
 
     @Test
@@ -135,7 +147,7 @@ class ReplicatedRepositoryTest {
 
     @Test fun `concurrent write 9`() = concurrentWrite(9)
 
-    fun concurrentWrite(iteration: Int) = runTest {
+    fun concurrentWrite(iteration: Int) = runTest { scope ->
         val url = "http://localhost/v2"
         val clients = (1..3).map {
             ModelClientV2.builder().url(url).client(client).build().also { it.init() }
@@ -145,47 +157,249 @@ class ReplicatedRepositoryTest {
         val initialVersion = clients[0].initRepository(repositoryId)
         val branchId = repositoryId.getBranchReference("my-branch")
         clients[0].push(branchId, initialVersion, initialVersion)
-        val models = clients.map { client -> client.getReplicatedModel(branchId).also { it.start() } }
+        val models = clients.map { client -> client.getReplicatedModel(branchId, scope).also { it.start() } }
 
-        val createdNodes: MutableSet<String> = Collections.synchronizedSet(TreeSet<String>())
+        try {
+            val createdNodes: MutableSet<String> = Collections.synchronizedSet(TreeSet<String>())
 
-        coroutineScope {
-            suspend fun launchWriter(model: ReplicatedModel, seed: Int) {
-                launch {
-                    val rand = Random(seed)
-                    for (i in 1..10) {
-                        delay(rand.nextLong(50, 100))
-                        model.getBranch().runWriteT { t ->
-                            createdNodes += t.addNewChild(ITree.ROOT_ID, "role", -1, null as IConceptReference?).toString(16)
+            coroutineScope {
+                suspend fun launchWriter(model: ReplicatedModel, seed: Int) {
+                    launch {
+                        val rand = Random(seed)
+                        for (i in 1..10) {
+                            delay(rand.nextLong(50, 100))
+                            model.getBranch().runWriteT { t ->
+                                createdNodes += t.addNewChild(ITree.ROOT_ID, "role", -1, null as IConceptReference?).toString(16)
+                            }
                         }
                     }
                 }
-            }
-            models.forEachIndexed { index, model ->
-                launchWriter(model, 56456 + index + iteration * 100000)
-                delay(200.milliseconds)
-            }
-        }
-
-        fun getChildren(model: ReplicatedModel): SortedSet<String> {
-            val branch = model.getBranch()
-            return branch.computeRead {
-                branch.getRootNode().allChildren.map { (it as PNodeAdapter).nodeId.toString(16) }.toSortedSet()
-            }
-        }
-
-        assertEquals(clients.size * 10, createdNodes.size)
-
-        runCatching {
-            withTimeout(5.seconds) {
-                models.forEach { model ->
-                    while (getChildren(model) != createdNodes) delay(10.milliseconds)
+                models.forEachIndexed { index, model ->
+                    launchWriter(model, 56456 + index + iteration * 100000)
+                    delay(200.milliseconds)
                 }
             }
+
+            fun getChildren(model: ReplicatedModel): SortedSet<String> {
+                return getChildren(model.getBranch())
+            }
+
+            assertEquals(clients.size * 10, createdNodes.size)
+
+            println("writing done. waiting for convergence.")
+            runCatching {
+                withTimeout(30.seconds) {
+                    models.forEach { model ->
+                        while (getChildren(model) != createdNodes) delay(100.milliseconds)
+                    }
+                }
+            }
+
+            // models.forEach { it.resetToServerVersion() }
+
+            val serverVersion = clients[0].pull(branchId, null)
+            val childrenOnServer = getChildren(PBranch(serverVersion.getTree(), IdGeneratorDummy()))
+
+            assertEquals(createdNodes, childrenOnServer)
+
+            for (model in models) {
+                assertEquals(createdNodes, getChildren(model))
+            }
+        } finally {
+            models.forEach { it.dispose() }
+        }
+        println("all successful")
+    }
+
+    @Ignore
+    @Test
+    fun mergePerformanceTest() {
+        val rand = Random(917563)
+        val idGenerator = IdGenerator.getInstance(100)
+        val initialTree = ModelFacade.newLocalTree() as CLTree
+        val initialVersion = CLVersion.createRegularVersion(
+            idGenerator.generate(),
+            null,
+            null,
+            initialTree,
+            null,
+            emptyArray(),
+        )
+        val versions: MutableList<CLVersion> = mutableListOf(initialVersion)
+        val nonMergedVersions = mutableSetOf<CLVersion>()
+        var headVersion: CLVersion = initialVersion
+        val createdNodes: MutableSet<String> = Collections.synchronizedSet(TreeSet<String>())
+
+        fun mergeVersion(versionToMerge: CLVersion) {
+            headVersion = VersionMerger(initialTree.store, idGenerator).mergeChange(headVersion, versionToMerge)
+            nonMergedVersions.remove(versionToMerge)
         }
 
-        for (model in models) {
-            assertEquals(createdNodes, getChildren(model))
+        for (i in 1..100) {
+            val baseVersion = versions[rand.nextInt(versions.size)]
+            val branch = OTBranch(PBranch(baseVersion.tree, idGenerator), idGenerator, initialTree.store)
+            branch.runWriteT { t ->
+                createdNodes += t.addNewChild(ITree.ROOT_ID, "role", -1, null as IConceptReference?).toString(16)
+            }
+            val (ops, newTree) = branch.getPendingChanges()
+            val newVersion = CLVersion.createRegularVersion(
+                idGenerator.generate(),
+                null,
+                null,
+                newTree as CLTree,
+                baseVersion,
+                ops.map { it.getOriginalOp() }.toTypedArray(),
+            )
+            versions += newVersion
+            nonMergedVersions -= baseVersion
+            nonMergedVersions += newVersion
+
+            while (nonMergedVersions.size > rand.nextInt(10)) {
+                mergeVersion(nonMergedVersions.random(rand))
+            }
+        }
+
+        while (nonMergedVersions.isNotEmpty()) {
+            mergeVersion(nonMergedVersions.random(rand))
+        }
+
+        val headChildren = getChildren(PBranch(headVersion.getTree(), IdGeneratorDummy()))
+
+        assertEquals(createdNodes, headChildren)
+    }
+
+    @Ignore
+    @Test
+    fun linearHistoryPerformance() {
+        val idGenerator = IdGenerator.getInstance(100)
+        val initialTree = ModelFacade.newLocalTree() as CLTree
+        fun version(id: Long, base: CLVersion?): CLVersion {
+            return CLVersion.createRegularVersion(
+                id,
+                null,
+                null,
+                initialTree,
+                base,
+                emptyArray(),
+            )
+        }
+
+        fun merge(id: Long, base: CLVersion, v1: CLVersion, v2: CLVersion): CLVersion {
+            return CLVersion.createAutoMerge(
+                id,
+                initialTree,
+                base,
+                v1,
+                v2,
+                emptyArray<IOperation>(),
+                initialTree.store,
+            )
+        }
+
+        val v30000003a = version(12884901946, null)
+        val v1000004d1 = version(4294968529, v30000003a)
+        val v1000004d3 = version(4294968531, v1000004d1)
+        val v200000353 = version(8589935443, v1000004d3)
+        val v1000004d5 = version(4294968533, v1000004d3)
+        val v30000003c = merge(12884901948, v1000004d3, v200000353, v1000004d5)
+        val v1000004d6 = merge(4294968534, v1000004d3, v1000004d5, v200000353)
+        val v30000003d = merge(12884901949, v1000004d3, v30000003c, v1000004d6)
+        val v30000003e = merge(12884901950, v1000004d3, v30000003d, v1000004d6)
+        val v200000354 = merge(8589935444, v1000004d3, v200000353, v30000003d)
+        val v30000003f = merge(12884901951, v1000004d3, v30000003e, v200000354)
+        val v300000040 = merge(12884901952, v1000004d3, v30000003f, v200000354)
+        val v200000356 = version(8589935446, v200000354)
+        val v300000041 = merge(12884901953, v1000004d3, v300000040, v200000356)
+        val v1000004d8 = version(4294968536, v1000004d6)
+        val v300000042 = merge(12884901954, v1000004d3, v300000041, v1000004d8)
+        val v1000004d9 = merge(4294968537, v1000004d3, v1000004d8, v300000041)
+        val v300000043 = merge(12884901955, v1000004d3, v300000042, v1000004d9)
+        val v300000044 = merge(12884901956, v1000004d3, v300000043, v1000004d9)
+        val v200000357 = merge(8589935447, v1000004d3, v200000356, v300000041)
+        val v300000045 = merge(12884901957, v1000004d3, v300000044, v200000357)
+        val v300000046 = merge(12884901958, v1000004d3, v300000045, v200000357)
+        val v1000004da = merge(4294968538, v1000004d3, v1000004d9, v300000046)
+        val v300000047 = merge(12884901959, v1000004d3, v300000046, v1000004da)
+        val v300000048 = merge(12884901960, v1000004d3, v300000047, v1000004da)
+        val v200000359 = version(8589935449, v200000357)
+        val v300000049 = merge(12884901961, v1000004d3, v300000048, v200000359)
+        val v1000004dc = version(4294968540, v1000004da)
+        val v30000004a = merge(12884901962, v1000004d3, v300000049, v1000004dc)
+        val v20000035a = merge(8589935450, v1000004d3, v200000359, v300000046)
+        val v30000004b = merge(12884901963, v1000004d3, v30000004a, v20000035a)
+        val v30000004c = merge(12884901964, v1000004d3, v30000004b, v20000035a)
+        val v1000004dd = merge(4294968541, v1000004d3, v1000004dc, v30000004c)
+        val v30000004d = merge(12884901965, v1000004d3, v30000004c, v1000004dd)
+        val v30000004e = merge(12884901966, v1000004d3, v30000004d, v1000004dd)
+        val v20000035b = merge(8589935451, v1000004d3, v20000035a, v30000004c)
+        val v30000004f = merge(12884901967, v1000004d3, v30000004e, v20000035b)
+        val v300000050 = merge(12884901968, v1000004d3, v30000004f, v20000035b)
+        val v1000004df = version(4294968543, v1000004dd)
+        val v300000051 = merge(12884901969, v1000004d3, v300000050, v1000004df)
+        val v20000035d = version(8589935453, v20000035b)
+        val v300000052 = merge(12884901970, v1000004d3, v300000051, v20000035d)
+        val v1000004e0 = merge(4294968544, v1000004d3, v1000004df, v300000051)
+        val v300000053 = merge(12884901971, v1000004d3, v300000052, v1000004e0)
+        val v300000054 = merge(12884901972, v1000004d3, v300000053, v1000004e0)
+        val v20000035f = version(8589935455, v20000035d)
+        val v300000055 = merge(12884901973, v1000004d3, v300000054, v20000035f)
+        val v200000360 = merge(8589935456, v1000004d3, v20000035f, v300000052)
+        val v300000056 = merge(12884901974, v1000004d3, v300000055, v200000360)
+        val v300000057 = merge(12884901975, v1000004d3, v300000056, v200000360)
+        val v1000004e2 = version(4294968546, v1000004e0)
+        val v300000058 = merge(12884901976, v1000004d3, v300000057, v1000004e2)
+        val v200000362 = version(8589935458, v200000360)
+        val v300000059 = merge(12884901977, v1000004d3, v300000058, v200000362)
+        val v1000004e3 = merge(4294968547, v1000004d3, v1000004e2, v300000058)
+        val v30000005a = merge(12884901978, v1000004d3, v300000059, v1000004e3)
+        val v30000005b = merge(12884901979, v1000004d3, v30000005a, v1000004e3)
+        val v1000004e5 = version(4294968549, v1000004e3)
+        val v30000005c = merge(12884901980, v1000004d3, v30000005b, v1000004e5)
+        val v200000363 = merge(8589935459, v1000004d3, v200000362, v300000058)
+        val v30000005d = merge(12884901981, v1000004d3, v30000005c, v200000363)
+        val v30000005e = merge(12884901982, v1000004d3, v30000005d, v200000363)
+        val v200000365 = version(8589935461, v200000363)
+        val v30000005f = merge(12884901983, v1000004d3, v30000005e, v200000365)
+        val v1000004e7 = version(4294968551, v1000004e5)
+        val v300000060 = merge(12884901984, v1000004d3, v30000005f, v1000004e7)
+        val v200000367 = version(8589935463, v200000365)
+        val v300000061 = merge(12884901985, v1000004d3, v300000060, v200000367)
+        val v1000004e9 = version(4294968553, v1000004e7)
+        val v300000062 = merge(12884901986, v1000004d3, v300000061, v1000004e9)
+        val v1000004ea = merge(4294968554, v1000004d3, v1000004e9, v300000060)
+        val v300000063 = merge(12884901987, v1000004d3, v300000062, v1000004ea)
+        val v300000064 = merge(12884901988, v1000004d3, v300000063, v1000004ea)
+        val v200000369 = version(8589935465, v200000367)
+        val v300000065 = merge(12884901989, v1000004d3, v300000064, v200000369)
+        val v20000036a = merge(8589935466, v1000004d3, v200000369, v300000060)
+        val v300000066 = merge(12884901990, v1000004d3, v300000065, v20000036a)
+        val v1000004eb = merge(4294968555, v1000004d3, v1000004ea, v300000061)
+        val v300000067 = merge(12884901991, v1000004d3, v300000066, v1000004eb)
+        val v20000036c = version(8589935468, v20000036a)
+        val v300000068 = merge(12884901992, v1000004d3, v300000067, v20000036c)
+        val v300000069 = merge(12884901993, v1000004d3, v300000068, v20000036a)
+        val v30000006b = merge(12884901995, v1000004d3, v300000069, v1000004eb)
+        val v20000036d = merge(8589935469, v1000004d3, v20000036c, v300000063)
+        val v30000006c = merge(12884901996, v1000004d3, v30000006b, v20000036d)
+        val v30000006d = merge(12884901997, v1000004d3, v30000006c, v20000036d)
+        val v1000004ec = merge(4294968556, v1000004d3, v1000004eb, v30000006c)
+        val v30000006e = merge(12884901998, v1000004d3, v30000006d, v1000004ec)
+        val v300000070 = merge(12884902000, v1000004d3, v30000006e, v1000004ec)
+        val v20000036e = merge(8589935470, v1000004d3, v20000036d, v30000006e)
+        val v300000071 = merge(12884902001, v1000004d3, v300000070, v20000036e)
+        val v1000004ed = merge(4294968557, v1000004d3, v1000004ec, v30000006e)
+        val v300000072 = merge(12884902002, v1000004d3, v300000071, v1000004ed)
+        val v20000036f = merge(8589935471, v1000004d3, v20000036e, v30000006e)
+        val v300000073 = merge(12884902003, v1000004d3, v300000072, v20000036f)
+        val v300000074 = merge(12884902004, v1000004d3, v300000073, v20000036f)
+        val v300000075 = merge(12884902005, v1000004d3, v300000074, v20000036e)
+        val v1000004ee = merge(4294968558, v1000004d3, v30000006e, v300000075)
+        LinearHistory(v1000004d3.getContentHash()).load(v300000075, v1000004ee)
+    }
+
+    private fun getChildren(branch: IBranch): SortedSet<String> {
+        return branch.computeRead {
+            branch.getRootNode().allChildren.map { (it as PNodeAdapter).nodeId.toString(16) }.toSortedSet()
         }
     }
 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -44,7 +44,6 @@ import java.util.Collections
 import java.util.SortedSet
 import java.util.TreeSet
 import kotlin.random.Random
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
@@ -116,9 +115,27 @@ class ReplicatedRepositoryTest {
         }
     }
 
-    @Ignore
-    @Test
-    fun `concurrent write`() = runTest {
+    @Test fun `concurrent write 0`() = concurrentWrite(0)
+
+    @Test fun `concurrent write 1`() = concurrentWrite(1)
+
+    @Test fun `concurrent write 2`() = concurrentWrite(2)
+
+    @Test fun `concurrent write 3`() = concurrentWrite(3)
+
+    @Test fun `concurrent write 4`() = concurrentWrite(4)
+
+    @Test fun `concurrent write 5`() = concurrentWrite(5)
+
+    @Test fun `concurrent write 6`() = concurrentWrite(6)
+
+    @Test fun `concurrent write 7`() = concurrentWrite(7)
+
+    @Test fun `concurrent write 8`() = concurrentWrite(8)
+
+    @Test fun `concurrent write 9`() = concurrentWrite(9)
+
+    fun concurrentWrite(iteration: Int) = runTest {
         val url = "http://localhost/v2"
         val clients = (1..3).map {
             ModelClientV2.builder().url(url).client(client).build().also { it.init() }
@@ -145,7 +162,7 @@ class ReplicatedRepositoryTest {
                 }
             }
             models.forEachIndexed { index, model ->
-                launchWriter(model, 56456 + index)
+                launchWriter(model, 56456 + index + iteration * 100000)
                 delay(200.milliseconds)
             }
         }


### PR DESCRIPTION
The reason that the test failed sometimes was that each replica kept creating new merge commits after receiving an update, causing the history to grow without any actual change to the model. The complexity of the merge operation also kept growing and at some point the algorithm just took to long and the synchronization didn't finish within the time limit.