### PR TITLE
fix(model-datastructure): detect changed children in a node if a child node changes its role

### DIFF
--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
@@ -450,8 +450,13 @@ class CLTree : ITree, IBulkTree {
                             if (oldElement!!::class != newElement!!::class) {
                                 throw RuntimeException("Unsupported type change of node " + key + "from " + oldElement::class.simpleName + " to " + newElement::class.simpleName)
                             }
-                            if (oldElement.parentId != newElement.parentId || oldElement.roleInParent != newElement.roleInParent) {
+                            if (oldElement.parentId != newElement.parentId) {
                                 visitor.containmentChanged(key)
+                            }
+                            if (oldElement.parentId == newElement.parentId && oldElement.roleInParent != newElement.roleInParent) {
+                                visitor.containmentChanged(key)
+                                visitor.childrenChanged(oldElement.parentId, oldElement.roleInParent)
+                                visitor.childrenChanged(newElement.parentId, newElement.roleInParent)
                             }
                             oldElement.propertyRoles.asSequence()
                                 .plus(newElement.propertyRoles.asSequence())

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
@@ -424,6 +424,12 @@ class CLTree : ITree, IBulkTree {
         nodesMap!!.visitChanges(
             oldVersion.nodesMap,
             object : CPHamtNode.IChangeVisitor {
+                private val childrenChangeEvents = HashSet<Pair<Long, String?>>()
+
+                private fun notifyChildrenChange(parent: Long, role: String?) {
+                    if (childrenChangeEvents.add(parent to role)) visitor.childrenChanged(parent, role)
+                }
+
                 override fun visitChangesOnly(): Boolean {
                     return changesOnly
                 }
@@ -452,11 +458,10 @@ class CLTree : ITree, IBulkTree {
                             }
                             if (oldElement.parentId != newElement.parentId) {
                                 visitor.containmentChanged(key)
-                            }
-                            if (oldElement.parentId == newElement.parentId && oldElement.roleInParent != newElement.roleInParent) {
+                            } else if (oldElement.roleInParent != newElement.roleInParent) {
                                 visitor.containmentChanged(key)
-                                visitor.childrenChanged(oldElement.parentId, oldElement.roleInParent)
-                                visitor.childrenChanged(newElement.parentId, newElement.roleInParent)
+                                notifyChildrenChange(oldElement.parentId, oldElement.roleInParent)
+                                notifyChildrenChange(newElement.parentId, newElement.roleInParent)
                             }
                             oldElement.propertyRoles.asSequence()
                                 .plus(newElement.propertyRoles.asSequence())
@@ -491,7 +496,7 @@ class CLTree : ITree, IBulkTree {
                                     val oldValues = oldChildrenInRole?.map { it.id }
                                     val newValues = newChildrenInRole?.map { it.id }
                                     if (oldValues != newValues) {
-                                        visitor.childrenChanged(newElement.id, role)
+                                        notifyChildrenChange(newElement.id, role)
                                     }
                                 }
                             }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
@@ -23,6 +23,9 @@ import org.modelix.model.persistent.SerializationUtil.intFromHex
 import org.modelix.model.persistent.SerializationUtil.longFromHex
 import kotlin.jvm.JvmStatic
 
+/**
+ * Implementation of a hash array mapped trie.
+ */
 abstract class CPHamtNode : IKVValue {
     override var isWritten: Boolean = false
 

--- a/model-datastructure/src/commonTest/kotlin/DiffTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/DiffTest.kt
@@ -71,6 +71,41 @@ class DiffTest {
     }
 
     @Test
+    fun moveChildOutsideNode() {
+        runTest(
+            setOf(
+                TreeChangeCollector.ChildrenChangedEvent(ITree.ROOT_ID, "children1"),
+                TreeChangeCollector.ChildrenChangedEvent(200, "children1"),
+                TreeChangeCollector.ContainmentChangedEvent(100),
+            ),
+            {
+                it.addNewChild(ITree.ROOT_ID, "children1", -1, 100, null as ConceptReference?)
+                    .addNewChild(ITree.ROOT_ID, "children2", -1, 200, null as ConceptReference?)
+            },
+            {
+                it.moveChild(200, "children1", -1, 100)
+            },
+        )
+    }
+
+    @Test
+    fun moveChildInsideNode() {
+        runTest(
+            setOf(
+                TreeChangeCollector.ChildrenChangedEvent(ITree.ROOT_ID, "children1"),
+                TreeChangeCollector.ChildrenChangedEvent(ITree.ROOT_ID, "children2"),
+                TreeChangeCollector.ContainmentChangedEvent(100),
+            ),
+            {
+                it.addNewChild(ITree.ROOT_ID, "children1", -1, 100, null as ConceptReference?)
+            },
+            {
+                it.moveChild(ITree.ROOT_ID, "children2", -1, 100)
+            },
+        )
+    }
+
+    @Test
     fun removeChild() {
         runTest(
             setOf(
@@ -90,7 +125,11 @@ class DiffTest {
         runTest(expectedEvents, { it }, mutator)
     }
 
-    private fun runTest(expectedEvents: Set<TreeChangeCollector.ChangeEvent>, initialMutator: (ITree) -> ITree, mutator: (ITree) -> ITree) {
+    private fun runTest(
+        expectedEvents: Set<TreeChangeCollector.ChangeEvent>,
+        initialMutator: (ITree) -> ITree,
+        mutator: (ITree) -> ITree,
+    ) {
         val tree1 = initialMutator(CLTree.builder(ObjectStoreCache(MapBaseStore())).build())
         val tree2 = mutator(tree1)
         val collector = TreeChangeCollector()

--- a/model-datastructure/src/commonTest/kotlin/DiffTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/DiffTest.kt
@@ -1,12 +1,3 @@
-import org.modelix.model.api.ConceptReference
-import org.modelix.model.api.ITree
-import org.modelix.model.api.NodeReference
-import org.modelix.model.lazy.CLTree
-import org.modelix.model.lazy.ObjectStoreCache
-import org.modelix.model.persistent.MapBaseStore
-import kotlin.test.Test
-import kotlin.test.assertEquals
-
 /*
  * Copyright (c) 2023.
  *
@@ -22,6 +13,16 @@ import kotlin.test.assertEquals
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.modelix.model.api.ConceptReference
+import org.modelix.model.api.ITree
+import org.modelix.model.api.NodeReference
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.persistent.MapBaseStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class DiffTest {
 
@@ -97,7 +98,9 @@ class DiffTest {
                 TreeChangeCollector.ContainmentChangedEvent(100),
             ),
             {
-                it.addNewChild(ITree.ROOT_ID, "children1", -1, 100, null as ConceptReference?)
+                it
+                    .addNewChild(ITree.ROOT_ID, "children1", -1, 100, null as ConceptReference?)
+                    .addNewChild(ITree.ROOT_ID, "children1", -1, 101, null as ConceptReference?)
             },
             {
                 it.moveChild(ITree.ROOT_ID, "children2", -1, 100)
@@ -134,6 +137,10 @@ class DiffTest {
         val tree2 = mutator(tree1)
         val collector = TreeChangeCollector()
         tree2.visitChanges(tree1, collector)
+        val duplicateEvents = collector.events.groupBy { it }.filter { it.value.size > 1 }.map { it.key }
+        if (duplicateEvents.isNotEmpty()) {
+            fail("duplicate events: $duplicateEvents")
+        }
 
         assertEquals(
             expectedEvents,


### PR DESCRIPTION
This fixes the case tested by `DiffTest.moveChildInsideNode`.

The problem was, that when a child node moved inside its parent node, the changed was not propagated to the visitor.
Moving a child inside a node is equivalent to changing the role of the child node in the parent.

`DiffTest.moveChildOutsideNode` works without the fix and was added for completeness.

---

Locally, this change makes sense. But I'm not sure about the global implications.