### PR TITLE
MODELIX-608 Health check for warming up the MPS cache

### DIFF
--- a/docs/global/modules/core/pages/reference/component-mps-model-server-plugin.adoc
+++ b/docs/global/modules/core/pages/reference/component-mps-model-server-plugin.adoc
@@ -9,9 +9,21 @@ https://api.modelix.org/3.12.0/mps-model-server-plugin/index.html[API doc^] | ht
 
 == Health checks
 
-The plugin offers a set of health checks via HTTP on port 48305 and path `/health`.
-Health checks can be enabled adding query parameters with the health check name and the value `true` to the request.
+The plugin offers a set of health checks via HTTP GET on port `48305` and path `/health`.
 
+Health checks can be enabled adding query parameters with the health check name and the value `true` to the request.
+Some health checks require further information that needs to be provided by query parameters.
+
+.Example of combining health check
+[source,text]
+----
+http(s)://<host>:48305/health?indexer=true&loadModels=true&loadModelsModuleNamespacePrefix=foo.bar <1> <2>
+----
+<.> `indexer=true` enables <<indexer>>
+<.> `loadModels=true` enables <<loadModels>>
+* `loadModelsModuleNamespacePrefix` is a parameter related to `loadModels`
+
+[#indexer]
 === indexer
 
 The check fails, if the indexer is currently running for one of the opened projects.
@@ -30,3 +42,26 @@ Reports an unhealthy system whenever no project is loaded.
 
 Reports an unhealthy system when no virtual folders are available.
 This might also be true in case a project without virtual folders is fully loaded.
+
+[#loadModels]
+=== loadModels
+
+Returns after trying to eagerly load a set of specified modules.
+This check can be used to avoid a slow first ModelQl query after launching an MPS instance running this plugin.
+
+[NOTE]
+This health check has the side effect of loading the model data.
+It does not just report whether the model data is loaded or not.
+It always tries to load model data before returning a result.
+
+Multiple `loadModelsModuleNamespacePrefix` parameters can be provided
+to specify the modules from which the models should be loaded.
+
+.Usage example
+[source,text]
+----
+http(s)://<host>:48305/health?loadModels=true&loadModelsModuleNamespacePrefix=org.foo&loadModelsModuleNamespacePrefix=org.bar <.> <.> <.>
+----
+<.> `loadModels=true` enables <<loadModels>>
+<.> `loadModelsModuleNamespacePrefix=org.foo` specifies to load all models from modules starting with `org.foo`
+<.> `loadModelsModuleNamespacePrefix=org.bar` specifies to load all models from modules starting with `org.bar`


### PR DESCRIPTION
New health check `loadModels` implemented. Multiple `moduleNamespace` parameters can be provided to specify the relevant modules.