### PR TITLE
Feature/js model client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ modelix-mps-buildtools = { id = "org.modelix.mps.build-tools", version = "1.1.0"
 dokka = {id = "org.jetbrains.dokka", version = "1.9.0"}
 node = {id = "com.github.node-gradle.node", version = "7.0.1"}
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.1" }
+npm-publish = { id = "dev.petuska.npm.publish", version = "3.4.1" }
 
 [versions]
 kotlin = "1.9.10"

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/UnstableModelixFeature.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/UnstableModelixFeature.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.kotlin.utils
+
+/**
+ * Marks an API as unstable.
+ *
+ * @param reason Describes why the feature is experimental.
+ * @param intendedFinalization Describes when this API is intended to be finalized or removed.
+ */
+@RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.")
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.TYPEALIAS,
+)
+annotation class UnstableModelixFeature(
+    val reason: String,
+    val intendedFinalization: String,
+)

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.diffplug.spotless")
     `java-library`
     jacoco
+    alias(libs.plugins.npm.publish)
 }
 
 java {
@@ -34,6 +35,8 @@ kotlin {
                 }
             }
         }
+        binaries.library()
+        generateTypeScriptDefinitions()
         useCommonJs()
     }
     @Suppress("UNUSED_VARIABLE", "KotlinRedundantDiagnosticSuppress")
