### PR TITLE
MODELIX-514 Make changes from the MPS model sync plugin visible to the ModelClientV2

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -55,5 +55,11 @@ interface IModelClientV2 {
 
     suspend fun pullHash(branch: BranchReference): String
 
+    /**
+     * While `pull` returns immediately `poll` returns as soon as a new version, that is different from the given
+     * `lastKnownVersion`, is pushed to the server or after some timout specified by the server (usually ~30 seconds).
+     */
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
+
+    suspend fun pollHash(branch: BranchReference, lastKnownVersion: IVersion?): String
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -53,5 +53,7 @@ interface IModelClientV2 {
 
     suspend fun pull(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
 
+    suspend fun pullHash(branch: BranchReference): String
+
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -57,7 +57,7 @@ interface IModelClientV2 {
 
     /**
      * While `pull` returns immediately `poll` returns as soon as a new version, that is different from the given
-     * `lastKnownVersion`, is pushed to the server or after some timout specified by the server (usually ~30 seconds).
+     * `lastKnownVersion`, is pushed to the server or after some timeout specified by the server (usually ~30 seconds).
      */
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
 

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -173,7 +173,20 @@ class ModelClientV2(
             }
         }
         val receivedHash: String = response.body()
-//        LOG.debug { "${clientId.toString(16)}.pullHash($branch) -> $receivedHash" }
+        return receivedHash
+    }
+
+    override suspend fun pollHash(branch: BranchReference, lastKnownVersion: IVersion?): String {
+        val response = httpClient.get {
+            url {
+                takeFrom(baseUrl)
+                appendPathSegmentsEncodingSlash("repositories", branch.repositoryId.id, "branches", branch.branchName, "pollHash")
+                if (lastKnownVersion != null) {
+                    parameters["lastKnown"] = lastKnownVersion.getContentHash()
+                }
+            }
+        }
+        val receivedHash: String = response.body()
         return receivedHash
     }
 

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -165,6 +165,18 @@ class ModelClientV2(
         return receivedVersion
     }
 
+    override suspend fun pullHash(branch: BranchReference): String {
+        val response = httpClient.get {
+            url {
+                takeFrom(baseUrl)
+                appendPathSegmentsEncodingSlash("repositories", branch.repositoryId.id, "branches", branch.branchName, "hash")
+            }
+        }
+        val receivedHash: String = response.body()
+//        LOG.debug { "${clientId.toString(16)}.pullHash($branch) -> $receivedHash" }
+        return receivedHash
+    }
+
     override suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion {
         require(lastKnownVersion is CLVersion?)
         LOG.debug { "${clientId.toString(16)}.poll($branch, $lastKnownVersion)" }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
@@ -30,7 +30,7 @@ class LinearHistory(val baseVersionHash: String?) {
             collect(fromVersion)
         }
 
-        var result: List<Long> = ArrayList()
+        var result: List<Long> = emptyList()
 
         for (version in versions.values.filter { !it.isMerge() }.sortedBy { it.id }) {
             val descendantIds = collectAllDescendants(version.id).filter { !versions[it]!!.isMerge() }.sorted().toSet()

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
@@ -5,7 +5,14 @@ import org.modelix.model.lazy.IDeserializingKeyValueStore
 import org.modelix.model.lazy.KVEntryReference
 import org.modelix.model.persistent.CPVersion
 
-class LinearHistory(val baseVersionHash: String?) {
+/**
+ * Was introduced in https://github.com/modelix/modelix/commit/19c74bed5921028af3ac3ee9d997fc1c4203ad44
+ * together with the UndoOp. The idea is that an undo should only revert changes if there is no other change that relies
+ * on it. In that case the undo should do nothing to not indirectly undo newer changes.
+ * For example, if you added a node and someone else started changing properties on the that node, your undo should not
+ * remove the node to not lose the property changes.
+ */
+class SlowLinearHistory(val baseVersionHash: String?) {
 
     val version2descendants: MutableMap<Long, MutableSet<Long>> = HashMap()
     val versions: MutableMap<Long, CLVersion> = HashMap()
@@ -21,7 +28,7 @@ class LinearHistory(val baseVersionHash: String?) {
         var result: List<Long> = ArrayList()
 
         for (version in versions.values.filter { !it.isMerge() }.sortedBy { it.id }) {
-            val descendantIds = version2descendants[version.id]!!.sorted()
+            val descendantIds = version2descendants[version.id]!!.sorted().toSet()
             val idsInResult = result.toHashSet()
             if (idsInResult.contains(version.id)) {
                 result =
@@ -53,6 +60,76 @@ class LinearHistory(val baseVersionHash: String?) {
             val previous = version.baseVersion
             if (previous != null) {
                 collect(previous, path + version)
+            }
+        }
+    }
+
+    private fun getVersion(hash: KVEntryReference<CPVersion>, store: IDeserializingKeyValueStore): CLVersion {
+        return CLVersion(hash.getValue(store), store)
+    }
+}
+
+class LinearHistory(val baseVersionHash: String?) {
+
+    val version2directDescendants: MutableMap<Long, Set<Long>> = HashMap()
+    val versions: MutableMap<Long, CLVersion> = HashMap()
+
+    /**
+     * Oldest version first
+     */
+    fun load(vararg fromVersions: CLVersion): List<CLVersion> {
+        for (fromVersion in fromVersions) {
+            collect(fromVersion, null)
+        }
+
+        var result: List<Long> = ArrayList()
+
+        for (version in versions.values.filter { !it.isMerge() }.sortedBy { it.id }) {
+            val descendantIds = HashSet<Long>().also { collectAllDescendants(version.id, it) }.filter { !versions[it]!!.isMerge() }.sorted().toSet()
+            val idsInResult = result.toHashSet()
+            if (idsInResult.contains(version.id)) {
+                result =
+                    result +
+                    descendantIds.filter { !idsInResult.contains(it) }
+            } else {
+                result =
+                    result.filter { !descendantIds.contains(it) } +
+                    version.id +
+                    result.filter { descendantIds.contains(it) } +
+                    descendantIds.filter { !idsInResult.contains(it) }
+            }
+        }
+        return result.map { versions[it]!! }
+    }
+
+    private fun collectAllDescendants(ancestor: Long, result: MutableSet<Long>, visited: MutableSet<Long> = HashSet()) {
+        if (!visited.add(ancestor)) return
+        val descendants = version2directDescendants[ancestor] ?: return
+
+        result += descendants
+        descendants.forEach {
+            collectAllDescendants(it, result, visited)
+        }
+    }
+
+    private fun collect(version: CLVersion, descendant: CLVersion?) {
+        if (version.getContentHash() == baseVersionHash) return
+        if (descendant != null) {
+            version2directDescendants[version.id] = (version2directDescendants[version.id] ?: emptySet()) + setOf(descendant.id)
+        }
+        if (versions.containsKey(version.id)) return
+
+        versions[version.id] = version
+
+        if (version.isMerge()) {
+            val version1 = getVersion(version.data!!.mergedVersion1!!, version.store)
+            val version2 = getVersion(version.data!!.mergedVersion2!!, version.store)
+            collect(version1, version)
+            collect(version2, version)
+        } else {
+            val previous = version.baseVersion
+            if (previous != null) {
+                collect(previous, version)
             }
         }
     }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
@@ -8,84 +8,32 @@ import org.modelix.model.persistent.CPVersion
 /**
  * Was introduced in https://github.com/modelix/modelix/commit/19c74bed5921028af3ac3ee9d997fc1c4203ad44
  * together with the UndoOp. The idea is that an undo should only revert changes if there is no other change that relies
- * on it. In that case the undo should do nothing to not indirectly undo newer changes.
+ * on it. In that case the undo should do nothing, to not indirectly undo newer changes.
  * For example, if you added a node and someone else started changing properties on the that node, your undo should not
  * remove the node to not lose the property changes.
+ * This requires the versions to be ordered in a way that the undo appears later.
  */
-class SlowLinearHistory(val baseVersionHash: String?) {
-
-    val version2descendants: MutableMap<Long, MutableSet<Long>> = HashMap()
-    val versions: MutableMap<Long, CLVersion> = HashMap()
-
-    /**
-     * Oldest version first
-     */
-    fun load(vararg fromVersions: CLVersion): List<CLVersion> {
-        for (fromVersion in fromVersions) {
-            collect(fromVersion, emptyList())
-        }
-
-        var result: List<Long> = ArrayList()
-
-        for (version in versions.values.filter { !it.isMerge() }.sortedBy { it.id }) {
-            val descendantIds = version2descendants[version.id]!!.sorted().toSet()
-            val idsInResult = result.toHashSet()
-            if (idsInResult.contains(version.id)) {
-                result =
-                    result +
-                    descendantIds.filter { !idsInResult.contains(it) }
-            } else {
-                result =
-                    result.filter { !descendantIds.contains(it) } +
-                    version.id +
-                    result.filter { descendantIds.contains(it) } +
-                    descendantIds.filter { !idsInResult.contains(it) }
-            }
-        }
-        return result.map { versions[it]!! }
-    }
-
-    private fun collect(version: CLVersion, path: List<CLVersion>) {
-        if (version.hash == baseVersionHash) return
-
-        if (!versions.containsKey(version.id)) versions[version.id] = version
-        version2descendants.getOrPut(version.id) { HashSet() }.addAll(path.asSequence().map { it.id })
-
-        if (version.isMerge()) {
-            val version1 = getVersion(version.data!!.mergedVersion1!!, version.store)
-            val version2 = getVersion(version.data!!.mergedVersion2!!, version.store)
-            collect(version1, path)
-            collect(version2, path)
-        } else {
-            val previous = version.baseVersion
-            if (previous != null) {
-                collect(previous, path + version)
-            }
-        }
-    }
-
-    private fun getVersion(hash: KVEntryReference<CPVersion>, store: IDeserializingKeyValueStore): CLVersion {
-        return CLVersion(hash.getValue(store), store)
-    }
-}
-
 class LinearHistory(val baseVersionHash: String?) {
 
     val version2directDescendants: MutableMap<Long, Set<Long>> = HashMap()
-    val versions: MutableMap<Long, CLVersion> = HashMap()
+    val versions: MutableMap<Long, CLVersion> = LinkedHashMap()
 
     /**
-     * Oldest version first
+     * @param fromVersions it is assumed that the versions are sorted by the oldest version first. When merging a new
+     *        version into an existing one the new version should appear after the existing one. The resulting order
+     *        will prefer existing versions to new ones, meaning during the conflict resolution the existing changes
+     *        have a higher probability of surviving.
+     * @returns oldest version first
      */
     fun load(vararg fromVersions: CLVersion): List<CLVersion> {
         for (fromVersion in fromVersions) {
-            collect(fromVersion, null)
+            collect(fromVersion)
         }
 
         var result: List<Long> = ArrayList()
 
         for (version in versions.values.filter { !it.isMerge() }.sortedBy { it.id }) {
-            val descendantIds = HashSet<Long>().also { collectAllDescendants(version.id, it) }.filter { !versions[it]!!.isMerge() }.sorted().toSet()
+            val descendantIds = collectAllDescendants(version.id).filter { !versions[it]!!.isMerge() }.sorted().toSet()
             val idsInResult = result.toHashSet()
             if (idsInResult.contains(version.id)) {
                 result =
@@ -102,34 +50,45 @@ class LinearHistory(val baseVersionHash: String?) {
         return result.map { versions[it]!! }
     }
 
-    private fun collectAllDescendants(ancestor: Long, result: MutableSet<Long>, visited: MutableSet<Long> = HashSet()) {
-        if (!visited.add(ancestor)) return
-        val descendants = version2directDescendants[ancestor] ?: return
+    private fun collectAllDescendants(root: Long): Set<Long> {
+        val result = LinkedHashSet<Long>()
+        var previousSize = 0
+        result += root
 
-        result += descendants
-        descendants.forEach {
-            collectAllDescendants(it, result, visited)
+        while (previousSize != result.size) {
+            val nextElements = result.asSequence().drop(previousSize).toList()
+            previousSize = result.size
+            for (ancestor in nextElements) {
+                version2directDescendants[ancestor]?.let { result += it }
+            }
         }
+
+        return result.drop(1).toSet()
     }
 
-    private fun collect(version: CLVersion, descendant: CLVersion?) {
-        if (version.getContentHash() == baseVersionHash) return
-        if (descendant != null) {
-            version2directDescendants[version.id] = (version2directDescendants[version.id] ?: emptySet()) + setOf(descendant.id)
-        }
-        if (versions.containsKey(version.id)) return
+    private fun collect(root: CLVersion) {
+        if (root.getContentHash() == baseVersionHash) return
 
-        versions[version.id] = version
+        var previousSize = versions.size
+        versions[root.id] = root
 
-        if (version.isMerge()) {
-            val version1 = getVersion(version.data!!.mergedVersion1!!, version.store)
-            val version2 = getVersion(version.data!!.mergedVersion2!!, version.store)
-            collect(version1, version)
-            collect(version2, version)
-        } else {
-            val previous = version.baseVersion
-            if (previous != null) {
-                collect(previous, version)
+        while (previousSize != versions.size) {
+            val nextElements = versions.asSequence().drop(previousSize).map { it.value }.toList()
+            previousSize = versions.size
+
+            for (descendant in nextElements) {
+                val ancestors = if (descendant.isMerge()) {
+                    sequenceOf(
+                        getVersion(descendant.data!!.mergedVersion1!!, descendant.store),
+                        getVersion(descendant.data!!.mergedVersion2!!, descendant.store),
+                    )
+                } else {
+                    sequenceOf(descendant.baseVersion)
+                }.filterNotNull().filter { it.getContentHash() != baseVersionHash }.toList()
+                for (ancestor in ancestors) {
+                    versions[ancestor.id] = ancestor
+                    version2directDescendants[ancestor.id] = (version2directDescendants[ancestor.id] ?: emptySet()) + setOf(descendant.id)
+                }
             }
         }
     }

--- a/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
@@ -28,7 +28,7 @@ class LinearHistoryTest {
     val initialTree = CLTree.builder(ObjectStoreCache(MapBaseStore())).repositoryId("LinearHistoryTest").build()
 
     @Test
-    fun simpleTest1() {
+    fun noCommonHistory() {
         val v20 = version(20, null)
         val v21 = version(21, null)
 
@@ -36,7 +36,7 @@ class LinearHistoryTest {
     }
 
     @Test
-    fun simpleTest2() {
+    fun divergedByTwoCommits() {
         val v10 = version(10, null)
         val v20 = version(20, v10)
         val v21 = version(21, v10)
@@ -45,7 +45,9 @@ class LinearHistoryTest {
     }
 
     @Test
-    fun linearHistoryPerformance() {
+    fun knownPerformanceIssue() {
+        // This test was dumped from actual case discovered during a profiling session.
+
         val v30000003a = version(12884901946, null)
         val v1000004d1 = version(4294968529, v30000003a)
         val v1000004d3 = version(4294968531, v1000004d1)

--- a/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.modelix.model.LinearHistory
+import org.modelix.model.VersionMerger
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.CLVersion
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.operations.IOperation
+import org.modelix.model.persistent.MapBaseStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LinearHistoryTest {
+    val initialTree = CLTree.builder(ObjectStoreCache(MapBaseStore())).repositoryId("LinearHistoryTest").build()
+
+    @Test
+    fun simpleTest1() {
+        val v20 = version(20, null)
+        val v21 = version(21, null)
+
+        assertHistory(v20, v21, listOf(v20, v21))
+    }
+
+    @Test
+    fun simpleTest2() {
+        val v10 = version(10, null)
+        val v20 = version(20, v10)
+        val v21 = version(21, v10)
+
+        assertHistory(v20, v21, listOf(v20, v21))
+    }
+
+    @Test
+    fun linearHistoryPerformance() {
+        val v30000003a = version(12884901946, null)
+        val v1000004d1 = version(4294968529, v30000003a)
+        val v1000004d3 = version(4294968531, v1000004d1)
+        val v200000353 = version(8589935443, v1000004d3)
+        val v1000004d5 = version(4294968533, v1000004d3)
+        val v30000003c = merge(12884901948, v1000004d3, v200000353, v1000004d5)
+        val v1000004d6 = merge(4294968534, v1000004d3, v1000004d5, v200000353)
+        val v30000003d = merge(12884901949, v1000004d3, v30000003c, v1000004d6)
+        val v30000003e = merge(12884901950, v1000004d3, v30000003d, v1000004d6)
+        val v200000354 = merge(8589935444, v1000004d3, v200000353, v30000003d)
+        val v30000003f = merge(12884901951, v1000004d3, v30000003e, v200000354)
+        val v300000040 = merge(12884901952, v1000004d3, v30000003f, v200000354)
+        val v200000356 = version(8589935446, v200000354)
+        val v300000041 = merge(12884901953, v1000004d3, v300000040, v200000356)
+        val v1000004d8 = version(4294968536, v1000004d6)
+        val v300000042 = merge(12884901954, v1000004d3, v300000041, v1000004d8)
+        val v1000004d9 = merge(4294968537, v1000004d3, v1000004d8, v300000041)
+        val v300000043 = merge(12884901955, v1000004d3, v300000042, v1000004d9)
+        val v300000044 = merge(12884901956, v1000004d3, v300000043, v1000004d9)
+        val v200000357 = merge(8589935447, v1000004d3, v200000356, v300000041)
+        val v300000045 = merge(12884901957, v1000004d3, v300000044, v200000357)
+        val v300000046 = merge(12884901958, v1000004d3, v300000045, v200000357)
+        val v1000004da = merge(4294968538, v1000004d3, v1000004d9, v300000046)
+        val v300000047 = merge(12884901959, v1000004d3, v300000046, v1000004da)
+        val v300000048 = merge(12884901960, v1000004d3, v300000047, v1000004da)
+        val v200000359 = version(8589935449, v200000357)
+        val v300000049 = merge(12884901961, v1000004d3, v300000048, v200000359)
+        val v1000004dc = version(4294968540, v1000004da)
+        val v30000004a = merge(12884901962, v1000004d3, v300000049, v1000004dc)
+        val v20000035a = merge(8589935450, v1000004d3, v200000359, v300000046)
+        val v30000004b = merge(12884901963, v1000004d3, v30000004a, v20000035a)
+        val v30000004c = merge(12884901964, v1000004d3, v30000004b, v20000035a)
+        val v1000004dd = merge(4294968541, v1000004d3, v1000004dc, v30000004c)
+        val v30000004d = merge(12884901965, v1000004d3, v30000004c, v1000004dd)
+        val v30000004e = merge(12884901966, v1000004d3, v30000004d, v1000004dd)
+        val v20000035b = merge(8589935451, v1000004d3, v20000035a, v30000004c)
+        val v30000004f = merge(12884901967, v1000004d3, v30000004e, v20000035b)
+        val v300000050 = merge(12884901968, v1000004d3, v30000004f, v20000035b)
+        val v1000004df = version(4294968543, v1000004dd)
+        val v300000051 = merge(12884901969, v1000004d3, v300000050, v1000004df)
+        val v20000035d = version(8589935453, v20000035b)
+        val v300000052 = merge(12884901970, v1000004d3, v300000051, v20000035d)
+        val v1000004e0 = merge(4294968544, v1000004d3, v1000004df, v300000051)
+        val v300000053 = merge(12884901971, v1000004d3, v300000052, v1000004e0)
+        val v300000054 = merge(12884901972, v1000004d3, v300000053, v1000004e0)
+        val v20000035f = version(8589935455, v20000035d)
+        val v300000055 = merge(12884901973, v1000004d3, v300000054, v20000035f)
+        val v200000360 = merge(8589935456, v1000004d3, v20000035f, v300000052)
+        val v300000056 = merge(12884901974, v1000004d3, v300000055, v200000360)
+        val v300000057 = merge(12884901975, v1000004d3, v300000056, v200000360)
+        val v1000004e2 = version(4294968546, v1000004e0)
+        val v300000058 = merge(12884901976, v1000004d3, v300000057, v1000004e2)
+        val v200000362 = version(8589935458, v200000360)
+        val v300000059 = merge(12884901977, v1000004d3, v300000058, v200000362)
+        val v1000004e3 = merge(4294968547, v1000004d3, v1000004e2, v300000058)
+        val v30000005a = merge(12884901978, v1000004d3, v300000059, v1000004e3)
+        val v30000005b = merge(12884901979, v1000004d3, v30000005a, v1000004e3)
+        val v1000004e5 = version(4294968549, v1000004e3)
+        val v30000005c = merge(12884901980, v1000004d3, v30000005b, v1000004e5)
+        val v200000363 = merge(8589935459, v1000004d3, v200000362, v300000058)
+        val v30000005d = merge(12884901981, v1000004d3, v30000005c, v200000363)
+        val v30000005e = merge(12884901982, v1000004d3, v30000005d, v200000363)
+        val v200000365 = version(8589935461, v200000363)
+        val v30000005f = merge(12884901983, v1000004d3, v30000005e, v200000365)
+        val v1000004e7 = version(4294968551, v1000004e5)
+        val v300000060 = merge(12884901984, v1000004d3, v30000005f, v1000004e7)
+        val v200000367 = version(8589935463, v200000365)
+        val v300000061 = merge(12884901985, v1000004d3, v300000060, v200000367)
+        val v1000004e9 = version(4294968553, v1000004e7)
+        val v300000062 = merge(12884901986, v1000004d3, v300000061, v1000004e9)
+        val v1000004ea = merge(4294968554, v1000004d3, v1000004e9, v300000060)
+        val v300000063 = merge(12884901987, v1000004d3, v300000062, v1000004ea)
+        val v300000064 = merge(12884901988, v1000004d3, v300000063, v1000004ea)
+        val v200000369 = version(8589935465, v200000367)
+        val v300000065 = merge(12884901989, v1000004d3, v300000064, v200000369)
+        val v20000036a = merge(8589935466, v1000004d3, v200000369, v300000060)
+        val v300000066 = merge(12884901990, v1000004d3, v300000065, v20000036a)
+        val v1000004eb = merge(4294968555, v1000004d3, v1000004ea, v300000061)
+        val v300000067 = merge(12884901991, v1000004d3, v300000066, v1000004eb)
+        val v20000036c = version(8589935468, v20000036a)
+        val v300000068 = merge(12884901992, v1000004d3, v300000067, v20000036c)
+        val v300000069 = merge(12884901993, v1000004d3, v300000068, v20000036a)
+        val v30000006b = merge(12884901995, v1000004d3, v300000069, v1000004eb)
+        val v20000036d = merge(8589935469, v1000004d3, v20000036c, v300000063)
+        val v30000006c = merge(12884901996, v1000004d3, v30000006b, v20000036d)
+        val v30000006d = merge(12884901997, v1000004d3, v30000006c, v20000036d)
+        val v1000004ec = merge(4294968556, v1000004d3, v1000004eb, v30000006c)
+        val v30000006e = merge(12884901998, v1000004d3, v30000006d, v1000004ec)
+        val v300000070 = merge(12884902000, v1000004d3, v30000006e, v1000004ec)
+        val v20000036e = merge(8589935470, v1000004d3, v20000036d, v30000006e)
+        val v300000071 = merge(12884902001, v1000004d3, v300000070, v20000036e)
+        val v1000004ed = merge(4294968557, v1000004d3, v1000004ec, v30000006e)
+        val v300000072 = merge(12884902002, v1000004d3, v300000071, v1000004ed)
+        val v20000036f = merge(8589935471, v1000004d3, v20000036e, v30000006e)
+        val v300000073 = merge(12884902003, v1000004d3, v300000072, v20000036f)
+        val v300000074 = merge(12884902004, v1000004d3, v300000073, v20000036f)
+        val v300000075 = merge(12884902005, v1000004d3, v300000074, v20000036e)
+        val v1000004ee = merge(4294968558, v1000004d3, v30000006e, v300000075)
+
+        // val expected = SlowLinearHistory(v1000004d3.getContentHash()).load(v300000075, v1000004ee)
+        val expected = listOf(
+            v1000004d5,
+            v200000353,
+            v1000004d8,
+            v1000004dc,
+            v1000004df,
+            v1000004e2,
+            v1000004e5,
+            v1000004e7,
+            v1000004e9,
+            v200000356,
+            v200000359,
+            v20000035d,
+            v20000035f,
+            v200000362,
+            v200000365,
+            v200000367,
+            v200000369,
+            v20000036c,
+        )
+        assertHistory(v300000075, v1000004ee, expected)
+    }
+
+    private fun assertHistory(v1: CLVersion, v2: CLVersion, expected: List<CLVersion>) {
+        val actual = history(v1, v2)
+        assertEquals(expected.map { it.id.toString(16) }, actual.map { it.id.toString(16) })
+        assertEquals(expected, actual)
+    }
+
+    private fun history(v1: CLVersion, v2: CLVersion): List<CLVersion> {
+        val base = VersionMerger.commonBaseVersion(v1, v2)
+        return LinearHistory(base?.getContentHash()).load(v1, v2)
+    }
+
+    private fun version(id: Long, base: CLVersion?): CLVersion {
+        return CLVersion.createRegularVersion(
+            id,
+            null,
+            null,
+            initialTree,
+            base,
+            emptyArray(),
+        )
+    }
+
+    private fun merge(id: Long, v1: CLVersion, v2: CLVersion): CLVersion {
+        return merge(id, VersionMerger.Companion.commonBaseVersion(v1, v2)!!, v1, v2)
+    }
+
+    private fun merge(id: Long, base: CLVersion, v1: CLVersion, v2: CLVersion): CLVersion {
+        return CLVersion.createAutoMerge(
+            id,
+            initialTree,
+            base,
+            v1,
+            v2,
+            emptyArray<IOperation>(),
+            initialTree.store,
+        )
+    }
+}

--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -141,17 +141,16 @@ object Main {
                 storeClient.put(cmdLineArgs.setValues[i], cmdLineArgs.setValues[i + 1])
                 i += 2
             }
-            val modelServer = KeyValueLikeModelServer(storeClient)
             val localModelClient = LocalModelClient(storeClient)
+            val repositoriesManager = RepositoriesManager(localModelClient)
+            val modelServer = KeyValueLikeModelServer(repositoriesManager)
             val sharedSecretFile = cmdLineArgs.secretFile
             if (sharedSecretFile.exists()) {
                 modelServer.setSharedSecret(
                     FileUtils.readFileToString(sharedSecretFile, StandardCharsets.UTF_8),
                 )
             }
-
             val jsonModelServer = DeprecatedLightModelServer(localModelClient)
-            val repositoriesManager = RepositoriesManager(localModelClient)
             val repositoryOverview = RepositoryOverview(repositoriesManager)
             val historyHandler = HistoryHandler(localModelClient, repositoriesManager)
             val contentExplorer = ContentExplorer(localModelClient, repositoriesManager)

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
@@ -42,6 +42,7 @@ import org.modelix.authorization.checkPermission
 import org.modelix.authorization.getUserName
 import org.modelix.authorization.requiresPermission
 import org.modelix.authorization.toKeycloakScope
+import org.modelix.model.lazy.BranchReference
 import org.modelix.model.persistent.HashUtil
 import org.modelix.model.server.store.IStoreClient
 import org.modelix.model.server.store.pollEntry
@@ -50,6 +51,7 @@ import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.LinkedHashMap
 
 val PERMISSION_MODEL_SERVER = "model-server".asResource()
 val MODEL_SERVER_ENTRY = KeycloakResourceType("model-server-entry", KeycloakScope.READ_WRITE_DELETE)
@@ -62,37 +64,17 @@ private class NotFoundException(description: String?) : RuntimeException(descrip
 
 typealias CallContext = PipelineContext<Unit, ApplicationCall>
 
-class KeyValueLikeModelServer(val storeClient: IStoreClient) {
+class KeyValueLikeModelServer(val repositoriesManager: RepositoriesManager) {
     companion object {
         private val LOG = LoggerFactory.getLogger(KeyValueLikeModelServer::class.java)
         val HASH_PATTERN = Pattern.compile("[a-zA-Z0-9\\-_]{5}\\*[a-zA-Z0-9\\-_]{38}")
         const val PROTECTED_PREFIX = "$$$"
         val HEALTH_KEY = PROTECTED_PREFIX + "health2"
-        private const val LEGACY_SERVER_ID_KEY = "repositoryId"
-        private const val SERVER_ID_KEY = "server-id"
-
-        private fun randomUUID(): String {
-            return UUID.randomUUID().toString().replace("[^a-zA-Z0-9]".toRegex(), "")
-        }
-
-        fun initServerId(storeClient: IStoreClient) {
-            storeClient.runTransaction {
-                var serverId = storeClient[SERVER_ID_KEY]
-                if (serverId == null) {
-                    serverId = storeClient[LEGACY_SERVER_ID_KEY] ?: randomUUID()
-                    storeClient.put(SERVER_ID_KEY, serverId)
-                    storeClient.put(LEGACY_SERVER_ID_KEY, serverId)
-                }
-            }
-        }
-
-        fun getServerId(storeClient: IStoreClient): String {
-            return storeClient[SERVER_ID_KEY]!!
-        }
     }
 
+    val storeClient: IStoreClient get() = repositoriesManager.client.store
+
     fun init(application: Application) {
-        initServerId(storeClient)
         application.apply {
             modelServerModule()
         }
@@ -298,7 +280,46 @@ class KeyValueLikeModelServer(val storeClient: IStoreClient) {
                 throw NotFoundException("Referenced key $key not found")
             }
         }
-        storeClient.putAll(newEntries)
+
+        // Entries were previously written directly to the store.
+        // Now we use the RepositoriesManager to merge changes instead of just overwriting a branch.
+
+        val hashedObjects = LinkedHashMap<String, String>()
+        val branchChanges = LinkedHashMap<BranchReference, String>()
+        val userDefinedEntries = LinkedHashMap<String, String?>()
+
+        for ((key, value) in newEntries) {
+            when {
+                HashUtil.isSha256(key) -> {
+                    hashedObjects[key] = value ?: throw IllegalArgumentException("No value provided for $key")
+                }
+                BranchReference.tryParseBranch(key) != null -> {
+                    branchChanges[BranchReference.tryParseBranch(key)!!] = value ?: throw IllegalArgumentException("Deleting branch $key not allowed")
+                }
+                key.startsWith(PROTECTED_PREFIX) -> {
+                    throw NoPermissionException("Access to keys starting with '$PROTECTED_PREFIX' is only permitted to the model server itself.")
+                }
+                key.startsWith(RepositoriesManager.KEY_PREFIX) -> {
+                    throw NoPermissionException("Access to keys starting with '${RepositoriesManager.KEY_PREFIX}' is only permitted to the model server itself.")
+                }
+                key == RepositoriesManager.LEGACY_SERVER_ID_KEY || key == RepositoriesManager.LEGACY_SERVER_ID_KEY2 -> {
+                    throw NoPermissionException("'$key' is read-only.")
+                }
+                else -> {
+                    userDefinedEntries[key] = value
+                }
+            }
+        }
+
+        HashUtil.checkObjectHashes(hashedObjects)
+
+        repositoriesManager.client.store.runTransaction {
+            storeClient.putAll(hashedObjects)
+            storeClient.putAll(userDefinedEntries)
+            for ((branch, value) in branchChanges) {
+                repositoriesManager.mergeChanges(branch, value)
+            }
+        }
     }
 
     private suspend fun CallContext.respondValue(key: String, value: String?) {
@@ -317,7 +338,7 @@ class KeyValueLikeModelServer(val storeClient: IStoreClient) {
         if (key.startsWith(RepositoriesManager.KEY_PREFIX)) {
             throw NoPermissionException("Access to keys starting with '${RepositoriesManager.KEY_PREFIX}' is only permitted to the model server itself.")
         }
-        if ((key == SERVER_ID_KEY || key == LEGACY_SERVER_ID_KEY) && type.includes(EPermissionType.WRITE)) {
+        if ((key == RepositoriesManager.LEGACY_SERVER_ID_KEY || key == RepositoriesManager.LEGACY_SERVER_ID_KEY2) && type.includes(EPermissionType.WRITE)) {
             throw NoPermissionException("'$key' is read-only.")
         }
         if (HashUtil.isSha256(key)) {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -127,6 +127,18 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
                             }
                             call.respondDelta(versionHash, baseVersionHash)
                         }
+                        get("hash") {
+                            val branch = branchRef()
+                            val versionHash = repositoriesManager.getVersionHash(branch)
+                            if (versionHash == null) {
+                                call.respondText(
+                                    "Branch '${branch.branchName}' doesn't exist in repository '${branch.repositoryId.id}'",
+                                    status = HttpStatusCode.NotFound,
+                                )
+                                return@get
+                            }
+                            call.respondText(versionHash)
+                        }
                         post {
                             val deltaFromClient = call.receive<VersionDelta>()
                             deltaFromClient.checkObjectHashes()

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -75,7 +75,6 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
     private val storeClient: IStoreClient get() = modelClient.store
 
     fun init(application: Application) {
-        KeyValueLikeModelServer.initServerId(storeClient)
         application.apply {
             routing {
                 route("v2") {
@@ -90,7 +89,7 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
             call.respondText(storeClient.generateId("clientId").toString())
         }
         get("server-id") {
-            call.respondText(KeyValueLikeModelServer.getServerId(storeClient))
+            call.respondText(repositoriesManager.getServerId())
         }
         get("user-id") {
             call.respondText(call.getUserName() ?: call.request.origin.remoteHost)

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -150,6 +150,11 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
                             val newVersionHash = repositoriesManager.pollVersionHash(branchRef(), lastKnownVersionHash)
                             call.respondDelta(newVersionHash, lastKnownVersionHash)
                         }
+                        get("pollHash") {
+                            val lastKnownVersionHash = call.request.queryParameters["lastKnown"]
+                            val newVersionHash = repositoriesManager.pollVersionHash(branchRef(), lastKnownVersionHash)
+                            call.respondText(newVersionHash)
+                        }
                         webSocket("listen") {
                             var lastVersionHash = call.request.queryParameters["lastKnown"]
                             while (coroutineContext[Job]?.isCancelled == false) {

--- a/model-server/src/test/java/org/modelix/model/server/RestModelServerTest.java
+++ b/model-server/src/test/java/org/modelix/model/server/RestModelServerTest.java
@@ -22,14 +22,17 @@ import java.util.HashSet;
 import org.json.JSONArray;
 import org.junit.Test;
 import org.modelix.model.server.handlers.KeyValueLikeModelServer;
+import org.modelix.model.server.handlers.RepositoriesManager;
 import org.modelix.model.server.store.InMemoryStoreClient;
+import org.modelix.model.server.store.LocalModelClient;
 
 public class RestModelServerTest {
 
     @Test
     public void testCollectUnexistingKey() {
-        InMemoryStoreClient storeClient = new InMemoryStoreClient();
-        KeyValueLikeModelServer rms = new KeyValueLikeModelServer(storeClient);
+        KeyValueLikeModelServer rms =
+                new KeyValueLikeModelServer(
+                        new RepositoriesManager(new LocalModelClient(new InMemoryStoreClient())));
         JSONArray result = rms.collect("unexistingKey");
         assertEquals(1, result.length());
         assertEquals(new HashSet<>(Arrays.asList("key")), result.getJSONObject(0).keySet());
@@ -40,7 +43,9 @@ public class RestModelServerTest {
     public void testCollectExistingKeyNotHash() {
         InMemoryStoreClient storeClient = new InMemoryStoreClient();
         storeClient.put("existingKey", "foo", false);
-        KeyValueLikeModelServer rms = new KeyValueLikeModelServer(storeClient);
+        KeyValueLikeModelServer rms =
+                new KeyValueLikeModelServer(
+                        new RepositoriesManager(new LocalModelClient(storeClient)));
         JSONArray result = rms.collect("existingKey");
         assertEquals(1, result.length());
         assertEquals(
@@ -54,7 +59,9 @@ public class RestModelServerTest {
         InMemoryStoreClient storeClient = new InMemoryStoreClient();
         storeClient.put("existingKey", "hash-*0123456789-0123456789-0123456789-00001", false);
         storeClient.put("hash-*0123456789-0123456789-0123456789-00001", "bar", false);
-        KeyValueLikeModelServer rms = new KeyValueLikeModelServer(storeClient);
+        KeyValueLikeModelServer rms =
+                new KeyValueLikeModelServer(
+                        new RepositoriesManager(new LocalModelClient(storeClient)));
         JSONArray result = rms.collect("existingKey");
         assertEquals(2, result.length());
 
@@ -86,7 +93,9 @@ public class RestModelServerTest {
                 "hash-*0123456789-0123456789-0123456789-00004",
                 false);
         storeClient.put("hash-*0123456789-0123456789-0123456789-00004", "end", false);
-        KeyValueLikeModelServer rms = new KeyValueLikeModelServer(storeClient);
+        KeyValueLikeModelServer rms =
+                new KeyValueLikeModelServer(
+                        new RepositoriesManager(new LocalModelClient(storeClient)));
         JSONArray result = rms.collect("root");
         assertEquals(5, result.length());
 
@@ -132,7 +141,9 @@ public class RestModelServerTest {
                 "hash-*0123456789-0123456789-0123456789-00003",
                 "hash-*0123456789-0123456789-0123456789-00001",
                 false);
-        KeyValueLikeModelServer rms = new KeyValueLikeModelServer(storeClient);
+        KeyValueLikeModelServer rms =
+                new KeyValueLikeModelServer(
+                        new RepositoriesManager(new LocalModelClient(storeClient)));
         JSONArray result = rms.collect("root");
         assertEquals(4, result.length());
 

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientTest.kt
@@ -23,7 +23,9 @@ import org.modelix.authorization.installAuthentication
 import org.modelix.model.IKeyListener
 import org.modelix.model.client.RestWebModelClient
 import org.modelix.model.server.handlers.KeyValueLikeModelServer
+import org.modelix.model.server.handlers.RepositoriesManager
 import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.model.server.store.LocalModelClient
 import java.util.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,7 +37,7 @@ class ModelClientTest {
     private fun runTest(block: suspend ApplicationTestBuilder.() -> Unit) = testApplication {
         application {
             installAuthentication(unitTestMode = true)
-            KeyValueLikeModelServer(InMemoryStoreClient()).init(this)
+            KeyValueLikeModelServer(RepositoriesManager(LocalModelClient(InMemoryStoreClient()))).init(this)
         }
         block()
     }

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -329,6 +329,7 @@ class ReplicatedRepositoryTest {
         println("all successful")
     }
 
+    @Ignore
     @RepeatedTest(value = 10)
     fun clientCompatibility(repetitionInfo: RepetitionInfo) = runTest { scope ->
         val url = "http://localhost/v2"

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -174,7 +174,6 @@ class ReplicatedRepositoryTest {
 
             assertEquals(clients.size * 10, createdNodes.size)
 
-            println("writing done. waiting for convergence.")
             runCatching {
                 withTimeout(30.seconds) {
                     models.forEach { model ->
@@ -196,7 +195,6 @@ class ReplicatedRepositoryTest {
         } finally {
             models.forEach { it.dispose() }
         }
-        println("all successful")
     }
 
     private interface IRandomOperation {
@@ -302,14 +300,11 @@ class ReplicatedRepositoryTest {
             },
         )
 
-        var iterations = 0
         while (true) {
             val applicableOps = clients.flatMap { createOpsForClient(it) }.filter { it.isApplicable() }
             if (applicableOps.isEmpty()) break
             applicableOps.random(rand).apply()
-            iterations++
         }
-        println("Iterations: $iterations")
 
         fun getChildren(model: CLVersion): SortedSet<String> {
             return getChildren(PBranch(model.getTree(), IdGeneratorDummy()))
@@ -325,8 +320,6 @@ class ReplicatedRepositoryTest {
         for (client in clients) {
             assertEquals(createdNodes, getChildren(localVersions[client]!!))
         }
-
-        println("all successful")
     }
 
     @Ignore
@@ -392,7 +385,6 @@ class ReplicatedRepositoryTest {
 
             assertEquals((clients.size + v1clients.size) * 10, createdNodes.size)
 
-            println("writing done. waiting for convergence.")
             runCatching {
                 withTimeout(30.seconds) {
                     models.forEach { model ->
@@ -422,7 +414,6 @@ class ReplicatedRepositoryTest {
             v1models.forEach { it.dispose() }
             v1clients.forEach { it.dispose() }
         }
-        println("all successful")
     }
 
     @Ignore

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -322,7 +322,7 @@ class ReplicatedRepositoryTest {
         }
     }
 
-    @Ignore
+    @Ignore("Not stable yet. See https://issues.modelix.org/issue/MODELIX-554/Unstable-ModelClient-v1")
     @RepeatedTest(value = 10)
     fun clientCompatibility(repetitionInfo: RepetitionInfo) = runTest { scope ->
         val url = "http://localhost/v2"

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.RepetitionInfo
 import org.modelix.authorization.installAuthentication
-import org.modelix.model.LinearHistory
 import org.modelix.model.ModelFacade
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IBranch
@@ -47,10 +46,12 @@ import org.modelix.model.data.asData
 import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.RepositoryId
-import org.modelix.model.operations.IOperation
 import org.modelix.model.operations.OTBranch
+import org.modelix.model.server.handlers.KeyValueLikeModelServer
 import org.modelix.model.server.handlers.ModelReplicationServer
+import org.modelix.model.server.handlers.RepositoriesManager
 import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.model.server.store.LocalModelClient
 import org.modelix.model.test.RandomModelChangeGenerator
 import java.util.Collections
 import java.util.SortedSet
@@ -72,7 +73,9 @@ class ReplicatedRepositoryTest {
                 json()
             }
             install(WebSockets)
-            ModelReplicationServer(InMemoryStoreClient()).init(this)
+            val repositoriesManager = RepositoriesManager(LocalModelClient(InMemoryStoreClient()))
+            ModelReplicationServer(repositoriesManager).init(this)
+            KeyValueLikeModelServer(repositoriesManager).init(this)
         }
 
         coroutineScope {
@@ -194,6 +197,136 @@ class ReplicatedRepositoryTest {
         println("all successful")
     }
 
+    private interface IRandomOperation {
+        suspend fun isApplicable(): Boolean
+        suspend fun apply()
+    }
+
+    /**
+     * Similar to the concurrentWrite test, but without race conditions.
+     * Doesn't use the ReplicatedModel which allows to narrow down the cause of issues.
+     * Makes it easier to test and fix performance issues.
+     */
+    @RepeatedTest(value = 10)
+    fun deterministicConcurrentWrite(repetitionInfo: RepetitionInfo) = runTest { scope ->
+        val url = "http://localhost/v2"
+        val clients = (1..3).map {
+            ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+        }
+
+        val repositoryId = RepositoryId("repo1")
+        val initialVersion = clients[0].initRepository(repositoryId)
+        val branchId = repositoryId.getBranchReference("my-branch")
+        clients[0].push(branchId, initialVersion, initialVersion)
+        val localVersions: MutableMap<ModelClientV2, CLVersion> = clients.associateWith { it.pull(branchId, null) as CLVersion }.toMutableMap()
+        val remoteVersions: MutableMap<ModelClientV2, CLVersion> = localVersions.toMutableMap()
+        val lastKnownRemoteVersion: MutableMap<ModelClientV2, CLVersion> = localVersions.toMutableMap()
+
+        val createdNodes: MutableSet<String> = Collections.synchronizedSet(TreeSet<String>())
+        val rand = Random(repetitionInfo.currentRepetition + 8745000)
+        val nodesToCreate = clients.size * 10
+
+        fun createOpsForClient(client: ModelClientV2) = listOf<IRandomOperation>(
+            object : IRandomOperation {
+                override suspend fun isApplicable(): Boolean {
+                    return createdNodes.size < nodesToCreate
+                }
+
+                override suspend fun apply() {
+                    // Change local version
+                    val baseVersion = localVersions[client]!!
+                    val branch = OTBranch(PBranch(baseVersion.getTree(), client.getIdGenerator()), client.getIdGenerator(), client.store)
+                    branch.runWriteT { t ->
+                        createdNodes += t.addNewChild(ITree.ROOT_ID, "role", -1, null as IConceptReference?).toString(16)
+                    }
+                    val (ops, tree) = branch.getPendingChanges()
+                    val newVersion = CLVersion.createRegularVersion(
+                        id = client.getIdGenerator().generate(),
+                        author = client.getUserId(),
+                        tree = tree as CLTree,
+                        baseVersion = baseVersion,
+                        operations = ops.map { it.getOriginalOp() }.toTypedArray(),
+                    )
+                    localVersions[client] = newVersion
+                }
+            },
+            object : IRandomOperation {
+                override suspend fun isApplicable(): Boolean {
+                    return remoteVersions[client]!!.getContentHash() != localVersions[client]!!.getContentHash()
+                }
+
+                override suspend fun apply() {
+                    // Merge local into remote
+                    remoteVersions[client] = VersionMerger(client.store, client.getIdGenerator())
+                        .mergeChange(remoteVersions[client]!!, localVersions[client]!!)
+                }
+            },
+            object : IRandomOperation {
+                override suspend fun isApplicable(): Boolean {
+                    return remoteVersions[client]!!.getContentHash() != localVersions[client]!!.getContentHash()
+                }
+
+                override suspend fun apply() {
+                    // Merge remote into local
+                    localVersions[client] = VersionMerger(client.store, client.getIdGenerator())
+                        .mergeChange(localVersions[client]!!, remoteVersions[client]!!)
+                }
+            },
+            object : IRandomOperation {
+                override suspend fun isApplicable(): Boolean {
+                    return remoteVersions[client]!!.getContentHash() != lastKnownRemoteVersion[client]!!.getContentHash()
+                }
+
+                override suspend fun apply() {
+                    // Push to server
+                    val receivedVersion = client.push(branchId, remoteVersions[client]!!, lastKnownRemoteVersion[client]!!) as CLVersion
+                    lastKnownRemoteVersion[client] = receivedVersion
+                    remoteVersions[client] = VersionMerger(client.store, client.getIdGenerator())
+                        .mergeChange(remoteVersions[client]!!, receivedVersion)
+                }
+            },
+            object : IRandomOperation {
+                override suspend fun isApplicable(): Boolean {
+                    return client.pullHash(branchId) != remoteVersions[client]!!.getContentHash()
+                }
+
+                override suspend fun apply() {
+                    // Pull from server
+                    val receivedVersion = client.pull(branchId, lastKnownRemoteVersion[client]!!) as CLVersion
+                    lastKnownRemoteVersion[client] = receivedVersion
+                    remoteVersions[client] = VersionMerger(client.store, client.getIdGenerator())
+                        .mergeChange(remoteVersions[client]!!, receivedVersion)
+                }
+            },
+        )
+
+        var iterations = 0
+        while (true) {
+            val applicableOps = clients.flatMap { createOpsForClient(it) }.filter { it.isApplicable() }
+            if (applicableOps.isEmpty()) break
+            applicableOps.random(rand).apply()
+            iterations++
+        }
+        println("Iterations: $iterations")
+
+        fun getChildren(model: CLVersion): SortedSet<String> {
+            return getChildren(PBranch(model.getTree(), IdGeneratorDummy()))
+        }
+
+        assertEquals(nodesToCreate, createdNodes.size)
+
+        val serverVersion = clients[0].pull(branchId, null)
+        val childrenOnServer = getChildren(PBranch(serverVersion.getTree(), IdGeneratorDummy()))
+
+        assertEquals(createdNodes, childrenOnServer)
+
+        for (client in clients) {
+            assertEquals(createdNodes, getChildren(localVersions[client]!!))
+        }
+
+        println("all successful")
+    }
+
     @Ignore
     @Test
     fun mergePerformanceTest() {
@@ -249,135 +382,6 @@ class ReplicatedRepositoryTest {
         val headChildren = getChildren(PBranch(headVersion.getTree(), IdGeneratorDummy()))
 
         assertEquals(createdNodes, headChildren)
-    }
-
-    @Ignore
-    @Test
-    fun linearHistoryPerformance() {
-        val idGenerator = IdGenerator.getInstance(100)
-        val initialTree = ModelFacade.newLocalTree() as CLTree
-        fun version(id: Long, base: CLVersion?): CLVersion {
-            return CLVersion.createRegularVersion(
-                id,
-                null,
-                null,
-                initialTree,
-                base,
-                emptyArray(),
-            )
-        }
-
-        fun merge(id: Long, base: CLVersion, v1: CLVersion, v2: CLVersion): CLVersion {
-            return CLVersion.createAutoMerge(
-                id,
-                initialTree,
-                base,
-                v1,
-                v2,
-                emptyArray<IOperation>(),
-                initialTree.store,
-            )
-        }
-
-        val v30000003a = version(12884901946, null)
-        val v1000004d1 = version(4294968529, v30000003a)
-        val v1000004d3 = version(4294968531, v1000004d1)
-        val v200000353 = version(8589935443, v1000004d3)
-        val v1000004d5 = version(4294968533, v1000004d3)
-        val v30000003c = merge(12884901948, v1000004d3, v200000353, v1000004d5)
-        val v1000004d6 = merge(4294968534, v1000004d3, v1000004d5, v200000353)
-        val v30000003d = merge(12884901949, v1000004d3, v30000003c, v1000004d6)
-        val v30000003e = merge(12884901950, v1000004d3, v30000003d, v1000004d6)
-        val v200000354 = merge(8589935444, v1000004d3, v200000353, v30000003d)
-        val v30000003f = merge(12884901951, v1000004d3, v30000003e, v200000354)
-        val v300000040 = merge(12884901952, v1000004d3, v30000003f, v200000354)
-        val v200000356 = version(8589935446, v200000354)
-        val v300000041 = merge(12884901953, v1000004d3, v300000040, v200000356)
-        val v1000004d8 = version(4294968536, v1000004d6)
-        val v300000042 = merge(12884901954, v1000004d3, v300000041, v1000004d8)
-        val v1000004d9 = merge(4294968537, v1000004d3, v1000004d8, v300000041)
-        val v300000043 = merge(12884901955, v1000004d3, v300000042, v1000004d9)
-        val v300000044 = merge(12884901956, v1000004d3, v300000043, v1000004d9)
-        val v200000357 = merge(8589935447, v1000004d3, v200000356, v300000041)
-        val v300000045 = merge(12884901957, v1000004d3, v300000044, v200000357)
-        val v300000046 = merge(12884901958, v1000004d3, v300000045, v200000357)
-        val v1000004da = merge(4294968538, v1000004d3, v1000004d9, v300000046)
-        val v300000047 = merge(12884901959, v1000004d3, v300000046, v1000004da)
-        val v300000048 = merge(12884901960, v1000004d3, v300000047, v1000004da)
-        val v200000359 = version(8589935449, v200000357)
-        val v300000049 = merge(12884901961, v1000004d3, v300000048, v200000359)
-        val v1000004dc = version(4294968540, v1000004da)
-        val v30000004a = merge(12884901962, v1000004d3, v300000049, v1000004dc)
-        val v20000035a = merge(8589935450, v1000004d3, v200000359, v300000046)
-        val v30000004b = merge(12884901963, v1000004d3, v30000004a, v20000035a)
-        val v30000004c = merge(12884901964, v1000004d3, v30000004b, v20000035a)
-        val v1000004dd = merge(4294968541, v1000004d3, v1000004dc, v30000004c)
-        val v30000004d = merge(12884901965, v1000004d3, v30000004c, v1000004dd)
-        val v30000004e = merge(12884901966, v1000004d3, v30000004d, v1000004dd)
-        val v20000035b = merge(8589935451, v1000004d3, v20000035a, v30000004c)
-        val v30000004f = merge(12884901967, v1000004d3, v30000004e, v20000035b)
-        val v300000050 = merge(12884901968, v1000004d3, v30000004f, v20000035b)
-        val v1000004df = version(4294968543, v1000004dd)
-        val v300000051 = merge(12884901969, v1000004d3, v300000050, v1000004df)
-        val v20000035d = version(8589935453, v20000035b)
-        val v300000052 = merge(12884901970, v1000004d3, v300000051, v20000035d)
-        val v1000004e0 = merge(4294968544, v1000004d3, v1000004df, v300000051)
-        val v300000053 = merge(12884901971, v1000004d3, v300000052, v1000004e0)
-        val v300000054 = merge(12884901972, v1000004d3, v300000053, v1000004e0)
-        val v20000035f = version(8589935455, v20000035d)
-        val v300000055 = merge(12884901973, v1000004d3, v300000054, v20000035f)
-        val v200000360 = merge(8589935456, v1000004d3, v20000035f, v300000052)
-        val v300000056 = merge(12884901974, v1000004d3, v300000055, v200000360)
-        val v300000057 = merge(12884901975, v1000004d3, v300000056, v200000360)
-        val v1000004e2 = version(4294968546, v1000004e0)
-        val v300000058 = merge(12884901976, v1000004d3, v300000057, v1000004e2)
-        val v200000362 = version(8589935458, v200000360)
-        val v300000059 = merge(12884901977, v1000004d3, v300000058, v200000362)
-        val v1000004e3 = merge(4294968547, v1000004d3, v1000004e2, v300000058)
-        val v30000005a = merge(12884901978, v1000004d3, v300000059, v1000004e3)
-        val v30000005b = merge(12884901979, v1000004d3, v30000005a, v1000004e3)
-        val v1000004e5 = version(4294968549, v1000004e3)
-        val v30000005c = merge(12884901980, v1000004d3, v30000005b, v1000004e5)
-        val v200000363 = merge(8589935459, v1000004d3, v200000362, v300000058)
-        val v30000005d = merge(12884901981, v1000004d3, v30000005c, v200000363)
-        val v30000005e = merge(12884901982, v1000004d3, v30000005d, v200000363)
-        val v200000365 = version(8589935461, v200000363)
-        val v30000005f = merge(12884901983, v1000004d3, v30000005e, v200000365)
-        val v1000004e7 = version(4294968551, v1000004e5)
-        val v300000060 = merge(12884901984, v1000004d3, v30000005f, v1000004e7)
-        val v200000367 = version(8589935463, v200000365)
-        val v300000061 = merge(12884901985, v1000004d3, v300000060, v200000367)
-        val v1000004e9 = version(4294968553, v1000004e7)
-        val v300000062 = merge(12884901986, v1000004d3, v300000061, v1000004e9)
-        val v1000004ea = merge(4294968554, v1000004d3, v1000004e9, v300000060)
-        val v300000063 = merge(12884901987, v1000004d3, v300000062, v1000004ea)
-        val v300000064 = merge(12884901988, v1000004d3, v300000063, v1000004ea)
-        val v200000369 = version(8589935465, v200000367)
-        val v300000065 = merge(12884901989, v1000004d3, v300000064, v200000369)
-        val v20000036a = merge(8589935466, v1000004d3, v200000369, v300000060)
-        val v300000066 = merge(12884901990, v1000004d3, v300000065, v20000036a)
-        val v1000004eb = merge(4294968555, v1000004d3, v1000004ea, v300000061)
-        val v300000067 = merge(12884901991, v1000004d3, v300000066, v1000004eb)
-        val v20000036c = version(8589935468, v20000036a)
-        val v300000068 = merge(12884901992, v1000004d3, v300000067, v20000036c)
-        val v300000069 = merge(12884901993, v1000004d3, v300000068, v20000036a)
-        val v30000006b = merge(12884901995, v1000004d3, v300000069, v1000004eb)
-        val v20000036d = merge(8589935469, v1000004d3, v20000036c, v300000063)
-        val v30000006c = merge(12884901996, v1000004d3, v30000006b, v20000036d)
-        val v30000006d = merge(12884901997, v1000004d3, v30000006c, v20000036d)
-        val v1000004ec = merge(4294968556, v1000004d3, v1000004eb, v30000006c)
-        val v30000006e = merge(12884901998, v1000004d3, v30000006d, v1000004ec)
-        val v300000070 = merge(12884902000, v1000004d3, v30000006e, v1000004ec)
-        val v20000036e = merge(8589935470, v1000004d3, v20000036d, v30000006e)
-        val v300000071 = merge(12884902001, v1000004d3, v300000070, v20000036e)
-        val v1000004ed = merge(4294968557, v1000004d3, v1000004ec, v30000006e)
-        val v300000072 = merge(12884902002, v1000004d3, v300000071, v1000004ed)
-        val v20000036f = merge(8589935471, v1000004d3, v20000036e, v30000006e)
-        val v300000073 = merge(12884902003, v1000004d3, v300000072, v20000036f)
-        val v300000074 = merge(12884902004, v1000004d3, v300000073, v20000036f)
-        val v300000075 = merge(12884902005, v1000004d3, v300000074, v20000036e)
-        val v1000004ee = merge(4294968558, v1000004d3, v30000006e, v300000075)
-        LinearHistory(v1000004d3.getContentHash()).load(v300000075, v1000004ee)
     }
 
     private fun getChildren(branch: IBranch): SortedSet<String> {

--- a/model-server/src/test/resources/functionaltests/storing.feature
+++ b/model-server/src/test/resources/functionaltests/storing.feature
@@ -63,8 +63,8 @@ Feature: Storing routes
 
   Scenario: Get recursively
     Given the server has been started with in-memory storage
-      And I PUT on "/put/hash-*0123456789-0123456789-0123456789-00001" the value "bar"
-      And I PUT on "/put/existingKey" the value "hash-*0123456789-0123456789-0123456789-00001"
+      And I PUT on "/put/_N4rL*tula_QIYB-3If6bXDONEO5CnqBPrlURto-_j7k" the value "bar"
+      And I PUT on "/put/existingKey" the value "_N4rL*tula_QIYB-3If6bXDONEO5CnqBPrlURto-_j7k"
      When I visit "/getRecursively/existingKey"
      Then I should get an OK response
-      And the text of the page should be this JSON "[{'value': 'hash-*0123456789-0123456789-0123456789-00001', 'key': 'existingKey'}, {'key': 'hash-*0123456789-0123456789-0123456789-00001', 'value': 'bar'}]"
+      And the text of the page should be this JSON "[{'value': '_N4rL*tula_QIYB-3If6bXDONEO5CnqBPrlURto-_j7k', 'key': 'existingKey'}, {'key': '_N4rL*tula_QIYB-3If6bXDONEO5CnqBPrlURto-_j7k', 'value': 'bar'}]"


### PR DESCRIPTION
The old REST API now also uses the RepositoriesManager to write to branches in a safe way (in a transaction with conflict resolution) instead of just overwriting the existing value. A write to a key that matches the branch pattern is dispatched to the RepositoriesManager and not written directly to the key-value store anymore.

While trying to make the tests succeed I had to fix a few issues, especially a performance issue in LinearHistory that also was another reason for MODELIX-524.

There is a new test that writes concurrently using the old and new client. Some of the iterations always fail which is probably a bug in the old model-client. I disabled the test for now and will fix that in a separate PR ([MODELIX-554](https://issues.modelix.org/issue/MODELIX-554/Unstable-ModelClient-v1)).