### PR TITLE
chore(model-server): update base image to reduce vulnerabilities

### DIFF
--- a/model-server/Dockerfile
+++ b/model-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.16-1.1687182723
+FROM registry.access.redhat.com/ubi8/openjdk-11:1.17-1.1696520348
 WORKDIR /usr/modelix-model
 EXPOSE 28101
 COPY run-model-server.sh /usr/modelix-model/


### PR DESCRIPTION
Vulnerability report of the [new](https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4?architecture=amd64&image=651ef9c1cb96549bcc6abc38&container-tabs=security) vs. [previous](https://catalog.redhat.com/software/containers/ubi8/openjdk-11/5dd6a4b45a13461646f677f4?architecture=amd64&image=649348c8e97f8bf5eeed4680) images.