### PR TITLE
Feature/make modelclientv2 closable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ ktor-server-websockets = { group = "io.ktor", name = "ktor-server-websockets", v
 
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-websockets = { group = "io.ktor", name = "ktor-client-websockets", version.ref = "ktor" }
 ktor-client-js = { group = "io.ktor", name = "ktor-client-js", version.ref = "ktor" }

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -55,8 +55,9 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                kotlin("test-common")
-                kotlin("test-annotations-common")
+                implementation(libs.ktor.client.mock)
+                implementation(libs.kotlin.coroutines.test)
+                implementation(kotlin("test"))
             }
         }
         val jvmMain by getting {
@@ -81,22 +82,12 @@ kotlin {
                 implementation(libs.ktor.serialization.json)
             }
         }
-        val jvmTest by getting {
-            dependencies {
-                implementation(kotlin("test"))
-            }
-        }
         val jsMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-js"))
                 implementation(npm("uuid", "^8.3.0"))
                 implementation(npm("js-sha256", "^0.9.0"))
                 implementation(npm("js-base64", "^3.4.5"))
-            }
-        }
-        val jsTest by getting {
-            dependencies {
-                implementation(kotlin("test-js"))
             }
         }
     }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -13,13 +13,14 @@
  */
 package org.modelix.model.client2
 
+import io.ktor.utils.io.core.Closeable
 import org.modelix.model.IVersion
 import org.modelix.model.api.IIdGenerator
 import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.server.api.ModelQuery
 
-interface IModelClientV2 {
+interface IModelClientV2 : Closeable {
     fun getClientId(): Int
     fun getIdGenerator(): IIdGenerator
     fun getUserId(): String?
@@ -44,4 +45,6 @@ interface IModelClientV2 {
 
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?, filter: ModelQuery): IVersion
+
+    override fun close()
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -190,6 +190,10 @@ class ModelClientV2(
         TODO("Not yet implemented")
     }
 
+    override fun close() {
+        httpClient.close()
+    }
+
     private fun createVersion(baseVersion: CLVersion?, delta: VersionDelta): CLVersion {
         return if (baseVersion == null) {
             CLVersion(

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -17,6 +17,7 @@ import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.operations.OTBranch
 import org.modelix.model.server.api.ModelQuery
+import kotlin.coroutines.cancellation.CancellationException
 
 class ReplicatedModel(val client: IModelClientV2, val branchRef: BranchReference, val query: ModelQuery? = null) {
     private val scope = CoroutineScope(Dispatchers.Default)
@@ -62,6 +63,9 @@ class ReplicatedModel(val client: IModelClientV2, val branchRef: BranchReference
                     } as CLVersion
                     remoteVersionReceived(newRemoteVersion)
                     nextDelayMs = 0
+                } catch (ex: CancellationException) {
+                    LOG.debug { "Stop to poll branch $branchRef after disposing." }
+                    throw ex
                 } catch (ex: Throwable) {
                     LOG.error(ex) { "Failed to poll branch $branchRef" }
                     nextDelayMs = (nextDelayMs * 3 / 2).coerceIn(1000, 30000)

--- a/model-client/src/commonTest/kotlin/org/modelix/model/client2/ModelClientV2Test.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/client2/ModelClientV2Test.kt
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.modelix.model.client2
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class ModelClientV2Test {
+
+    @Test
+    fun disposeClient() = runTest {
+        val url = "http://localhost/v2"
+        val mockEngine = MockEngine {
+            respondError(HttpStatusCode.NotFound)
+        }
+        val httpClient = HttpClient(mockEngine)
+        val modelClient = ModelClientV2.builder()
+            .client(httpClient)
+            .url(url)
+            .build()
+        modelClient.close()
+        assertFailsWith<CancellationException>("Parent job is Completed") {
+            modelClient.init()
+        }
+    }
+}


### PR DESCRIPTION
This useful, when the application lives longer than the model client. The HTTP client of the model client can then be disposed of.