### PR TITLE
MODELIX-577 Add ModelQL v2 support to model-server

### DIFF
--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -43,6 +43,8 @@ kotlin {
                 api(project(":model-api"))
                 api(project(":model-datastructure"))
                 api(project(":model-server-api"))
+                implementation(project(":modelql-client"))
+                api(project(":modelql-core"))
                 implementation(kotlin("stdlib-common"))
                 implementation(libs.kotlin.collections.immutable)
                 implementation(libs.kotlin.coroutines.core)

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -13,6 +13,7 @@
  */
 package org.modelix.model.client2
 
+import org.modelix.kotlin.utils.DeprecationInfo
 import org.modelix.model.IVersion
 import org.modelix.model.api.IIdGenerator
 import org.modelix.model.api.INode
@@ -44,6 +45,7 @@ interface IModelClientV2 {
     suspend fun listBranches(repository: RepositoryId): List<BranchReference>
 
     @Deprecated("repository ID is required for permission checks")
+    @DeprecationInfo("3.7.0", "May be removed with the next major release. Also remove the endpoint from the model-server.")
     suspend fun loadVersion(versionHash: String, baseVersion: IVersion?): IVersion
 
     suspend fun loadVersion(repositoryId: RepositoryId, versionHash: String, baseVersion: IVersion?): IVersion

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -43,7 +43,10 @@ interface IModelClientV2 {
 
     suspend fun listBranches(repository: RepositoryId): List<BranchReference>
 
+    @Deprecated("repository ID is required for permission checks")
     suspend fun loadVersion(versionHash: String, baseVersion: IVersion?): IVersion
+
+    suspend fun loadVersion(repositoryId: RepositoryId, versionHash: String, baseVersion: IVersion?): IVersion
 
     /**
      * The pushed version is merged automatically by the server with the current head.

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -15,8 +15,10 @@ package org.modelix.model.client2
 
 import org.modelix.model.IVersion
 import org.modelix.model.api.IIdGenerator
+import org.modelix.model.api.INode
 import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.RepositoryId
+import org.modelix.modelql.core.IMonoStep
 
 /**
  * This interface is meant exclusively for model client usage.
@@ -62,4 +64,8 @@ interface IModelClientV2 {
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
 
     suspend fun pollHash(branch: BranchReference, lastKnownVersion: IVersion?): String
+
+    suspend fun <R> query(branch: BranchReference, body: (IMonoStep<INode>) -> IMonoStep<R>): R
+
+    suspend fun <R> query(repositoryId: RepositoryId, versionHash: String, body: (IMonoStep<INode>) -> IMonoStep<R>): R
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -32,6 +32,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import org.modelix.kotlin.utils.DeprecationInfo
 import org.modelix.model.IVersion
 import org.modelix.model.api.IIdGenerator
 import org.modelix.model.api.INode
@@ -123,6 +124,7 @@ class ModelClientV2(
     }
 
     @Deprecated("repository ID is required for permission checks")
+    @DeprecationInfo("3.7.0", "May be removed with the next major release. Also remove the endpoint from the model-server.")
     override suspend fun loadVersion(versionHash: String, baseVersion: IVersion?): IVersion {
         val response = httpClient.post {
             url {

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     testImplementation(libs.cucumber.java)
     testImplementation(libs.ktor.server.test.host)
     testImplementation(kotlin("test"))
+    testImplementation(project(":modelql-untyped"))
 }
 
 tasks.test {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -14,20 +14,17 @@
 
 package org.modelix.model.server.handlers
 
-import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.plugins.origin
 import io.ktor.server.request.receive
-import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
-import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.webSocket
@@ -38,6 +35,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.modelix.authorization.getUserName
 import org.modelix.model.api.PBranch
+import org.modelix.model.api.TreePointer
 import org.modelix.model.api.getRootNode
 import org.modelix.model.area.getArea
 import org.modelix.model.client2.checkObjectHashes
@@ -46,14 +44,11 @@ import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.operations.OTBranch
-import org.modelix.model.persistent.HashUtil
-import org.modelix.model.server.api.ModelQuery
 import org.modelix.model.server.api.v2.VersionDelta
 import org.modelix.model.server.store.IStoreClient
 import org.modelix.model.server.store.LocalModelClient
 import org.modelix.modelql.server.ModelQLServer
 import org.slf4j.LoggerFactory
-import java.util.UUID
 
 /**
  * Implements the endpoints used by the 'model-client', but compared to KeyValueLikeModelServer also understands what
@@ -65,10 +60,6 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
 
     companion object {
         private val LOG = LoggerFactory.getLogger(ModelReplicationServer::class.java)
-
-        private fun randomUUID(): String {
-            return UUID.randomUUID().toString().replace("[^a-zA-Z0-9]".toRegex(), "")
-        }
     }
 
     private val modelClient: LocalModelClient get() = repositoriesManager.client
@@ -188,6 +179,35 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
                                 )
                                 repositoriesManager.mergeChanges(branchRef, newVersion.getContentHash())
                             }
+                        }
+                    }
+                }
+                route("versions") {
+                    route("{versionHash}") {
+                        get {
+                            // TODO permission check on the repository ID is not sufficient, because the client could
+                            //      provide any repository ID to access a version inside a different repository.
+                            //      A check if the version belongs to the repository is required.
+                            val baseVersionHash = call.request.queryParameters["lastKnown"]
+                            val versionHash = call.parameters["versionHash"]!!
+                            if (storeClient[versionHash] == null) {
+                                call.respondText(
+                                    "Version '$versionHash' doesn't exist",
+                                    status = HttpStatusCode.NotFound,
+                                )
+                                return@get
+                            }
+                            call.respondDelta(versionHash, baseVersionHash)
+                        }
+                        get("history/{oldestVersionHash}") {
+                            TODO()
+                        }
+                        post("query") {
+                            val versionHash = call.parameters["versionHash"]!!
+                            val version = CLVersion.loadFromHash(versionHash, repositoriesManager.client.storeCache)
+                            val initialTree = version.getTree()
+                            val branch = TreePointer(initialTree)
+                            ModelQLServer.handleCall(call, branch.getRootNode(), branch.getArea())
                         }
                     }
                 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -90,7 +90,7 @@ class ModelClientV2Test {
     }
 
     @Test
-    fun testModelQLEndpoint() = runTest {
+    fun modelqlSmokeTest() = runTest {
         val url = "http://localhost/v2"
         val client = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
 

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -32,6 +32,8 @@ import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.operations.OTBranch
 import org.modelix.model.server.handlers.ModelReplicationServer
 import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.modelql.core.count
+import org.modelix.modelql.untyped.allChildren
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -85,6 +87,21 @@ class ModelClientV2Test {
             client.listBranches(repositoryId).toSet(),
             setOf(repositoryId.getBranchReference(), branchId),
         )
+    }
+
+    @Test
+    fun testModelQLEndpoint() = runTest {
+        val url = "http://localhost/v2"
+        val client = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+
+        val repositoryId = RepositoryId("repo1")
+        val branchRef = repositoryId.getBranchReference()
+        val initialVersion = client.initRepository(repositoryId)
+        val size = client.query(branchRef) { it.allChildren().count() }
+        assertEquals(0, size)
+
+        val size2 = client.query(repositoryId, initialVersion.getContentHash()) { it.allChildren().count() }
+        assertEquals(0, size2)
     }
 
     @Test


### PR DESCRIPTION
The endpoint was already implemented on the server side, but there was no method on the client side to call it.