### PR TITLE
fix(model-api-gen): disambiguate meta properties and metamodel members

### DIFF
--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
@@ -62,8 +62,8 @@ internal class ProcessedLanguageSet(dataList: List<LanguageData>) : IProcessedLa
     private fun process() {
         initIndexes()
         resolveConceptReferences()
-        fixRoleConflicts()
         collectConceptMetaProperties()
+        fixRoleConflicts()
     }
 
     private fun collectConceptMetaProperties() {
@@ -128,8 +128,9 @@ internal class ProcessedLanguageSet(dataList: List<LanguageData>) : IProcessedLa
         sameInHierarchyConflicts.forEach { it.generatedName += "_" + it.concept.name }
 
         // replace illegal names
+        val illegalNames = reservedPropertyNames + conceptMetaProperties
         allConcepts.flatMap { it.getOwnRoles() }.forEach {
-            if (reservedPropertyNames.contains(it.generatedName)) {
+            if (illegalNames.contains(it.generatedName)) {
                 it.generatedName += getTypeSuffix(it)
             }
         }


### PR DESCRIPTION
Avoids compilation errors when the metaProperties contain something that also exists in the metamodel by treating the metaProperties keys as reserved names.

Fixes: MODELIX-610