### PR TITLE
fix(modelql): error message for failed node resolution didn't contain the reference

### DIFF
--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStepOutput.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStepOutput.kt
@@ -33,7 +33,11 @@ typealias StepFlow<E> = Flow<IStepOutput<E>>
 val <T> Flow<IStepOutput<T>>.value: Flow<T> get() = map { it.value }
 fun <T> Flow<T>.asStepFlow(owner: IProducingStep<T>?): StepFlow<T> = map { it.asStepOutput(owner) }
 
-class SimpleStepOutput<out E>(override val value: E, val owner: IProducingStep<E>?) : IStepOutput<E>
+class SimpleStepOutput<out E>(override val value: E, val owner: IProducingStep<E>?) : IStepOutput<E> {
+    override fun toString(): String {
+        return "SimpleStepOutput[$value]"
+    }
+}
 
 class SimpleStepOutputSerializer<E>(val valueSerializer: KSerializer<E>, val owner: IProducingStep<E>?) : KSerializer<SimpleStepOutput<E>> {
     init {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ResolveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ResolveNodeStep.kt
@@ -39,7 +39,7 @@ import org.modelix.modelql.core.stepOutputSerializer
 class ResolveNodeStep() : MonoTransformingStep<INodeReference, INode>() {
     override fun createFlow(input: StepFlow<INodeReference>, context: IFlowInstantiationContext): StepFlow<INode> {
         return input.map {
-            it.value.resolveInCurrentContext() ?: throw IllegalArgumentException("Node not found: $it")
+            it.value.resolveInCurrentContext() ?: throw IllegalArgumentException("Node not found: ${it.value}")
         }.asStepFlow(this)
     }
 


### PR DESCRIPTION
The error message was just `java.lang.IllegalArgumentException: Node not found: org.modelix.modelql.core.SimpleStepOutput@4ac2d1e8` which makes it hard to debug.