### PR TITLE
MODELIX-552 (2) ClassCastException executing query

### DIFF
--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
@@ -26,6 +26,7 @@ import org.modelix.model.api.INodeReference
 import org.modelix.model.area.IArea
 import org.modelix.modelql.core.IMonoStep
 import org.modelix.modelql.core.IUnboundQuery
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.UnboundQuery
 import org.modelix.modelql.core.VersionAndData
 import org.modelix.modelql.core.castToInstance
@@ -61,7 +62,7 @@ class ModelQLClient(val url: String, val client: HttpClient, includedSerializers
         return ModelQLArea(this).runWithAdditionalScope {
             VersionAndData.deserialize(
                 serializedJson,
-                query.getAggregationOutputSerializer(json.serializersModule),
+                query.getAggregationOutputSerializer(SerializationContext(json.serializersModule)),
                 json,
             ).data.value
         }

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/AndOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/AndOperatorStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class AndOperatorStep() : SimpleMonoTransformingStep<IZipOutput<Boolean>, Boolean>() {
@@ -35,8 +34,8 @@ class AndOperatorStep() : SimpleMonoTransformingStep<IZipOutput<Boolean>, Boolea
         }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectionSizeStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectionSizeStep.kt
@@ -16,12 +16,11 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class CollectionSizeStep : SimpleMonoTransformingStep<Collection<*>, Int>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Int>> {
-        return serializersModule.serializer<Int>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Int>> {
+        return serializationContext.serializer<Int>().stepOutputSerializer(this)
     }
 
     override fun transform(evaluationContext: QueryEvaluationContext, input: Collection<*>): Int {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectorStep.kt
@@ -20,11 +20,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.modules.SerializersModule
 
 abstract class CollectorStep<E, CollectionT>() : AggregationStep<E, CollectionT>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<CollectionT>> {
-        val element = getProducers().first().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<CollectionT>> {
+        val element = getProducers().first().getOutputSerializer(serializationContext)
         return getOutputSerializer(element.upcast())
     }
 

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ConstantSourceStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ConstantSourceStep.kt
@@ -27,7 +27,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeStructure
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import kotlin.jvm.JvmName
 import kotlin.reflect.KType
@@ -68,8 +67,8 @@ open class ConstantSourceStep<E>(val element: E, val type: KType) : ProducingSte
         return """Mono($element)"""
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return (serializersModule.serializer(type) as KSerializer<E>).stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return (serializationContext.serializer(type) as KSerializer<E>).stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder): StepDescriptor = Descriptor(element, type.toString())

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CountingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CountingStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.count
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class CountingStep() : AggregationStep<Any?, Int>() {
@@ -35,8 +34,8 @@ class CountingStep() : AggregationStep<Any?, Int>() {
         }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Int>> {
-        return serializersModule.serializer<Int>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Int>> {
+        return serializationContext.serializer<Int>().stepOutputSerializer(this)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EmptyStringIfNullStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EmptyStringIfNullStep.kt
@@ -17,18 +17,17 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class EmptyStringIfNullStep : MonoTransformingStep<String?, String>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<String>> {
-        val inputSerializer: KSerializer<IStepOutput<String?>> = getProducer().getOutputSerializer(serializersModule).upcast()
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<String>> {
+        val inputSerializer: KSerializer<IStepOutput<String?>> = getProducer().getOutputSerializer(serializationContext).upcast()
         return MultiplexedOutputSerializer<String>(
             this,
             listOf<KSerializer<IStepOutput<String>>>(
                 inputSerializer as KSerializer<IStepOutput<String>>,
-                serializersModule.serializer<String>().stepOutputSerializer(this).upcast(),
+                serializationContext.serializer<String>().stepOutputSerializer(this).upcast(),
             ),
         )
     }

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EqualsOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EqualsOperatorStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class EqualsOperatorStep<E>() : TransformingStepWithParameter<E, E, E, Boolean>() {
@@ -25,8 +24,8 @@ class EqualsOperatorStep<E>() : TransformingStepWithParameter<E, E, E, Boolean>(
         return (input.value == parameter?.value).asStepOutput(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FilteringStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FilteringStep.kt
@@ -17,13 +17,8 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class FilteringStep<E>(val condition: MonoUnboundQuery<E, Boolean?>) : TransformingStep<E, E>(), IMonoStep<E>, IFluxStep<E> {
-
-    init {
-        condition.inputStep.indirectConsumer = this
-    }
 
     override fun canBeEmpty(): Boolean = true
 
@@ -43,8 +38,8 @@ class FilteringStep<E>(val condition: MonoUnboundQuery<E, Boolean?>) : Transform
         // return input.filter { condition.evaluate(it.value).presentAndEqual(true) }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return getProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return getProducer().getOutputSerializer(serializationContext)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstElementStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstElementStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class FirstElementStep<E>() : MonoTransformingStep<E, E>() {
     override fun canBeMultiple(): Boolean = false
@@ -32,8 +31,8 @@ class FirstElementStep<E>() : MonoTransformingStep<E, E>() {
         return getProducer().toString() + ".first()"
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return getProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return getProducer().getOutputSerializer(serializationContext)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = FirstElementDescriptor()

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstOrNullStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstOrNullStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class FirstOrNullStep<E>() : AggregationStep<E, E?>() {
 
@@ -30,11 +29,11 @@ class FirstOrNullStep<E>() : AggregationStep<E, E?>() {
         return "${getProducer()}.firstOrNull()"
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E?>> {
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E?>> {
         return MultiplexedOutputSerializer<E?>(
             this,
             listOf(
-                getProducer().getOutputSerializer(serializersModule).upcast(),
+                getProducer().getOutputSerializer(serializationContext).upcast(),
                 nullSerializer<E>().stepOutputSerializer(this) as KSerializer<IStepOutput<E?>>,
             ),
         )

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStep.kt
@@ -66,6 +66,10 @@ class FlowInstantiationContext(
     }
 }
 
+/**
+ * The output serializer of a query is context dependent when used by multiple `QueryCallStep`s.
+ * This class carries the correct serializer for the input of a query depending on from where it is called.
+ */
 class SerializationContext(val serializersModule: SerializersModule, val queryInputSerializers: Map<QueryInput<*>, KSerializer<IStepOutput<*>>> = emptyMap()) {
     operator fun <T> plus(queryInputSerializer: Pair<QueryInput<T>, KSerializer<out IStepOutput<T>>>): SerializationContext {
         return SerializationContext(

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IdentityStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IdentityStep.kt
@@ -16,11 +16,10 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 open class IdentityStep<E> : TransformingStep<E, E>(), IFluxOrMonoStep<E> {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return getProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return getProducer().getOutputSerializer(serializationContext)
     }
 
     override fun createFlow(input: StepFlow<E>, context: IFlowInstantiationContext): StepFlow<E> {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IfEmpty.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IfEmpty.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.onEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlin.jvm.JvmName
 
 class IfEmptyStep<In : Out, Out>(val alternative: UnboundQuery<Unit, *, Out>) : TransformingStep<In, Out>(), IFluxOrMonoStep<Out> {
@@ -35,12 +34,12 @@ class IfEmptyStep<In : Out, Out>(val alternative: UnboundQuery<Unit, *, Out>) : 
     override fun canBeMultiple(): Boolean = getProducer().canBeMultiple() || alternative.outputStep.canBeMultiple()
     override fun requiresSingularQueryInput(): Boolean = true
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Out>> {
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Out>> {
         return MultiplexedOutputSerializer(
             this,
             listOf(
-                getProducer().getOutputSerializer(serializersModule).upcast(),
-                alternative.getElementOutputSerializer(serializersModule).upcast(),
+                getProducer().getOutputSerializer(serializationContext).upcast(),
+                alternative.getElementOutputSerializer(serializationContext).upcast(),
             ),
         )
     }

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/InPredicate.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/InPredicate.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class InPredicate<E>() : TransformingStepWithParameter<E, Set<E>, Any?, Boolean>() {
@@ -25,8 +24,8 @@ class InPredicate<E>() : TransformingStepWithParameter<E, Set<E>, Any?, Boolean>
         return (parameter?.value?.contains(input.value) == true).asStepOutput(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IntSumStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IntSumStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class IntSumStep(val operand: Int) : SimpleMonoTransformingStep<Int, Int>() {
@@ -35,8 +34,8 @@ class IntSumStep(val operand: Int) : SimpleMonoTransformingStep<Int, Int>() {
         }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Int>> {
-        return serializersModule.serializer<Int>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Int>> {
+        return serializationContext.serializer<Int>().stepOutputSerializer(this)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsEmptyStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsEmptyStep.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class IsEmptyStep() : AggregationStep<Any?, Boolean>() {
@@ -38,8 +37,8 @@ class IsEmptyStep() : AggregationStep<Any?, Boolean>() {
         }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsNullPredicateStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsNullPredicateStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class IsNullPredicateStep<In>() : SimpleMonoTransformingStep<In, Boolean>() {
@@ -25,8 +24,8 @@ class IsNullPredicateStep<In>() : SimpleMonoTransformingStep<In, Boolean>() {
         return input == null
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/JoinStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/JoinStep.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class JoinStep<E>() : ProducingStep<E>(), IConsumingStep<E>, IFluxStep<E> {
     override fun canBeEmpty(): Boolean = getProducers().all { it.canBeEmpty() }
@@ -53,8 +52,8 @@ class JoinStep<E>() : ProducingStep<E>(), IConsumingStep<E>, IFluxStep<E> {
             .asFlow().flattenConcat()
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return MultiplexedOutputSerializer(this, getProducers().map { it.getOutputSerializer(serializersModule).upcast() })
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return MultiplexedOutputSerializer(this, getProducers().map { it.getOutputSerializer(serializationContext).upcast() })
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/LocalMappingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/LocalMappingStep.kt
@@ -18,12 +18,11 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.modules.SerializersModule
 import kotlin.experimental.ExperimentalTypeInference
 
 open class LocalMappingStep<In, Out>(val transformation: (In) -> Out) : MonoTransformingStep<In, Out>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Out>> {
-        return LocalMappingSerializer(this, getProducer().getOutputSerializer(serializersModule)).stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Out>> {
+        return LocalMappingSerializer(this, getProducer().getOutputSerializer(serializationContext)).stepOutputSerializer(this)
     }
 
     override fun createFlow(input: StepFlow<In>, context: IFlowInstantiationContext): StepFlow<Out> {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MappingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MappingStep.kt
@@ -16,14 +16,14 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class MappingStep<In, Out>(val query: MonoUnboundQuery<In, Out>) : MonoTransformingStep<In, Out>() {
 
-    init {
-        query.inputStep.indirectConsumer = this
+    override fun validate() {
+        super.validate()
         check(query.outputStep != this)
     }
+
     override fun canBeEmpty(): Boolean = getProducer().canBeEmpty() || query.outputStep.canBeEmpty()
 
     override fun canBeMultiple(): Boolean = getProducer().canBeMultiple() || query.outputStep.canBeMultiple()
@@ -40,8 +40,8 @@ class MappingStep<In, Out>(val query: MonoUnboundQuery<In, Out>) : MonoTransform
         return query.asFlow(context.evaluationContext, input)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Out>> {
-        return query.getAggregationOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Out>> {
+        return query.getAggregationOutputSerializer(serializationContext + (query.inputStep to getProducer().getOutputSerializer(serializationContext)))
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NotOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NotOperatorStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class NotOperatorStep() : SimpleMonoTransformingStep<Boolean, Boolean>() {
@@ -25,8 +24,8 @@ class NotOperatorStep() : SimpleMonoTransformingStep<Boolean, Boolean>() {
         return !input
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = NotDescriptor()

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NullIfEmpty.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NullIfEmpty.kt
@@ -18,15 +18,14 @@ import kotlinx.coroutines.flow.onEmpty
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class NullIfEmpty<E>() : MonoTransformingStep<E, E?>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E?>> {
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E?>> {
         return MultiplexedOutputSerializer(
             this,
             listOf(
-                getProducer().getOutputSerializer(serializersModule).upcast(),
+                getProducer().getOutputSerializer(serializationContext).upcast(),
                 nullSerializer<E?>().stepOutputSerializer(this).upcast(),
             ),
         )

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/OrOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/OrOperatorStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class OrOperatorStep() : SimpleMonoTransformingStep<IZipOutput<Boolean>, Boolean>() {
@@ -35,8 +34,8 @@ class OrOperatorStep() : SimpleMonoTransformingStep<IZipOutput<Boolean>, Boolean
         }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun toString(): String {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/PrintStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/PrintStep.kt
@@ -17,11 +17,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class PrintStep<E>(val prefix: String) : MonoTransformingStep<E, E>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return getProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return getProducer().getOutputSerializer(serializationContext)
     }
 
     override fun createFlow(input: StepFlow<E>, context: IFlowInstantiationContext): StepFlow<E> {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/RegexPredicate.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/RegexPredicate.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class RegexPredicate(val regex: Regex) : SimpleMonoTransformingStep<String?, Boolean>() {
@@ -25,8 +24,8 @@ class RegexPredicate(val regex: Regex) : SimpleMonoTransformingStep<String?, Boo
         return input?.matches(regex) ?: false
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor(regex.pattern)

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SharedStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SharedStep.kt
@@ -16,11 +16,10 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class SharedStep<E>() : MonoTransformingStep<E, E>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return getProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return getProducer().getOutputSerializer(serializationContext)
     }
 
     override fun createFlow(input: StepFlow<E>, context: IFlowInstantiationContext): StepFlow<E> {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SingleStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SingleStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.single
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class SingleStep<E>() : AggregationStep<E, E>() {
 
@@ -29,8 +28,8 @@ class SingleStep<E>() : AggregationStep<E, E>() {
         return "${getProducer()}.single()"
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<E>> {
-        return getProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<E>> {
+        return getProducer().getOutputSerializer(serializationContext)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringContainsPredicate.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringContainsPredicate.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class StringContainsPredicate(val substring: String) : SimpleMonoTransformingStep<String?, Boolean>() {
@@ -25,8 +24,8 @@ class StringContainsPredicate(val substring: String) : SimpleMonoTransformingSte
         return input?.contains(substring) ?: false
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = StringContainsDescriptor(substring)

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToBooleanStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToBooleanStep.kt
@@ -16,12 +16,11 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class StringToBooleanStep : SimpleMonoTransformingStep<String?, Boolean>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Boolean>> {
-        return serializersModule.serializer<Boolean>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Boolean>> {
+        return serializationContext.serializer<Boolean>().stepOutputSerializer(this)
     }
 
     override fun transform(evaluationContext: QueryEvaluationContext, input: String?): Boolean {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToIntStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToIntStep.kt
@@ -16,12 +16,11 @@ package org.modelix.modelql.core
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 class StringToIntStep : SimpleMonoTransformingStep<String?, Int>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Int>> {
-        return serializersModule.serializer<Int>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Int>> {
+        return serializationContext.serializer<Int>().stepOutputSerializer(this)
     }
 
     override fun transform(evaluationContext: QueryEvaluationContext, input: String?): Int {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ToStringStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ToStringStep.kt
@@ -17,13 +17,12 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import kotlin.jvm.JvmName
 
 class ToStringStep : SimpleMonoTransformingStep<Any?, String?>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<String?>> {
-        return serializersModule.serializer<String>().nullable.stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<String?>> {
+        return serializationContext.serializer<String>().nullable.stepOutputSerializer(this)
     }
 
     override fun transform(evaluationContext: QueryEvaluationContext, input: Any?): String? {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/WithIndexStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/WithIndexStep.kt
@@ -19,17 +19,16 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.modules.SerializersModule
 
 class WithIndexStep<E> : MonoTransformingStep<E, IZip2Output<Any?, E, Int>>() {
     override fun requiresSingularQueryInput(): Boolean {
         return true
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<IZip2Output<Any?, E, Int>>> {
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<IZip2Output<Any?, E, Int>>> {
         return ZipOutputSerializer(
             arrayOf(
-                getProducer().getOutputSerializer(serializersModule).upcast(),
+                getProducer().getOutputSerializer(serializationContext).upcast(),
                 Int.serializer().stepOutputSerializer(null).upcast(),
             ),
         )

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
@@ -17,12 +17,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 
 class ZipElementAccessStep<Out>(val index: Int) : MonoTransformingStep<IZipOutput<Any?>, Out>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Out>> {
-        val zipSerializer = getProducers().single().getOutputSerializer(serializersModule) as ZipOutputSerializer<Out, *>
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Out>> {
+        val zipSerializer = getProducers().single().getOutputSerializer(serializationContext) as ZipOutputSerializer<Out, *>
         return zipSerializer.elementSerializers[index]
     }
 

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
@@ -30,7 +30,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeCollection
-import kotlinx.serialization.modules.SerializersModule
 
 open class ZipStep<CommonIn, Out : ZipNOutputC<CommonIn>>() : ProducingStep<Out>(), IConsumingStep<CommonIn>, IMonoStep<Out>, IFluxStep<Out> {
     private val producers = ArrayList<IProducingStep<CommonIn>>()
@@ -78,9 +77,9 @@ open class ZipStep<CommonIn, Out : ZipNOutputC<CommonIn>>() : ProducingStep<Out>
         }
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Out>> {
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Out>> {
         val elementSerializers: Array<KSerializer<IStepOutput<CommonIn>>> = producers.map {
-            it.getOutputSerializer(serializersModule).upcast()
+            it.getOutputSerializer(serializationContext).upcast()
         }.toTypedArray()
         return ZipOutputSerializer(elementSerializers)
     }

--- a/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
+++ b/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
@@ -28,6 +28,7 @@ import org.modelix.model.area.IArea
 import org.modelix.modelql.core.IMonoUnboundQuery
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryGraphDescriptor
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.VersionAndData
 import org.modelix.modelql.core.modelqlVersion
 import org.modelix.modelql.core.upcast
@@ -95,13 +96,16 @@ class ModelQLServer private constructor(val rootNodeProvider: () -> INode?, val 
                     area.executeRead(transactionBody)
                 }
                 val serializer: KSerializer<IStepOutput<Any?>> =
-                    query.getAggregationOutputSerializer(json.serializersModule).upcast()
+                    query.getAggregationOutputSerializer(SerializationContext(json.serializersModule)).upcast()
 
                 val versionAndResult = VersionAndData(result)
                 val serializedResult = json.encodeToString(VersionAndData.serializer(serializer), versionAndResult)
                 call.respondText(text = serializedResult, contentType = ContentType.Application.Json)
             } catch (ex: Throwable) {
-                call.respondText(text = "server version: $modelqlVersion\n" + ex.stackTraceToString(), status = HttpStatusCode.InternalServerError)
+                call.respondText(
+                    text = "server version: $modelqlVersion\n" + ex.stackTraceToString(),
+                    status = HttpStatusCode.InternalServerError,
+                )
             }
         }
     }

--- a/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
+++ b/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
@@ -45,6 +45,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.IdentityStep
 import org.modelix.modelql.core.MonoTransformingStep
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepOutput
@@ -175,8 +176,8 @@ fun IMonoStep<ITypedNode?>.untyped(): IMonoStep<INode?> = mapIfNotNull { it.unty
 fun IFluxStep<ITypedNode?>.untyped(): IFluxStep<INode?> = mapIfNotNull { it.untyped() }
 
 class TypedNodeStep<Typed : ITypedNode>(val nodeClass: KClass<out Typed>) : MonoTransformingStep<INode, Typed>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Typed>> {
-        val inputSerializer = getProducer().getOutputSerializer(serializersModule).upcast()
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Typed>> {
+        val inputSerializer = getProducer().getOutputSerializer(serializationContext).upcast()
         return TypedNodeSerializer(nodeClass, inputSerializer).stepOutputSerializer(this)
     }
 
@@ -218,8 +219,8 @@ class UntypedNodeSerializer(val typedSerializer: KSerializer<IStepOutput<ITypedN
 }
 
 class UntypedNodeStep : MonoTransformingStep<ITypedNode, INode>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return UntypedNodeSerializer(getProducer().getOutputSerializer(serializersModule).upcast()).stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return UntypedNodeSerializer(getProducer().getOutputSerializer(serializationContext).upcast()).stepOutputSerializer(this)
     }
 
     override fun createFlow(input: StepFlow<ITypedNode>, context: IFlowInstantiationContext): StepFlow<INode> {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AddNewChildNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AddNewChildNodeStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.IChildLink
@@ -29,6 +28,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.connect
@@ -37,8 +37,8 @@ import org.modelix.modelql.core.stepOutputSerializer
 class AddNewChildNodeStep(val role: String?, val index: Int, val concept: ConceptReference?) :
     SimpleMonoTransformingStep<INode, INode>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun transform(evaluationContext: QueryEvaluationContext, input: INode): INode {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllChildrenTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllChildrenTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.modelql.core.FluxTransformingStep
@@ -28,6 +27,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -39,8 +39,8 @@ class AllChildrenTraversalStep() : FluxTransformingStep<INode, INode>() {
         return input.flatMapConcat { it.value.getAllChildrenAsFlow() }.asStepFlow(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = AllChildrenStepDescriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllReferencesTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllReferencesTraversalStep.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.modelql.core.FluxTransformingStep
@@ -30,6 +29,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -41,8 +41,8 @@ class AllReferencesTraversalStep() : FluxTransformingStep<INode, INode>(), IMono
         return input.flatMapConcat { it.value.getAllReferenceTargetsAsFlow().map { it.second } }.asStepFlow(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ChildrenTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ChildrenTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.resolveChildLinkOrFallback
@@ -29,6 +28,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -40,8 +40,8 @@ class ChildrenTraversalStep(val role: String?) : FluxTransformingStep<INode, INo
         return input.flatMapConcat { it.value.getChildrenAsFlow(it.value.resolveChildLinkOrFallback(role)) }.asStepFlow(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = ChildrenStepDescriptor(role)

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.INode
@@ -28,6 +27,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.stepOutputSerializer
@@ -37,8 +37,8 @@ class ConceptReferenceTraversalStep() : SimpleMonoTransformingStep<INode?, Conce
         return input?.getConceptReference() as ConceptReference?
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<ConceptReference?>> {
-        return serializersModule.serializer<ConceptReference>().nullable.stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<ConceptReference?>> {
+        return serializationContext.serializer<ConceptReference>().nullable.stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.ConceptReference
 import org.modelix.modelql.core.IFluxStep
@@ -26,6 +25,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.mapIfNotNull
@@ -37,8 +37,8 @@ class ConceptReferenceUIDTraversalStep() : SimpleMonoTransformingStep<ConceptRef
         return input.getUID()
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<String>> {
-        return serializersModule.serializer<String>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<String>> {
+        return serializationContext.serializer<String>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/DescendantsTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/DescendantsTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.modelql.core.FluxTransformingStep
@@ -28,6 +27,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -39,8 +39,8 @@ class DescendantsTraversalStep(val includeSelf: Boolean) : FluxTransformingStep<
         return input.flatMapConcat { it.value.getDescendantsAsFlow(includeSelf) }.asStepFlow(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = if (includeSelf) WithSelfDescriptor() else WithoutSelfDescriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/MoveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/MoveNodeStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import org.modelix.model.api.IChildLink
 import org.modelix.model.api.INode
 import org.modelix.model.api.key
@@ -26,6 +25,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.TransformingStepWithParameter
 import org.modelix.modelql.core.connect
@@ -33,8 +33,8 @@ import org.modelix.modelql.core.connect
 class MoveNodeStep(val role: String?, val index: Int) :
     TransformingStepWithParameter<INode, INode, INode, INode>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return getInputProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return getInputProducer().getOutputSerializer(serializationContext)
     }
 
     override fun validate() {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
@@ -27,6 +26,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.stepOutputSerializer
@@ -36,8 +36,8 @@ class NodeReferenceAsStringTraversalStep() : SimpleMonoTransformingStep<INodeRef
         return input.serialize()
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<String>> {
-        return serializersModule.serializer<String>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<String>> {
+        return serializationContext.serializer<String>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceSourceStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceSourceStep.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INodeReference
 import org.modelix.model.api.SerializedNodeReference
@@ -27,14 +26,15 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.stepOutputSerializer
 import kotlin.jvm.JvmName
 import kotlin.reflect.typeOf
 
 class NodeReferenceSourceStep(element: INodeReference?) : ConstantSourceStep<INodeReference?>(element, typeOf<INodeReference?>()) {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INodeReference?>> {
-        return serializersModule.serializer<INodeReference>().nullable.stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INodeReference?>> {
+        return serializationContext.serializer<INodeReference>().nullable.stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor(element)

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceTraversalStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
@@ -27,6 +26,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.stepOutputSerializer
@@ -36,8 +36,8 @@ class NodeReferenceTraversalStep() : SimpleMonoTransformingStep<INode, INodeRefe
         return input.reference
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INodeReference>> {
-        return serializersModule.serializer<INodeReference>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INodeReference>> {
+        return serializationContext.serializer<INodeReference>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/OfConceptStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/OfConceptStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import org.modelix.model.api.IConcept
 import org.modelix.model.api.INode
 import org.modelix.model.api.getAllSubConcepts
@@ -29,6 +28,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.MonoTransformingStep
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 
@@ -40,8 +40,8 @@ class OfConceptStep(val conceptUIDs: Set<String>) : MonoTransformingStep<INode?,
         } as StepFlow<INode>
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return getProducer().getOutputSerializer(serializersModule) as KSerializer<out IStepOutput<INode>>
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return getProducer().getOutputSerializer(serializationContext) as KSerializer<out IStepOutput<INode>>
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor(conceptUIDs)

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ParentTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ParentTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.modelql.core.IFlowInstantiationContext
@@ -28,6 +27,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.MonoTransformingStep
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -43,8 +43,8 @@ class ParentTraversalStep() : MonoTransformingStep<INode, INode>(), IMonoStep<IN
 
     override fun canBeMultiple(): Boolean = getProducer().canBeMultiple()
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/PropertyTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/PropertyTraversalStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.resolvePropertyOrFallback
@@ -27,6 +26,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.stepOutputSerializer
@@ -40,8 +40,8 @@ class PropertyTraversalStep(val role: String) : SimpleMonoTransformingStep<INode
 
     override fun canBeMultiple(): Boolean = getProducer().canBeMultiple()
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<String?>> {
-        return serializersModule.serializer<String?>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<String?>> {
+        return serializationContext.serializer<String?>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = PropertyStepDescriptor(role)

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ReferenceTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ReferenceTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.resolveReferenceLinkOrFallback
@@ -29,6 +28,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.MonoTransformingStep
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -46,8 +46,8 @@ class ReferenceTraversalStep(val role: String) : MonoTransformingStep<INode, INo
 
     override fun canBeMultiple(): Boolean = getProducer().canBeMultiple()
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor(role)

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RemoveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RemoveNodeStep.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.remove
@@ -29,6 +28,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepOutput
@@ -37,8 +37,8 @@ import org.modelix.modelql.core.stepOutputSerializer
 
 class RemoveNodeStep() : AggregationStep<INode, Int>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<Int>> {
-        return serializersModule.serializer<Int>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<Int>> {
+        return serializationContext.serializer<Int>().stepOutputSerializer(this)
     }
 
     override suspend fun aggregate(input: StepFlow<INode>): IStepOutput<Int> {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ResolveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ResolveNodeStep.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
@@ -30,6 +29,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.MonoTransformingStep
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.StepFlow
 import org.modelix.modelql.core.asStepFlow
@@ -42,8 +42,8 @@ class ResolveNodeStep() : MonoTransformingStep<INodeReference, INode>() {
         }.asStepFlow(this)
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return serializersModule.serializer<INode>().stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return serializationContext.serializer<INode>().stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RoleInParentTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RoleInParentTraversalStep.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.nullable
-import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 import org.modelix.model.api.INode
 import org.modelix.modelql.core.IFluxStep
@@ -27,6 +26,7 @@ import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryEvaluationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.SimpleMonoTransformingStep
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.stepOutputSerializer
@@ -36,8 +36,8 @@ class RoleInParentTraversalStep() : SimpleMonoTransformingStep<INode, String?>()
         return input.roleInParent
     }
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<String?>> {
-        return serializersModule.serializer<String>().nullable.stepOutputSerializer(this)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<String?>> {
+        return serializationContext.serializer<String>().nullable.stepOutputSerializer(this)
     }
 
     override fun createDescriptor(context: QueryGraphDescriptorBuilder) = Descriptor()

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetPropertyStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetPropertyStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import org.modelix.model.api.INode
 import org.modelix.model.api.IProperty
 import org.modelix.model.api.key
@@ -26,6 +25,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.TransformingStepWithParameter
 import org.modelix.modelql.core.asMono
@@ -33,8 +33,8 @@ import org.modelix.modelql.core.connect
 
 class SetPropertyStep(val role: String) :
     TransformingStepWithParameter<INode, String?, Any?, INode>() {
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return getInputProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return getInputProducer().getOutputSerializer(serializationContext)
     }
 
     override fun transformElement(input: IStepOutput<INode>, parameter: IStepOutput<String?>?): IStepOutput<INode> {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetReferenceStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetReferenceStep.kt
@@ -16,7 +16,6 @@ package org.modelix.modelql.untyped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.SerializersModule
 import org.modelix.model.api.INode
 import org.modelix.model.api.IReferenceLink
 import org.modelix.model.api.key
@@ -26,6 +25,7 @@ import org.modelix.modelql.core.IStep
 import org.modelix.modelql.core.IStepOutput
 import org.modelix.modelql.core.QueryDeserializationContext
 import org.modelix.modelql.core.QueryGraphDescriptorBuilder
+import org.modelix.modelql.core.SerializationContext
 import org.modelix.modelql.core.StepDescriptor
 import org.modelix.modelql.core.TransformingStepWithParameter
 import org.modelix.modelql.core.connect
@@ -33,8 +33,8 @@ import org.modelix.modelql.core.connect
 class SetReferenceStep(val role: String) :
     TransformingStepWithParameter<INode, INode?, INode?, INode>() {
 
-    override fun getOutputSerializer(serializersModule: SerializersModule): KSerializer<out IStepOutput<INode>> {
-        return getInputProducer().getOutputSerializer(serializersModule)
+    override fun getOutputSerializer(serializationContext: SerializationContext): KSerializer<out IStepOutput<INode>> {
+        return getInputProducer().getOutputSerializer(serializationContext)
     }
 
     override fun transformElement(input: IStepOutput<INode>, parameter: IStepOutput<INode?>?): IStepOutput<INode> {


### PR DESCRIPTION
The serializer for the input of a query was computed with the assumption that a query is only used once and only one possible input step exists. After introducing `QueryCallStep` this isn't true anymore and the correct serializer depends on the context.

Extended the parameter of IProducingStep.getOutputSerializer to also carry the correct serializer for the QueryInput step.