### PR TITLE
ci: include detekt with GitHub code security analysis

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -1,0 +1,12 @@
+style:
+  # handled by ktlint
+  MaxLineLength:
+    active: false
+  ModifierOrder:
+    active: false
+
+  # No need for this
+  ReturnCount:
+    active: false
+  ThrowsCount:
+    active: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
           arguments: |
             --build-cache
             build
+            detekt
             -PciBuild=true
       - name: Archive test report
         uses: actions/upload-artifact@v3
@@ -37,6 +38,17 @@ jobs:
           path: |
             */build/test-results
             */build/reports
+      # In theory, the upload action should take care of stripping the GitHub
+      # runner workspace path from the file paths. But somehow that doesn't
+      # work. So do it manually.
+      - name: relativize SARIF file paths
+        run: |
+          sed -i 's#${{ github.workspace }}/##' build/reports/detekt/*.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'build/reports/detekt/'
+          category: detekt
 
   test-model-api-gen-gradle:
     runs-on: ubuntu-latest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ tasktree = { id = "com.dorongold.task-tree", version = "2.1.1" }
 modelix-mps-buildtools = { id = "org.modelix.mps.build-tools", version = "1.1.0" }
 dokka = {id = "org.jetbrains.dokka", version = "1.9.0"}
 node = {id = "com.github.node-gradle.node", version = "7.0.1"}
+detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.1" }
 
 [versions]
 kotlin = "1.9.10"


### PR DESCRIPTION
This PR includes [detekt](https://detekt.dev/docs/intro/) as a linter in the project. In contrast to ktlint, detect is more focused on coding problems and might provide some valuable hints. I have disable failing the build when detekt issues exist due to the current amount of violations that already exist in the current code base.

Detekt results are passed into the GitHub Code Scanning feature. Effectively this means that PRs will receive inline annotations for detected problems and we can use these as a hint when reviewing PRs.