### PR TITLE
fix(modelql): access to references outside of queries

### DIFF
--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLNode.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLNode.kt
@@ -198,7 +198,7 @@ abstract class ModelQLNode(val client: ModelQLClient) : INode, ISupportsModelQL,
     }
 
     private fun IMonoStep<INode>.nodeRefAndConcept(): IMonoStep<IZip2Output<Any?, INodeReference, ConceptReference?>> {
-        return nodeReference().zip(conceptReference())
+        return map { it.nodeReference().zip(it.conceptReference()) }
     }
 
     private fun IFluxStep<INode>.nodeRefAndConcept(): IFluxStep<IZip2Output<Any?, INodeReference, ConceptReference?>> {

--- a/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/ModelQLClientTest.kt
+++ b/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/ModelQLClientTest.kt
@@ -241,4 +241,13 @@ class ModelQLClientTest {
         println(result)
         assertEquals(listOf(1002, 2002), result)
     }
+
+    @Test
+    fun `test IMonoStep nodeRefAndConcept`() = runTest { httpClient ->
+        val client = ModelQLClient("http://localhost/query", httpClient)
+
+        val nullNode = client.getRootNode().getReferenceTarget("nonExistentReference")
+
+        assertEquals(null, nullNode)
+    }
 }


### PR DESCRIPTION
Fixes: MODELIX-530

TODO

* [x] add a test. @slisson is there an easy way to test this?