### PR TITLE
fix(model-client): memory leak in VersionChangeDetector

### DIFF
--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
@@ -371,7 +371,7 @@ class RestWebModelClient @JvmOverloads constructor(
         return runBlocking { getA(key) }
     }
 
-    suspend fun getA(key: String): String? {
+    override suspend fun getA(key: String): String? {
         val isHash = HashUtil.isSha256(key)
         if (isHash) {
             if (LOG.isDebugEnabled) {

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/VersionChangeDetector.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/VersionChangeDetector.kt
@@ -69,7 +69,7 @@ abstract class VersionChangeDetector(
             store.listen(key, keyListener)
             while (isActive) {
                 try {
-                    val version = store[key]
+                    val version = store.getA(key)
                     if (version != lastVersionHash) {
                         LOG.debug { "New version detected by polling: $version" }
                         versionChanged(version)

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyValueStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyValueStore.kt
@@ -17,6 +17,7 @@ package org.modelix.model
 
 interface IKeyValueStore {
     operator fun get(key: String): String?
+    suspend fun getA(key: String): String? = get(key)
     fun put(key: String, value: String?)
     fun getAll(keys: Iterable<String>): Map<String, String?>
     fun putAll(entries: Map<String, String?>)

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -165,6 +165,7 @@ class RepositoriesManager(val client: LocalModelClient) {
                 mergedVersion.hash
             }
             putVersionHash(branch, mergedHash)
+            ensureRepositoriesAreInList(setOf(branch.repositoryId))
             ensureBranchesAreInList(branch.repositoryId, setOf(branch.branchName))
             result = mergedHash
         }


### PR DESCRIPTION
VersionChangeDetector wasn't disposed, while waiting for a change.
It was transitively calling runBlocking from a coroutine which means a
cancellation of the coroutine has no effect while being blocked.