### PR TITLE
chore(bulk-model-sync-gradle): remove unused mpsDebugEnabled option

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
@@ -42,7 +42,6 @@ data class SyncDirection(
     internal val includedModules: Set<String> = mutableSetOf(),
     internal val registeredLanguages: Set<ILanguage> = mutableSetOf(),
     internal val includedModulePrefixes: Set<String> = mutableSetOf(),
-    internal var mpsDebugEnabled: Boolean = false,
     internal var continueOnError: Boolean = false,
 ) {
     fun fromModelServer(action: Action<ServerSource>) {


### PR DESCRIPTION
This option was not used at all and also not documented. Therefore, we might find it ok that this is not a breaking change.