### PR TITLE
MODELIX-655 Convert release to nightly

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -1,15 +1,11 @@
-name: Release
+name: Dry-Run Release
 on:
-  push:
-    branches:
-      - main
-  pull_request: {}
+  pull_request:
 
 jobs:
   lint-commits:
     name: Lint PR commits
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -19,7 +15,6 @@ jobs:
   test-release:
     name: Dry-run semantic-release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,29 +43,3 @@ jobs:
         # configuration from the CI environment by removing the variable that
         # is used for CI detection.
         run: unset GITHUB_ACTIONS && npx semantic-release --dry-run --ci false
-
-  release:
-    name: Run semantic release
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Cache Node packages
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: release-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: npx semantic-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Run semantic release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Cache Node packages
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: release-${{ hashFiles('package.json') }}-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: npx semantic-release


### PR DESCRIPTION
We want to release nightly, instead of after each merged PR to avoid spamming releases.
For urgent cases, the workflow can still be dispatched manually.