### PR TITLE
fix(mps-model-adapters): handle unresolvable model imports

### DIFF
--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelAsNode.kt
@@ -76,8 +76,9 @@ data class MPSModelAsNode(val model: SModel) : IDefaultNodeAdapter {
         } else if (link.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes)) {
             model.rootNodes.map { MPSNode(it) }
         } else if (link.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports)) {
-            ModelImports(model).importedModels.mapNotNull {
-                MPSModelImportAsNode(it.resolve(model.repository), model)
+            ModelImports(model).importedModels.mapNotNull { modelRef ->
+                val target = modelRef.resolve(model.repository)
+                target?.let { MPSModelImportAsNode(it, model) }
             }
         } else if (link.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.Model.usedLanguages)) {
             getImportedLanguagesAndDevKits()


### PR DESCRIPTION
If an imported model could not be resolved, it caused a `NullPointerException`. 
This change handles this case gracefully.