### PR TITLE
MODELIX-549 incorrect serialization of MPS node references

### DIFF
--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNodeReference.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNodeReference.kt
@@ -51,7 +51,7 @@ object MPSNodeReferenceSerializer : INodeReferenceSerializerEx {
     override val supportedReferenceClasses: Set<KClass<out INodeReference>> = setOf(MPSNodeReference::class)
 
     override fun serialize(ref: INodeReference): String {
-        return (ref as MPSNodeReference).ref.nodeId.toString()
+        return SNodePointer.serialize((ref as MPSNodeReference).ref)
     }
 
     override fun deserialize(serialized: String): INodeReference {


### PR DESCRIPTION
They contained only the node ID instead of the whole reference:
  `mps:741118295176715139`
instead of
  `mps:r:54d7f6a3-9a78-48d5-97cc-b47cbb1f005c(my.model)/741118295176715139`