@@ -84,6 +87,7 @@ kotlin {
             }
         }
         val jsMain by getting {
+            languageSettings.optIn("kotlin.js.ExperimentalJsExport")
             dependencies {
                 implementation(kotlin("stdlib-js"))
                 implementation(npm("uuid", "^8.3.0"))
@@ -124,5 +128,84 @@ spotless {
                 " */\n" +
                 "\n",
         )
+    }
+}
+
+val productionLibraryByKotlinOutputDirectory = layout.buildDirectory.dir("compileSync/js/main/productionLibrary/kotlin")
+val preparedProductionLibraryOutputDirectory = layout.buildDirectory.dir("npmPublication")
+
+val patchTypesScriptInProductionLibrary = tasks.register("patchTypesScriptInProductionLibrary") {
+    dependsOn("compileProductionLibraryKotlinJs")
+    inputs.dir(productionLibraryByKotlinOutputDirectory)
+    outputs.dir(preparedProductionLibraryOutputDirectory)
+    outputs.cacheIf { true }
+    doLast {
+        // Delete old data
+        delete {
+            delete(preparedProductionLibraryOutputDirectory)
+        }
+
+        // Copy over library create by Kotlin
+        copy {
+            from(productionLibraryByKotlinOutputDirectory)
+            into(preparedProductionLibraryOutputDirectory)
+        }
+
+        // Add correct TypeScript imports and mark exports as experimental.
+        val typescriptDeclaration =
+            preparedProductionLibraryOutputDirectory.get().file("modelix.core-model-client.d.ts").asFile
+        val originalTypescriptDeclarationContent = typescriptDeclaration.readLines()
+        val experimentalDeclaration = """
+
+        /**
+         * @experimental This feature is expected to be finalized with https://issues.modelix.org/issue/MODELIX-500.
+         */
+        """.trimIndent()
+        typescriptDeclaration.writer().use {
+            it.appendLine("""import { INodeJS } from "@modelix/ts-model-api";""")
+                .appendLine()
+            for (line in originalTypescriptDeclarationContent) {
+                // Only mark the parts of the client (`org.modelix.model.client2`) experimental.
+                // Reported declarations from `org.modelix.model.api` should not be annotated as experimental.
+                if (line.startsWith("export declare namespace org.modelix.model.client2")) {
+                    it.appendLine(experimentalDeclaration)
+                }
+                it.appendLine(line)
+            }
+        }
+    }
+}
+
+npmPublish {
+    registries {
+        register("itemis-npm-open") {
+            uri.set("https://artifacts.itemis.cloud/repository/npm-open")
+            System.getenv("NODE_AUTH_TOKEN").takeIf { !it.isNullOrBlank() }?.let {
+                authToken.set(it)
+            }
+        }
+    }
+    packages {
+        named("js") {
+            files {
+                // The files need to be set manually because we patch
+                // the JS/TS produces by `compileProductionLibraryKotlinJs`
+                // with the `patchTypesScriptInProductionLibrary` task
+                setFrom(patchTypesScriptInProductionLibrary)
+            }
+            packageJson {
+                name.set("@modelix/model-client")
+                homepage.set("https://modelix.org/")
+                repository {
+                    type.set("git")
+                    url.set("https://github.com/modelix/modelix.core.git")
+                    directory.set(project.name)
+                }
+            }
+            dependencies {
+                // The model client NPM package uses the types from this @modelix/ts-model-api
+                normal("@modelix/ts-model-api", rootProject.version.toString())
+            }
+        }
     }
 }

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ChangeJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ChangeJS.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.client2
+
+import INodeJS
+import org.modelix.kotlin.utils.UnstableModelixFeature
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+sealed interface ChangeJS {
+    val node: INodeJS
+}
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+data class PropertyChanged(override val node: INodeJS, val role: String) : ChangeJS
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+data class ChildrenChanged(override val node: INodeJS, val role: String?) : ChangeJS
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+data class ReferenceChanged(override val node: INodeJS, val role: String) : ChangeJS
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+data class ContainmentChanged(override val node: INodeJS) : ChangeJS

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(UnstableModelixFeature::class)
+
+package org.modelix.model.client2
+
+import INodeJS
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+import org.modelix.kotlin.utils.UnstableModelixFeature
+import org.modelix.model.ModelFacade
+import org.modelix.model.api.IBranch
+import org.modelix.model.api.IBranchListener
+import org.modelix.model.api.INode
+import org.modelix.model.api.ITree
+import org.modelix.model.api.ITreeChangeVisitor
+import org.modelix.model.api.JSNodeConverter
+import org.modelix.model.api.PNodeAdapter
+import org.modelix.model.api.getRootNode
+import org.modelix.model.data.ModelData
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.withAutoTransactions
+import kotlin.Unit
+import kotlin.js.Promise
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+fun loadModelsFromJson(
+    json: Array<String>,
+    changeCallback: (ChangeJS) -> Unit,
+): INodeJS {
+    val branch = ModelFacade.toLocalBranch(ModelFacade.newLocalTree())
+    json.forEach { ModelData.fromJson(it).load(branch) }
+    branch.addListener(ChangeListener(branch, changeCallback))
+    val rootNode = branch.withAutoTransactions().getRootNode()
+    return toNodeJs(rootNode)
+}
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+@DelicateCoroutinesApi
+fun connectClient(url: String): Promise<ClientJS> {
+    return GlobalScope.promise {
+        val client = ModelClientV2.builder().url(url).build()
+        client.init()
+        return@promise ClientJSImpl(client)
+    }
+}
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+interface ClientJS {
+    fun dispose()
+
+    fun connectBranch(
+        repositoryId: String,
+        branchId: String,
+        changeCallback: (ChangeJS) -> Unit,
+    ): Promise<BranchJS>
+
+    fun fetchBranches(repositoryId: String): Promise<Array<String>>
+
+    fun fetchRepositories(): Promise<Array<String>>
+}
+
+class ClientJSImpl(private val modelClient: ModelClientV2) : ClientJS {
+
+    @DelicateCoroutinesApi
+    override fun fetchRepositories(): Promise<Array<String>> {
+        return GlobalScope.promise {
+            return@promise modelClient.listRepositories()
+                .map { it.id }.toTypedArray()
+        }
+    }
+
+    @DelicateCoroutinesApi
+    override fun fetchBranches(
+        repositoryId: String,
+    ): Promise<Array<String>> {
+        return GlobalScope.promise {
+            val repositoryIdObject = RepositoryId(repositoryId)
+            return@promise modelClient.listBranches(repositoryIdObject)
+                .map { it.branchName }.toTypedArray()
+        }
+    }
+
+    @DelicateCoroutinesApi
+    override fun connectBranch(
+        repositoryId: String,
+        branchId: String,
+        changeCallback: (ChangeJS) -> Unit,
+    ): Promise<BranchJS> {
+        return GlobalScope.promise {
+            val modelClient = modelClient
+            val branchReference = RepositoryId(repositoryId).getBranchReference(branchId)
+            val model: ReplicatedModel = modelClient.getReplicatedModel(branchReference)
+            model.start()
+            val branch = model.getBranch()
+            branch.addListener(ChangeListener(branch, changeCallback))
+            val rootNode = branch.withAutoTransactions().getRootNode()
+            val jsRootNode = toNodeJs(rootNode)
+            return@promise BranchJSImpl(model, jsRootNode)
+        }
+    }
+
+    override fun dispose() {
+        modelClient.close()
+    }
+}
+
+@UnstableModelixFeature(
+    reason = "The overarching task https://issues.modelix.org/issue/MODELIX-500 is in development.",
+    intendedFinalization = "The client is intended to be finalized when the overarching task is finished.",
+)
+@JsExport
+interface BranchJS {
+    val rootNode: INodeJS
+    fun dispose()
+}
+
+class BranchJSImpl(private val model: ReplicatedModel, private val jsRootNode: INodeJS) : BranchJS {
+
+    override val rootNode: INodeJS
+        get() {
+            return jsRootNode
+        }
+
+    override fun dispose() {
+        model.dispose()
+    }
+}
+
+class ChangeListener(private val branch: IBranch, private val changeCallback: (ChangeJS) -> Unit) : IBranchListener {
+
+    fun nodeIdToInode(nodeId: Long): INodeJS {
+        return toNodeJs(PNodeAdapter(nodeId, branch))
+    }
+
+    override fun treeChanged(oldTree: ITree?, newTree: ITree) {
+        if (oldTree == null) {
+            return
+        }
+        newTree.visitChanges(
+            oldTree,
+            object : ITreeChangeVisitor {
+                override fun containmentChanged(nodeId: Long) {
+                    changeCallback(ContainmentChanged(nodeIdToInode(nodeId)))
+                }
+
+                override fun childrenChanged(nodeId: Long, role: String?) {
+                    changeCallback(ChildrenChanged(nodeIdToInode(nodeId), role))
+                }
+
+                override fun referenceChanged(nodeId: Long, role: String) {
+                    changeCallback(ReferenceChanged(nodeIdToInode(nodeId), role))
+                }
+
+                override fun propertyChanged(nodeId: Long, role: String) {
+                    changeCallback(PropertyChanged(nodeIdToInode(nodeId), role))
+                }
+            },
+        )
+    }
+}
+
+fun toNodeJs(rootNode: INode) = JSNodeConverter.nodeToJs(rootNode).unsafeCast<INodeJS>()

