### PR TITLE
ci: use gradle-build-action for setting up Gradle

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       # In theory, the upload action should take care of stripping the GitHub
       # runner workspace path from the file paths. But somehow that doesn't
       # work. So do it manually.
-      - name: relativize SARIF file paths
+      - name: Relativize SARIF file paths
         run: |
           sed -i 's#${{ github.workspace }}/##' build/reports/detekt/*.sarif
       - name: Upload SARIF file

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,16 +20,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Build
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          arguments: |
-            --build-cache
-            build
-            detekt
-            -PciBuild=true
+        run: ./gradlew --build-cache build detekt -PciBuild=true
       - name: Archive test report
         uses: actions/upload-artifact@v3
         if: always()
@@ -59,16 +55,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Assemble
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Assemble
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          arguments: |
-            --build-cache
-            assemble
-            publishToMavenLocal
-            -PciBuild=true
+        run: ./gradlew --build-cache assemble publishToMavenLocal -PciBuild=true
       - name: Test Model API Generator Gradle Plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,17 +75,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Assemble
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Assemble
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          arguments: |
-            --build-cache
-            assemble
-            publishToMavenLocal
-            -PciBuild=true
-
+        run: ./gradlew --build-cache assemble publishToMavenLocal -PciBuild=true
       - name: Test Bulk Model Sync Gradle Plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mps-compatibility.yaml
+++ b/.github/workflows/mps-compatibility.yaml
@@ -30,11 +30,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Build with ${{ matrix.version }}
+      - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: |
-            --build-cache
-            :mps-model-adapters:build
-            :mps-model-server-plugin:build
-            -Pmps.version=${{ matrix.version }}
+      - name: Build with ${{ matrix.version }}
+        run: ./gradlew --build-cache :mps-model-adapters:build :mps-model-server-plugin:build -Pmps.version=${{ matrix.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Use tag as version
         run: echo "${GITHUB_REF#refs/*/}" > version.txt
       - name: Build and Publish Artifacts
-        run: ./gradlew build publish -PciBuild=true -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}} -Pgpr.user=${{ github.actor }} -Pgpr.key=${{ secrets.GITHUB_TOKEN }} -Pgpr.universalkey=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
+        run: ./gradlew --build-cache build publish -PciBuild=true -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}} -Pgpr.user=${{ github.actor }} -Pgpr.key=${{ secrets.GITHUB_TOKEN }} -Pgpr.universalkey=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ARTIFACTS_ITEMIS_CLOUD_NPM_TOKEN }}
       - name: Set up QEMU


### PR DESCRIPTION
This adapts the way gradle-build-action is used in our workflow definition to the current recommended practice:
https://github.com/marketplace/actions/gradle-build-action#use-the-action-to-setup-gradle

Follow-up for the discussions in https://github.com/modelix/modelix.core/pull/284