### PR TITLE
fix(light-model-client): Do implement `org.modelix.incremental` interfaces in public classes

### DIFF
--- a/light-model-client/src/commonMain/kotlin/org/modelix/client/light/LightModelClient.kt
+++ b/light-model-client/src/commonMain/kotlin/org/modelix/client/light/LightModelClient.kt
@@ -63,7 +63,7 @@ class LightModelClient internal constructor(
     val autoFilterNonLoadedNodes: Boolean,
     val debugName: String = "",
     val modelQLClient: ModelQLClient? = null,
-) : IStateVariableGroup {
+) {
 
     private val nodes = NodesMap<NodeData>(this)
     private val area = Area()
@@ -105,10 +105,6 @@ class LightModelClient internal constructor(
                 }
             }
         }
-    }
-
-    override fun getGroup(): IStateVariableGroup? {
-        return null
     }
 
     fun dispose() {
@@ -904,11 +900,17 @@ fun INode.isLoaded() = isValid
 fun <T : INode> Iterable<T>.filterLoaded() = filter { it.isLoaded() }
 fun <T : INode> Sequence<T>.filterLoaded() = filter { it.isLoaded() }
 
-data class NodeDataDependency(val client: LightModelClient, val id: NodeId) : IStateVariableReference<NodeData> {
+private data class ClientDependency(val client: LightModelClient) : IStateVariableGroup {
+    override fun getGroup(): IStateVariableGroup? {
+        return null
+    }
+}
+
+private data class NodeDataDependency(val client: LightModelClient, val id: NodeId) : IStateVariableReference<NodeData> {
     override fun getGroup(): IStateVariableGroup {
         return client.tryGetParentId(id)
             ?.let { NodeDataDependency(client, it) }
-            ?: client
+            ?: ClientDependency(client)
     }
 
     override fun read(): NodeData {


### PR DESCRIPTION
Implementing `IStateVariableGroup` but not exposing `org.modelix.incremental` as API dependency resulted in the following error when using the light-model-client library: Cannot access 'org.modelix.incremental.IStateVariableGroup' which is a super type of 'org.modelix.client.light.LightModelClient'. Check your module class path for missing or conflicting dependencies.

Exposing `org.modelix.incremental` as an API dependency would have been a solution too, but we should not expose its API accidentally. When consumers want to use the light-model-client with its incremental functionality, they should add `org.modelix.incremental` as a dependency themselves.

Fixes https://github.com/modelix/modelix.samples/pull/205