### PR TITLE
build: suppress warnings from unused variables for source sets

### DIFF
--- a/bulk-model-sync-lib/build.gradle.kts
+++ b/bulk-model-sync-lib/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             useJUnitPlatform()
         }
     }
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/kotlin-utils/build.gradle.kts
+++ b/kotlin-utils/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         }
         useCommonJs()
     }
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/light-model-client/build.gradle.kts
+++ b/light-model-client/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-api-gen-runtime/build.gradle.kts
+++ b/model-api-gen-runtime/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         all {
             languageSettings.optIn("kotlin.js.ExperimentalJsExport")

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
         }
         useCommonJs()
     }
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
         }
         useCommonJs()
     }
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         }
         useCommonJs()
     }
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-server-api/build.gradle.kts
+++ b/model-server-api/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-client/build.gradle.kts
+++ b/modelql-client/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-html/build.gradle.kts
+++ b/modelql-html/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-typed/build.gradle.kts
+++ b/modelql-typed/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-untyped/build.gradle.kts
+++ b/modelql-untyped/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         useCommonJs()
     }
 
+    @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
     sourceSets {
         val commonMain by getting {
             dependencies {


### PR DESCRIPTION
Source set access in multi-platform projects is expected to happen by delegation. Yet, the created vals are usually not accessed afterwards and result in compilation warnings when Gradle compiles the build file.

This commit adds suppressions for these warnings. As IntelliJ understands these warnings as unneeded, despite having an effect on command-line compilation, another suppression for the unneeded suppressions is needed.

Cf.: https://youtrack.jetbrains.com/issue/KT-38871