### PR TITLE
fix(model-server): writing to a branch using the v1 API failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle/
 /build/
 /*/build/
+/*/ignite/
 .DS_Store
 .gradletasknamecache
 .idea/

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -32,4 +32,7 @@ module.exports = {
     // No need to restrict the body line length. That only gives issues with URLs etc.
     "body-max-line-length": [0, 'always']
   },
+  ignores: [
+    (message) => message.includes('skip-lint')
+  ],
 };

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.cucumber.java)
     testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.kotlin.coroutines.test)
     testImplementation(kotlin("test"))
     testImplementation(project(":modelql-untyped"))
 }

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IStoreClient.kt
@@ -21,10 +21,11 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.modelix.model.IKeyListener
 import kotlin.time.Duration.Companion.seconds
 
-interface IStoreClient {
+interface IStoreClient : AutoCloseable {
     operator fun get(key: String): String?
     fun getAll(keys: List<String>): List<String?>
     fun getAll(keys: Set<String>): Map<String, String?>
+    fun getAll(): Map<String, String?>
     fun put(key: String, value: String?, silent: Boolean = false)
     fun putAll(entries: Map<String, String?>, silent: Boolean = false)
     fun listen(key: String, listener: IKeyListener)

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
@@ -136,10 +136,15 @@ class IgniteStoreClient(jdbcConfFile: File?) : IStoreClient {
 
     override fun <T> runTransaction(body: () -> T): T {
         val transactions = ignite.transactions()
-        transactions.txStart().use { tx ->
-            val result = body()
-            tx.commit()
-            return result
+        if (transactions.tx() == null) {
+            transactions.txStart().use { tx ->
+                val result = body()
+                tx.commit()
+                return result
+            }
+        } else {
+            // already in a transaction
+            return body()
         }
     }
 

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt
@@ -16,10 +16,6 @@ package org.modelix.model.server.store
 
 import org.modelix.model.IKeyListener
 import org.slf4j.LoggerFactory
-import java.io.BufferedReader
-import java.io.FileReader
-import java.io.FileWriter
-import java.io.IOException
 import kotlin.collections.HashMap
 
 fun generateId(idStr: String?): Long {
@@ -102,30 +98,6 @@ class InMemoryStoreClient : IStoreClient {
         val id = generateId(get(key))
         put(key, id.toString(), false)
         return id
-    }
-
-    @Synchronized
-    @Throws(IOException::class)
-    fun dump(fileWriter: FileWriter) {
-        for (key in values.keys) {
-            fileWriter.append(key)
-            fileWriter.append("#")
-            fileWriter.append(values[key])
-            fileWriter.append("\n")
-        }
-    }
-
-    @Synchronized
-    fun load(fileReader: FileReader?): Int {
-        val br = BufferedReader(fileReader)
-        val n = intArrayOf(0)
-        br.lines()
-            .forEach { line: String ->
-                val parts = line.split("#".toRegex(), limit = 2).toTypedArray()
-                values[parts[0]] = parts[1]
-                n[0]++
-            }
-        return n[0]
     }
 
     @Synchronized

--- a/model-server/src/main/resources/org/modelix/model/server/store/ignite-inmemory.xml
+++ b/model-server/src/main/resources/org/modelix/model/server/store/ignite-inmemory.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <bean id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="consistentId" value="inmemory"/>
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="model"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="backups" value="0"/>
+                    <property name="statisticsEnabled" value="true"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/model-server/src/test/kotlin/org/modelix/model/server/StoreClientTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/StoreClientTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.modelix.model.server.store.IStoreClient
+import org.modelix.model.server.store.IgniteStoreClient
+import org.modelix.model.server.store.InMemoryStoreClient
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class MapBasedStoreClientTest : StoreClientTest(InMemoryStoreClient())
+class IgniteStoreClientTest : StoreClientTest(IgniteStoreClient(inmemory = true))
+
+abstract class StoreClientTest(val store: IStoreClient) {
+
+    @AfterTest
+    fun cleanup() {
+        store.close()
+    }
+
+    @Test
+    fun `transaction can be started from inside a transaction`() {
+        store.runTransaction {
+            store.runTransaction {
+                store.put("abc", "def")
+            }
+        }
+    }
+
+    @Test
+    fun `allow put without transaction`() {
+        val key = "ljnrdlfkesmgf"
+        val value = "izujztdrsew"
+        assertNull(store.get(key))
+        store.put(key, value)
+        assertEquals(value, store.get(key))
+    }
+
+    @Test
+    fun `transactions are isolated`() = runTest {
+        val key = "kjhndsweret"
+        repeat(2) {
+            val rand = Random(it)
+            launch {
+                store.runTransaction {
+                    repeat(10) {
+                        val value = rand.nextInt().toString()
+                        store.put(key, value)
+                        assertEquals(value, store.get(key))
+                        Thread.sleep(rand.nextLong(5, 10))
+                        assertEquals(value, store.get(key))
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `transactions are atomic`() = runTest {
+        val key = "ioudgbnr"
+        val value1 = "a"
+        val value2 = "b"
+
+        store.put(key, value1)
+        assertEquals(value1, store.get(key))
+        assertFailsWith(NullPointerException::class) {
+            store.runTransaction {
+                store.put(key, value2)
+                assertEquals(value2, store.get(key))
+                throw NullPointerException()
+            }
+        }
+        assertEquals(value1, store.get(key)) // failed transaction should be rolled back
+    }
+}


### PR DESCRIPTION
Ignite doesn't support nested transactions. Starting a transaction from inside a transaction throws the following exception:

```
java.lang.IllegalStateException: Failed to start new transaction (current thread already has a transaction): ...
	at org.apache.ignite.internal.processors.cache.transactions.IgniteTransactionsImpl.txStart0(IgniteTransactionsImpl.java:184)
	at org.apache.ignite.internal.processors.cache.transactions.IgniteTransactionsImpl.txStart(IgniteTransactionsImpl.java:70)
	at org.modelix.model.server.store.IgniteStoreClient.runTransaction(IgniteStoreClient.kt:139)
	at org.modelix.model.server.handlers.RepositoriesManager.mergeChanges(RepositoriesManager.kt:151)
	at org.modelix.model.server.handlers.KeyValueLikeModelServer$putEntries$1.invoke(KeyValueLikeModelServer.kt:323)
	at org.modelix.model.server.handlers.KeyValueLikeModelServer$putEntries$1.invoke(KeyValueLikeModelServer.kt:316)
	at org.modelix.model.server.store.IgniteStoreClient.runTransaction(IgniteStoreClient.kt:140)
	at org.modelix.model.server.handlers.KeyValueLikeModelServer.putEntries(KeyValueLikeModelServer.kt:316)
	at org.modelix.model.server.handlers.KeyValueLikeModelServer$modelServerModule$1$3$7.invokeSuspend(KeyValueLikeModelServer.kt:163)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.ktor.server.netty.EventLoopGroupProxy$Companion.create$lambda$1$lambda$0(NettyApplicationEngine.kt:296)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```