### PR TITLE
replace deprecated Project.buildDir usage in Gradle 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ subprojects {
         reports {
             sarif.required.set(true)
             // This is required for the GitHub upload action to easily find all sarif files in a single directory.
-            sarif.outputLocation.set(parentProject.buildDir.resolve("reports/detekt/${project.name}.sarif"))
+            sarif.outputLocation.set(parentProject.layout.buildDirectory.file("reports/detekt/${project.name}.sarif"))
             html.required.set(true)
         }
     }
@@ -237,7 +237,7 @@ fun MavenPublication.setMetadata() {
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask> {
     dependsOn(":ts-model-api:npm_run_build")
 }
-val docsDir = buildDir.resolve("dokka")
+val docsDir = project.layout.buildDirectory.dir("dokka").get().asFile
 
 tasks.dokkaHtmlMultiModule {
     outputDirectory.set(docsDir.resolve("$version"))

--- a/bulk-model-sync-gradle-test/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/build.gradle.kts
@@ -42,8 +42,8 @@ repositories {
 }
 
 val mps by configurations.creating
-val mpsDir = buildDir.resolve("mps").apply { mkdirs() }
-val kotlinGenDir = buildDir.resolve("metamodel/kotlin").apply { mkdirs() }
+val mpsDir = project.layout.buildDirectory.dir("mps").get().asFile.apply { mkdirs() }
+val kotlinGenDir = project.layout.buildDirectory.dir("metamodel/kotlin").get().asFile.apply { mkdirs() }
 
 dependencies {
     mps("com.jetbrains:mps:2021.2.5")
@@ -82,7 +82,7 @@ val resolveMps by tasks.registering(Copy::class) {
     into(mpsDir)
 }
 
-val repoDir = buildDir.resolve("test-repo")
+val repoDir = project.layout.buildDirectory.dir("test-repo").get().asFile
 
 val copyTestRepo by tasks.registering(Sync::class) {
     from(projectDir.resolve("test-repo"))

--- a/bulk-model-sync-gradle-test/graph-lang-api/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/graph-lang-api/build.gradle.kts
@@ -16,14 +16,14 @@ val modelixCoreVersion = file("../../version.txt").readText()
 version = modelixCoreVersion
 
 val mps: Configuration by configurations.creating
-val kotlinGenDir = buildDir.resolve("metamodel/kotlin").apply { mkdirs() }
+val kotlinGenDir = project.layout.buildDirectory.dir("metamodel/kotlin").get().asFile.apply { mkdirs() }
 
 dependencies {
     mps("com.jetbrains:mps:2021.2.5")
     api("org.modelix:model-api-gen-runtime:$modelixCoreVersion")
 }
 
-val mpsDir = buildDir.resolve("mps").apply { mkdirs() }
+val mpsDir = project.layout.buildDirectory.dir("mps").get().asFile.apply { mkdirs() }
 
 val resolveMps by tasks.registering(Copy::class) {
     from(mps.resolve().map { zipTree(it) })

--- a/docs/global/modules/core/pages/howto/usage-model-api-gen-gradle.adoc
+++ b/docs/global/modules/core/pages/howto/usage-model-api-gen-gradle.adoc
@@ -77,7 +77,7 @@ val mpsVersion: String by rootProject
 val modelixCoreVersion: String by rootProject
 
 // ensure that the MPS directory name is correct
-val mpsDir = buildDir.resolve("mps")
+val mpsDir = project.layout.buildDirectory.dir("mps").get().asFile
 
 val mps by configurations.creating
 val mpsDependencies by configurations.creating

--- a/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
@@ -131,7 +131,7 @@ modelSync {
         registerLanguage(L_MyGeneratedLanguage)
         includeModule("MySolution")
         fromLocal {
-            mpsHome = buildDir.resolve("mps")
+            mpsHome = project.layout.buildDirectory.dir("mps").get().asFile
             mpsHeapSize = "4g"
             repositoryDir = projectDir.resolve("my-repo")
         }

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
@@ -17,7 +17,7 @@ class MetaModelGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         this.project = project
         this.settings = project.extensions.create("metamodel", MetaModelGradleSettings::class.java)
-        this.buildDir = project.buildDir
+        this.buildDir = project.layout.buildDirectory.get().asFile
 
         val exporterDependencies = project.configurations.create("metamodel-mps-dependencies")
         val exporterDir = getBuildOutputDir().resolve("mpsExporter")

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -9,7 +9,9 @@ description = "API to access models stored in Modelix"
 ktlint {
     filter {
         exclude {
-            it.file.toPath().toAbsolutePath().startsWith(project(":ts-model-api").buildDir.toPath().toAbsolutePath())
+            val kotlinGeneratedFromTypeScript =
+                project(":ts-model-api").layout.buildDirectory.get().asFile.toPath().toAbsolutePath()
+            it.file.toPath().toAbsolutePath().startsWith(kotlinGeneratedFromTypeScript)
         }
     }
 }

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -95,9 +95,9 @@ kotlin {
 }
 
 tasks.jacocoTestReport {
-    classDirectories.setFrom("$buildDir/classes/kotlin/jvm/")
+    classDirectories.setFrom(project.layout.buildDirectory.dir("classes/kotlin/jvm/"))
     sourceDirectories.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
-    executionData.setFrom(files("$buildDir/jacoco/jvmTest.exec"))
+    executionData.setFrom(project.layout.buildDirectory.file("jacoco/jvmTest.exec"))
 
     reports {
         xml.required.set(true)

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -92,7 +92,7 @@ tasks.named<ShadowJar>("shadowJar") {
     }
 }
 
-val fatJarFile = file("$buildDir/libs/model-server-latest-fatJar.jar")
+val fatJarFile = project.layout.buildDirectory.file("libs/model-server-latest-fatJar.jar")
 val fatJarArtifact = artifacts.add("archives", fatJarFile) {
     type = "jar"
     builtBy("shadowJar")
@@ -116,7 +116,7 @@ tasks.named("build") {
 }
 
 task("copyLibs", Sync::class) {
-    into("$buildDir/dependency-libs")
+    into(project.layout.buildDirectory.dir("dependency-libs"))
     from(configurations.runtimeClasspath)
 }
 

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
                 implementation(libs.kotlin.serialization.json)
                 api(libs.kotlin.coroutines.core)
             }
-            kotlin.srcDir(buildDir.resolve("version_gen"))
+            kotlin.srcDir(project.layout.buildDirectory.dir("version_gen"))
         }
         val commonTest by getting {
             dependencies {
@@ -71,7 +71,7 @@ kotlin {
 
 val generateVersionVariable by tasks.creating {
     doLast {
-        val outputDir = buildDir.resolve("version_gen/org/modelix/modelql/core")
+        val outputDir = project.layout.buildDirectory.dir("version_gen/org/modelix/modelql/core").get().asFile
         outputDir.mkdirs()
         outputDir.resolve("Version.kt").writeText(
             """

--- a/mps-model-server-plugin/build.gradle.kts
+++ b/mps-model-server-plugin/build.gradle.kts
@@ -87,7 +87,7 @@ tasks {
     if (mpsPluginDir != null && mpsPluginDir.isDirectory) {
         create<Sync>("installMpsPlugin") {
             dependsOn(prepareSandbox)
-            from(buildDir.resolve("idea-sandbox/plugins/mps-model-server-plugin"))
+            from(project.layout.buildDirectory.dir("idea-sandbox/plugins/mps-model-server-plugin"))
             into(mpsPluginDir.resolve("mps-model-server-plugin"))
         }
     }

--- a/ts-model-api/build.gradle.kts
+++ b/ts-model-api/build.gradle.kts
@@ -18,7 +18,7 @@ val patchKotlinExternals = tasks.create("patchKotlinExternals") {
   dependsOn("npm_run_generateKotlin")
   doLast {
     val annotationLine = """@file:JsModule("@modelix/ts-model-api") @file:JsNonModule"""
-    val dukatDir = buildDir.resolve("dukat")
+    val dukatDir = project.layout.buildDirectory.dir("dukat").get().asFile
     val files = dukatDir.listFiles()?.toList() ?: emptyList()
     val matchingFiles = files.filter { it.name.contains("@modelix_ts-model-api") }
     if (matchingFiles.isEmpty()) throw RuntimeException("No files found for patching in $dukatDir")


### PR DESCRIPTION
Replace the usage of `Project.buildDir` in our build scripts and in our provided plugins.

See https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecations_2