### PR TITLE
MODELIX-561 Import into model-server is unsuccessful

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -74,7 +74,7 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
             client.runWrite(branchRef) { rootNode ->
                 logger.info("Got root node: {}", rootNode)
                 logger.info("Importing...")
-                ModelImporter(rootNode).importFilesAsRootChildren(*files.toTypedArray())
+                ModelImporter(rootNode).importFilesAsRootChildren(files)
                 logger.info("Import finished")
             }
         }

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -30,9 +30,8 @@ import org.gradle.api.tasks.TaskAction
 import org.modelix.model.ModelFacade
 import org.modelix.model.api.ILanguage
 import org.modelix.model.api.ILanguageRepository
-import org.modelix.model.api.getRootNode
 import org.modelix.model.client2.ModelClientV2PlatformSpecificBuilder
-import org.modelix.model.client2.getReplicatedModel
+import org.modelix.model.client2.runWrite
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.sync.bulk.ModelImporter
 import org.modelix.model.sync.bulk.importFilesAsRootChildren
@@ -67,20 +66,17 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
 
         val branchRef = ModelFacade.createBranchReference(repoId, branchName.get())
         val client = ModelClientV2PlatformSpecificBuilder().url(url.get()).build()
-        val branch = runBlocking {
-            client.init()
-            client.getReplicatedModel(branchRef).start()
-        }
-
         val files = inputDir.listFiles()?.filter { it.extension == "json" }
         if (files.isNullOrEmpty()) error("no json files found")
 
-        branch.runWrite {
-            val rootNode = branch.getRootNode()
-            logger.info("Got root node: {}", rootNode)
-            logger.info("Importing...")
-            ModelImporter(branch.getRootNode()).importFilesAsRootChildren(*files.toTypedArray())
-            logger.info("Import finished")
+        runBlocking {
+            client.init()
+            client.runWrite(branchRef) { rootNode ->
+                logger.info("Got root node: {}", rootNode)
+                logger.info("Importing...")
+                ModelImporter(rootNode).importFilesAsRootChildren(*files.toTypedArray())
+                logger.info("Import finished")
+            }
         }
     }
 }

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -53,6 +53,7 @@ class ModelImporter(private val root: INode) {
      */
     @JvmName("importData")
     fun import(data: ModelData) {
+        logImportSize(data.root, logger)
         logger.info { "Building indices for import..." }
         originalIdToExisting.clear()
         postponedReferences.clear()

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/Util.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/Util.kt
@@ -21,6 +21,11 @@ import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.data.ModelData
 import org.modelix.model.data.NodeData
 
+fun mergeModelData(models: Collection<ModelData>): ModelData {
+    return ModelData(root = NodeData(children = models.map { it.root }))
+}
+
+@Deprecated("use collection parameter for better performance")
 fun mergeModelData(vararg models: ModelData): ModelData {
     return ModelData(root = NodeData(children = models.map { it.root }))
 }

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/PlatformSpecific.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/PlatformSpecific.kt
@@ -35,6 +35,12 @@ fun ModelImporter.import(jsonFile: File) {
     import(data)
 }
 
+fun ModelImporter.importFilesAsRootChildren(files: Collection<File>) {
+    val models = files.map { ModelData.fromJson(it.readText()) }
+    import(mergeModelData(models))
+}
+
+@Deprecated("use collection parameter for better performance")
 fun ModelImporter.importFilesAsRootChildren(vararg files: File) {
     val models = files.map { ModelData.fromJson(it.readText()) }
     import(mergeModelData(*models.toTypedArray()))

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -34,13 +34,18 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.modelix.model.IVersion
 import org.modelix.model.api.IIdGenerator
+import org.modelix.model.api.INode
 import org.modelix.model.api.IdGeneratorDummy
+import org.modelix.model.api.TreePointer
+import org.modelix.model.api.getRootNode
 import org.modelix.model.client.IdGenerator
 import org.modelix.model.lazy.BranchReference
+import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.ObjectStoreCache
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.lazy.computeDelta
+import org.modelix.model.operations.OTBranch
 import org.modelix.model.persistent.HashUtil
 import org.modelix.model.persistent.MapBasedStore
 import org.modelix.model.server.api.v2.VersionDelta
@@ -307,3 +312,25 @@ private fun URLBuilder.appendPathSegmentsEncodingSlash(vararg components: String
 }
 
 fun VersionDelta.getAllObjects(): Map<String, String> = objectsMap + objects.associateBy { HashUtil.sha256(it) }
+
+/**
+ * Performs a write transaction on the root node of the given branch.
+ */
+suspend fun <T> IModelClientV2.runWrite(branchRef: BranchReference, body: (INode) -> T): T {
+    val client = this
+    val baseVersion = client.pull(branchRef, null)
+    val branch = OTBranch(TreePointer(baseVersion.getTree(), client.getIdGenerator()), client.getIdGenerator(), (client as ModelClientV2).store)
+    val result = branch.computeWrite {
+        body(branch.getRootNode())
+    }
+    val (ops, newTree) = branch.getPendingChanges()
+    val newVersion = CLVersion.createRegularVersion(
+        id = client.getIdGenerator().generate(),
+        author = client.getUserId(),
+        tree = newTree as CLTree,
+        baseVersion = baseVersion as CLVersion?,
+        operations = ops.map { it.getOriginalOp() }.toTypedArray(),
+    )
+    client.push(branchRef, newVersion, baseVersion)
+    return result
+}

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -21,6 +21,9 @@ import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.operations.OTBranch
 
+/**
+ * Dispose should be called on this, as otherwise a regular polling will go on.
+ */
 class ReplicatedModel(
     val client: IModelClientV2,
     val branchRef: BranchReference,


### PR DESCRIPTION
This PR fixes the issue, that imported models don't show up in the model-server.
Instead of using ReplicatedModel, which is intended for real-time collaboration (and doesn't seem to be able to handle the huge amount of changes that happen during the bulk sync), a new `runWrite` function is used to push the changes to the server.
By calling this method inside of `runBlocking` it is ensured, that the changes have been successfully pushed to the model-server.