### PR TITLE
ci: increase HTTP timeout in Gradle for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,16 @@ jobs:
       - name: Use tag as version
         run: echo "${GITHUB_REF#refs/*/}" > version.txt
       - name: Build and Publish Artifacts
-        run: ./gradlew --build-cache build publish -PciBuild=true -Partifacts.itemis.cloud.user=${{secrets.ARTIFACTS_ITEMIS_CLOUD_USER}} -Partifacts.itemis.cloud.pw=${{secrets.ARTIFACTS_ITEMIS_CLOUD_PW}} -Pgpr.user=${{ github.actor }} -Pgpr.key=${{ secrets.GITHUB_TOKEN }} -Pgpr.universalkey=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
+        run: >-
+          ./gradlew --build-cache build publish
+          -PciBuild=true
+          -Partifacts.itemis.cloud.user=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_USER }}
+          -Partifacts.itemis.cloud.pw=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_PW }}
+          -Pgpr.user=${{ github.actor }}
+          -Pgpr.key=${{ secrets.GITHUB_TOKEN }}
+          -Pgpr.universalkey=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
+          -Porg.gradle.internal.http.connectionTimeout=180000
+          -Porg.gradle.internal.http.socketTimeout=180000
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ARTIFACTS_ITEMIS_CLOUD_NPM_TOKEN }}
       - name: Set up QEMU


### PR DESCRIPTION
An increased timeout might reduce failing uploads that are caused by slow or unstable connections.