--- a/model-client/src/jsTest/kotlin/org/modelix/model/client2/ClientJSTest.kt
+++ b/model-client/src/jsTest/kotlin/org/modelix/model/client2/ClientJSTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.client2
+
+import GeneratedConcept
+import org.modelix.kotlin.utils.UnstableModelixFeature
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(UnstableModelixFeature::class)
+class ClientJSTest {
+
+    private val emptyRoot = """
+        {
+            "root": {
+            }
+        }
+    """.trimIndent()
+
+    @Test
+    fun canAddChildrenWithUnregisteredConcept() {
+        // Arrange
+        val rootNode = loadModelsFromJson(arrayOf(emptyRoot)) {}
+        val jsConcept = GeneratedConcept("aConceptUid")
+
+        // Act
+        // This call should work, even if no GeneratedLanguage for this concept
+        // was registered in the global ILanguageRepository.
+        rootNode.addNewChild("aRole", -1, jsConcept)
+
+        // Assert
+        val children = rootNode.getChildren("aRole")
+        assertEquals(1, children.size)
+        assertEquals("aConceptUid", children.get(0).getConceptUID())
+    }
+
+    @Test
+    fun changeDetectionWorksForPropertyUpdate() {
+        // Arrange
+        var propertyChanged = 0
+        val rootNode = loadModelsFromJson(arrayOf(emptyRoot)) {
+            when (it) {
+                is PropertyChanged -> propertyChanged++
+                else -> {}
+            }
+        }
+
+        // Act
+        rootNode.setPropertyValue("aProperty", "aValue")
+
+        // Assert
+        assertEquals(1, propertyChanged)
+    }
+
+    @Test
+    fun changeDetectionWorksForReferenceUpdate() {
+        // Arrange
+        var referenceChanged = 0
+        val rootNode = loadModelsFromJson(arrayOf(emptyRoot)) {
+            when (it) {
+                is ReferenceChanged -> referenceChanged++
+                else -> {}
+            }
+        }
+
+        // Act
+        rootNode.setReferenceTargetNode("aRef", rootNode)
+
+        // Assert
+        assertEquals(1, referenceChanged)
+    }
+
+    @Test
+    fun changeDetectionWorksForAddedChild() {
+        // Arrange
+        var childrenChanged = 0
+        val rootNode = loadModelsFromJson(arrayOf(emptyRoot)) {
+            when (it) {
+                is ChildrenChanged -> childrenChanged++
+                else -> {}
+            }
+        }
+
+        // Act
+        rootNode.addNewChild("aRole", -1, GeneratedConcept("aConceptUid"))
+
+        // Assert
+        assertEquals(1, childrenChanged)
+    }
+
+    @Test
+    fun changeDetectionWorksForMovedChild() {
+        // Arrange
+        var childrenChanged = 0
+        var containmentChanged = 0
+        val rootNode = loadModelsFromJson(arrayOf(emptyRoot)) {
+            when (it) {
+                is ChildrenChanged -> childrenChanged++
+                is ContainmentChanged -> containmentChanged++
+                else -> {}
+            }
+        }
+        val childNode = rootNode.addNewChild("aRole", -1, GeneratedConcept("aConceptUid"))
+        childrenChanged = 0
+
+        // Act
+        rootNode.moveChild("anotherRole", -1, childNode)
+
+        // Assert
+        assertEquals(2, childrenChanged)
+        assertEquals(1, containmentChanged)
+    }
+
+    @Test
+    fun changeDetectionWorksForRemovedChild() {
+        // Arrange
+        var childrenChanged = 0
+        var containmentChanged = 0
+        val rootNode = loadModelsFromJson(arrayOf(emptyRoot)) {
+            when (it) {
+                is ChildrenChanged -> childrenChanged++
+                is ContainmentChanged -> containmentChanged++
+                else -> {}
+            }
+        }
+        val childNode = rootNode.addNewChild("aRole", -1, GeneratedConcept("aConceptUid"))
+        childrenChanged = 0
+
+        // Act
+        rootNode.removeChild(childNode)
+
+        // Assert
+        assertEquals(1, childrenChanged)
+    }
+
+    @Test
+    fun canResolveReference() {
+        // Arrange
+        val data = """
+        {
+            "root": {
+                "children": [
+                    {
+                        "id": "child0"
+                    },
+                    {
+                        "id": "child1"
+                    }
+                ]
+            }
+        }
+        """.trimIndent()
+        val rootNode = loadModelsFromJson(arrayOf(data), {})
+        val child0 = rootNode.getAllChildren()[0]
+        val child1 = rootNode.getAllChildren()[1]
+
+        // Act
+        child0.setReferenceTargetRef("aReference", child1.getReference())
+
+        // Assert
+        assertEquals(child0.getReferenceTargetNode("aReference"), child1)
+    }
+}


### PR DESCRIPTION
The model client in Kotlin is multiplatform, but not usable from JavaScript because it
does not export the appropriate functionality for usage from JavaScript and needs to be used inside
coroutines, which cannot be directly created in JavaScript.

This PR is part of [MODELIX-500](https://issues.modelix.org/issue/MODELIX-500)
The API of the package is marked as experimental. I intend to finalize it when finishing the ticket [MODELIX-500](https://issues.modelix.org/issue/MODELIX-500).