### PR TITLE
chore: disable the commit message body line length limit

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -27,6 +27,8 @@ module.exports = {
         "vue-model-api",
       ],
     ],
-    "subject-case": [0, 'never']
+    "subject-case": [0, 'never'],
+    // No need to restrict the body line length. That only gives issues with URLs etc.
+    "body-max-line-length": [0, 'always']
   },
 };


### PR DESCRIPTION
This only breaks pasting URLs or long package names.