### PR TITLE
fix(bulk-model-sync-lib): use carriage returns only on TTYs

### DIFF
--- a/bulk-model-sync-lib/src/jsMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
+++ b/bulk-model-sync-lib/src/jsMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.sync.bulk
+
+actual fun isTty(): Boolean {
+    // Be safe and never assume a terminal as we cannot easily test for a TTY being attached
+    return false
+}

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.sync.bulk
+
+actual fun isTty(): Boolean {
+    return System.console() != null
+}

--- a/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ProgressReporterTest.kt
+++ b/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ProgressReporterTest.kt
@@ -1,0 +1,412 @@
+package org.modelix.model.sync.bulk
+
+import mu.KLogger
+import mu.KotlinLogging
+import mu.Marker
+import org.slf4j.Logger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProgressReporterTest {
+
+    @Test
+    fun `prints with carriage return if on TTY`() {
+        val logger = KotlinLogging.logger { }
+        var printed: String? = null
+        val reporter = ProgressReporter(1UL, logger, print = { arg -> printed = arg }, isTty = { true })
+
+        reporter.step(1UL)
+
+        assertTrue(printed!!.startsWith("\r(1 / 1)"), "Expected '$printed' to start with carriage return and count")
+    }
+
+    @Test
+    fun `prints to logger if not on TTY`() {
+        val logger = TestLogger()
+        val reporter = ProgressReporter(1UL, logger, print = { }, isTty = { false })
+
+        reporter.step(1UL)
+
+        assertTrue((logger.infoMessages[0] as String).startsWith("(1 / 1)"))
+    }
+
+    @Test
+    fun `avoids spamming the logger for every increment`() {
+        val logger = TestLogger()
+        val total = 400UL
+        val reporter = ProgressReporter(total, logger, print = { }, isTty = { false })
+
+        (1UL..total).forEach { step ->
+            reporter.step(step)
+        }
+
+        // Includes printing the first element, which is always shown
+        assertEquals(101, logger.infoMessages.size)
+    }
+
+    class TestLogger : KLogger {
+
+        var infoMessages: MutableList<Any?> = mutableListOf()
+
+        override val underlyingLogger: Logger
+            get() = throw RuntimeException("Not needed in test")
+
+        override fun <T : Throwable> catching(throwable: T) {
+            // not needed in this test
+        }
+
+        override fun debug(msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: Marker?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: Marker?, t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(msg: String?) {
+            // not needed in this test
+        }
+
+        override fun debug(format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: org.slf4j.Marker?, msg: String?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: org.slf4j.Marker?, format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun debug(marker: org.slf4j.Marker?, msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun entry(vararg argArray: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun error(t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: Marker?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: Marker?, t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun error(msg: String?) {
+            // not needed in this test
+        }
+
+        override fun error(format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: org.slf4j.Marker?, msg: String?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: org.slf4j.Marker?, format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun error(marker: org.slf4j.Marker?, msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun exit() {
+            // not needed in this test
+        }
+
+        override fun <T> exit(result: T): T {
+            // not needed in this test
+            return result
+        }
+
+        override fun getName(): String {
+            // not needed in this test
+            return ""
+        }
+
+        override fun info(msg: () -> Any?) {
+            infoMessages.add(msg())
+        }
+
+        override fun info(t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: Marker?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: Marker?, t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun info(msg: String?) {
+            // not needed in this test
+        }
+
+        override fun info(format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun info(format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun info(format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun info(msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: org.slf4j.Marker?, msg: String?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: org.slf4j.Marker?, format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun info(marker: org.slf4j.Marker?, msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun isDebugEnabled(): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isDebugEnabled(marker: org.slf4j.Marker?): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isErrorEnabled(): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isErrorEnabled(marker: org.slf4j.Marker?): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isInfoEnabled(): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isInfoEnabled(marker: org.slf4j.Marker?): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isTraceEnabled(): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isTraceEnabled(marker: org.slf4j.Marker?): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isWarnEnabled(): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun isWarnEnabled(marker: org.slf4j.Marker?): Boolean {
+            // not needed in this test
+            return false
+        }
+
+        override fun <T : Throwable> throwing(throwable: T): T {
+            // not needed in this test
+            return throwable
+        }
+
+        override fun trace(msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: Marker?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: Marker?, t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(msg: String?) {
+            // not needed in this test
+        }
+
+        override fun trace(format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: org.slf4j.Marker?, msg: String?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: org.slf4j.Marker?, format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: org.slf4j.Marker?, format: String?, vararg argArray: Any?) {
+            // not needed in this test
+        }
+
+        override fun trace(marker: org.slf4j.Marker?, msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun warn(msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: Marker?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: Marker?, t: Throwable?, msg: () -> Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(msg: String?) {
+            // not needed in this test
+        }
+
+        override fun warn(format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: org.slf4j.Marker?, msg: String?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: org.slf4j.Marker?, format: String?, arg: Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: org.slf4j.Marker?, format: String?, arg1: Any?, arg2: Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: org.slf4j.Marker?, format: String?, vararg arguments: Any?) {
+            // not needed in this test
+        }
+
+        override fun warn(marker: org.slf4j.Marker?, msg: String?, t: Throwable?) {
+            // not needed in this test
+        }
+    }
+}


### PR DESCRIPTION
The implemented progress reporting in the ModelImporter always used carriage returns to report progress. This only works in terminals and breaks incremental logging in setups like k8s.

This commit tries to detect if running in a terminal and if not, resorts to logging calls for progress reporting. Logging output is reduced to avoid excessive spam in captured log file.