### PR TITLE
feat(bulk-model-sync-gradle): add continueOnError option

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
@@ -177,6 +177,7 @@ class ModelSyncGradlePlugin : Plugin<Project> {
             it.branchName.set(serverTarget.branchName)
             it.includedModules.set(syncDirection.includedModules)
             it.includedModulePrefixes.set(syncDirection.includedModulePrefixes)
+            it.continueOnError.set(syncDirection.continueOnError)
         }
 
         project.tasks.register("runSync${syncDirection.name.replaceFirstChar { it.uppercaseChar() }}") {
@@ -191,6 +192,10 @@ class ModelSyncGradlePlugin : Plugin<Project> {
         previousTask: TaskProvider<*>,
         jsonDir: File,
     ) {
+        if (syncDirection.continueOnError) {
+            println("Continue on error is currently not supported for local targets")
+        }
+
         val localTarget = syncDirection.target as LocalTarget
 
         val antScript = jsonDir.resolve("build.xml")

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
@@ -43,6 +43,7 @@ data class SyncDirection(
     internal val registeredLanguages: Set<ILanguage> = mutableSetOf(),
     internal val includedModulePrefixes: Set<String> = mutableSetOf(),
     internal var mpsDebugEnabled: Boolean = false,
+    internal var continueOnError: Boolean = false,
 ) {
     fun fromModelServer(action: Action<ServerSource>) {
         val endpoint = ServerSource()
@@ -78,6 +79,10 @@ data class SyncDirection(
 
     fun registerLanguage(language: ILanguage) {
         (registeredLanguages as MutableSet).add(language)
+    }
+
+    fun enableContinueOnError(state: Boolean) {
+        continueOnError = state
     }
 }
 

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -62,6 +62,9 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
     @Input
     val includedModulePrefixes: SetProperty<String> = of.setProperty(String::class.java)
 
+    @Input
+    val continueOnError: Property<Boolean> = of.property(Boolean::class.java)
+
     @TaskAction
     fun import() {
         registeredLanguages.get().forEach {
@@ -83,7 +86,7 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
             client.runWrite(branchRef) { rootNode ->
                 logger.info("Got root node: {}", rootNode)
                 logger.info("Importing...")
-                ModelImporter(rootNode).importFilesAsRootChildren(files)
+                ModelImporter(rootNode, continueOnError.get()).importFilesAsRootChildren(files)
                 logger.info("Import finished")
             }
         }

--- a/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
@@ -74,6 +74,10 @@ This means that only a minimal amount of write operations is used to update the 
 |`includeModulesByPrefix`
 |String
 |Includes all modules, whose fully qualified name starts with the given prefix, in the synchronisation process.
+
+|`enableContinueOnError`
+|Boolean
+|If the sync encounters an error, simply log it and continue instead of terminating. This most likely results in an incomplete sync result. Defaults to `false`.
 |===
 
 === LocalSource/-Target configuration


### PR DESCRIPTION
With the new option, the sync can ignore errors encountered during syncing instead of immediately terminating. This is some sort of graceful degradation at the cost of potentially resulting in an inconsistent sync.

I'll add the missing implementation for the direction towards MPS after #312 is merged to avoid unnecessary conflicts.