### PR TITLE
MODELIX-587 IllegalStateException when syncing references

### DIFF
--- a/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/PullTest.kt
+++ b/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/PullTest.kt
@@ -16,22 +16,44 @@
 
 package org.modelix.model.sync.bulk.gradle.test
 
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.xmlunit.builder.Input
 import org.xmlunit.xpath.JAXPXPathEngine
 import java.io.File
+import javax.xml.transform.Source
 import kotlin.test.assertContentEquals
 
 class PullTest {
+    companion object {
+        private lateinit var source: Source
+
+        @JvmStatic
+        @BeforeAll
+        fun initSource() {
+            val localModel = File("build/test-repo/solutions/GraphSolution/models/GraphSolution.example.mps").readText()
+            source = Input.fromString(localModel).build()
+        }
+    }
 
     @Test
-    fun `nodes were synced to local`() {
-        val localModel = File("build/test-repo/solutions/GraphSolution/models/GraphSolution.example.mps").readText()
-        val source = Input.fromString(localModel).build()
-        val properties = JAXPXPathEngine().selectNodes("model/node/node[@concept='1DmExO']/property", source)
+    fun `properties were synced to local`() {
+        val properties = JAXPXPathEngine()
+            .selectNodes("model/node/node[@concept='1DmExO']/property", source)
 
         val actual = properties.map { it.attributes.getNamedItem("value").nodeValue }
         val expected = listOf("X", "Y", "Z", "D", "E")
+
+        assertContentEquals(expected, actual)
+    }
+
+    @Test
+    fun `references were synced to local`() {
+        val references = JAXPXPathEngine()
+            .selectNodes("model/node/node[@id='pSCM1J8Fg1']/ref", source)
+
+        val actual = references.map { it.attributes.getNamedItem("node").nodeValue }
+        val expected = listOf("pSCM1J8FfX", "pSCM1J8FfZ")
 
         assertContentEquals(expected, actual)
     }

--- a/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/PushTest.kt
+++ b/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/PushTest.kt
@@ -1,7 +1,9 @@
 package org.modelix.model.sync.bulk.gradle.test
 
 import GraphLang.L_GraphLang
+import GraphLang.N_Edge
 import GraphLang.N_Node
+import GraphLang._C_UntypedImpl_Edge
 import GraphLang._C_UntypedImpl_Node
 import jetbrains.mps.lang.core.L_jetbrains_mps_lang_core
 import kotlinx.coroutines.runBlocking
@@ -67,6 +69,15 @@ class PushTest {
                 graphNodes[0].name = "X"
                 graphNodes[1].name = "Y"
                 graphNodes[2].name = "Z"
+
+                val edges = rootNode
+                    .getDescendants(false)
+                    .filter { it.getConceptReference() == ConceptReference(_C_UntypedImpl_Edge.getUID()) }
+                    .map { it.typed<N_Edge>() }
+                    .toList()
+
+                edges[0].source = graphNodes[1]
+                edges[0].target = graphNodes[3]
             }
         }
     }

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
@@ -139,6 +139,7 @@ class ModelSyncGradlePlugin : Plugin<Project> {
             it.exportFlag.set(true)
             it.includedModules.set(syncDirection.includedModules)
             it.includedModulePrefixes.set(syncDirection.includedModulePrefixes)
+            it.debugPort.set(localSource.mpsDebugPort)
         }
 
         val exportFromMps = project.tasks.register("${syncDirection.name}ExportFromMps", ExportFromMps::class.java) {
@@ -205,6 +206,7 @@ class ModelSyncGradlePlugin : Plugin<Project> {
             it.exportFlag.set(false)
             it.includedModules.set(syncDirection.includedModules)
             it.includedModulePrefixes.set(syncDirection.includedModulePrefixes)
+            it.debugPort.set(localTarget.mpsDebugPort)
         }
 
         val importName = "${syncDirection.name}ImportIntoMps"

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
@@ -42,6 +42,7 @@ data class SyncDirection(
     internal val includedModules: Set<String> = mutableSetOf(),
     internal val registeredLanguages: Set<ILanguage> = mutableSetOf(),
     internal val includedModulePrefixes: Set<String> = mutableSetOf(),
+    internal var mpsDebugEnabled: Boolean = false,
 ) {
     fun fromModelServer(action: Action<ServerSource>) {
         val endpoint = ServerSource()
@@ -88,6 +89,7 @@ sealed interface LocalEndpoint : SyncEndpoint {
     var mpsHome: File?
     var mpsHeapSize: String
     var repositoryDir: File?
+    var mpsDebugPort: Int?
 
     override fun getValidationErrors(): List<String> {
         val errors = mutableListOf<String>()
@@ -105,12 +107,14 @@ data class LocalSource(
     override var mpsHome: File? = null,
     override var mpsHeapSize: String = "2g",
     override var repositoryDir: File? = null,
+    override var mpsDebugPort: Int? = null,
 ) : LocalEndpoint
 
 data class LocalTarget(
     override var mpsHome: File? = null,
     override var mpsHeapSize: String = "2g",
     override var repositoryDir: File? = null,
+    override var mpsDebugPort: Int? = null,
 ) : LocalEndpoint
 
 sealed interface ServerEndpoint : SyncEndpoint {

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/GenerateAntScriptForMps.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/GenerateAntScriptForMps.kt
@@ -23,6 +23,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -58,6 +59,10 @@ abstract class GenerateAntScriptForMps @Inject constructor(of: ObjectFactory) : 
 
     @Input
     val includedModulePrefixes: ListProperty<String> = of.listProperty(String::class.java)
+
+    @Optional
+    @Input
+    val debugPort: Property<Int> = of.property(Int::class.javaObjectType)
 
     @TaskAction
     fun generate() {
@@ -108,6 +113,7 @@ abstract class GenerateAntScriptForMps @Inject constructor(of: ObjectFactory) : 
                         <arg value="-Didea.system.path=${"$"}{build.mps.system.path}" />
                         <arg value="-ea" />
                         <arg value="-Xmx${mpsHeapSize.get()}" />
+                        ${if (debugPort.isPresent) """<arg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${debugPort.get()}" />""" else ""}
                     </jvmargs>
                 </runMPS>
             </target>

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -20,6 +20,7 @@ import mu.KotlinLogging
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
+import org.modelix.model.api.INodeResolutionScope
 import org.modelix.model.api.SerializedNodeReference
 import org.modelix.model.api.getDescendants
 import org.modelix.model.api.remove
@@ -84,7 +85,9 @@ class ModelImporter(private val root: INode) {
         print("\r($currentNodeProgress / $numExpectedNodes) Synchronizing nodes...                    ")
         syncProperties(node, data)
         syncChildren(node, data)
-        syncReferences(node, data)
+        INodeResolutionScope.runWithAdditionalScope(node.getArea()) {
+            syncReferences(node, data)
+        }
     }
 
     private fun syncChildren(node: INode, data: NodeData) {

--- a/bulk-model-sync-solution/solutions/org.modelix.mps.model.sync.bulk/org.modelix.mps.model.sync.bulk.msd
+++ b/bulk-model-sync-solution/solutions/org.modelix.mps.model.sync.bulk/org.modelix.mps.model.sync.bulk.msd
@@ -17,6 +17,9 @@
       <sourceRoot location="model-api-jvm.jar" />
       <sourceRoot location="slf4j-api.jar" />
     </modelRoot>
+    <modelRoot contentPath="${module}/lib/kotlin-utils-jvm.jar!/" type="java_classes">
+      <sourceRoot location="." />
+    </modelRoot>
   </models>
   <facets>
     <facet type="java">
@@ -36,6 +39,7 @@
     <stubModelEntry path="${module}/lib/slf4j-api.jar" />
     <stubModelEntry path="${module}/lib/mps-model-adapters.jar" />
     <stubModelEntry path="${module}/lib/bulk-model-sync-lib-jvm.jar" />
+    <stubModelEntry path="${module}/lib/kotlin-utils-jvm.jar" />
   </stubModelEntries>
   <sourcePath />
   <dependencies>

--- a/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
@@ -94,6 +94,10 @@ This means that only a minimal amount of write operations is used to update the 
 |`repositoryDir`
 |File
 |Directory in which the modules are stored.
+
+|`mpsDebugPort`
+|Int
+|If set, the headless MPS will suspend on startup and wait for a remote debugger on the specified port.
 |===
 
 === ServerSource/-Target configuration

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
@@ -70,10 +70,7 @@ data class MPSNode(val node: SNode) : IDeprecatedNodeDefaults {
 
     override fun getChildren(link: IChildLink): Iterable<INode> {
         return node.children.map { MPSNode(it) }.filter {
-            val actualLink = it.getContainmentLink() ?: return@filter false
-            actualLink.getUID() == link.getUID() ||
-                actualLink.getSimpleName() == link.getSimpleName() ||
-                link.getUID().contains(actualLink.getSimpleName())
+            it.getContainmentLink().conformsTo(link)
         }
     }
 


### PR DESCRIPTION
The issue here was two-fold:
1. There was a missing dependency in `bulk-model-sync-solution`
2. The INodeResolutionScope was not set

While looking for the exact issues, I found it useful to have the ability to debug the headless MPS in the bulk-sync plugin remotely. That's why this PR also includes a new feature, which enables users to turn on remote debugging for MPS by specifying a port.