### PR TITLE
MODELIX-644 Support writing in generated typed API with ModelQl

### DIFF
--- a/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTest.kt
+++ b/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTest.kt
@@ -17,6 +17,8 @@ import io.ktor.client.HttpClient
 import io.ktor.server.testing.testApplication
 import jetbrains.mps.baseLanguage.C_ClassConcept
 import jetbrains.mps.baseLanguage.C_IntegerType
+import jetbrains.mps.baseLanguage.C_MinusExpression
+import jetbrains.mps.baseLanguage.C_ParameterDeclaration
 import jetbrains.mps.baseLanguage.C_PlusExpression
 import jetbrains.mps.baseLanguage.C_PublicVisibility
 import jetbrains.mps.baseLanguage.C_ReturnStatement
@@ -24,8 +26,12 @@ import jetbrains.mps.baseLanguage.C_StaticMethodDeclaration
 import jetbrains.mps.baseLanguage.C_VariableReference
 import jetbrains.mps.baseLanguage.ClassConcept
 import jetbrains.mps.baseLanguage.StaticMethodDeclaration
+import jetbrains.mps.lang.editor.imageGen.C_ImageGenerator
+import jetbrains.mps.lang.editor.imageGen.ImageGenerator
 import org.modelix.apigen.test.ApigenTestLanguages
+import org.modelix.metamodel.instanceOf
 import org.modelix.metamodel.typed
+import org.modelix.metamodel.untyped
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.PBranch
 import org.modelix.model.api.getRootNode
@@ -33,25 +39,45 @@ import org.modelix.model.api.resolve
 import org.modelix.model.client.IdGenerator
 import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.ObjectStoreCache
-import org.modelix.model.persistent.MapBaseStore
+import org.modelix.model.persistent.MapBasedStore
 import org.modelix.model.server.light.LightModelServer
 import org.modelix.modelql.client.ModelQLClient
+import org.modelix.modelql.core.asMono
 import org.modelix.modelql.core.count
+import org.modelix.modelql.core.equalTo
 import org.modelix.modelql.core.filter
+import org.modelix.modelql.core.first
 import org.modelix.modelql.core.map
 import org.modelix.modelql.core.toList
 import org.modelix.modelql.core.toSet
 import org.modelix.modelql.core.zip
+import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.addToMember
+import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.expression
 import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.member
 import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.parameter
+import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.setExpression
+import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.setVariableDeclaration
 import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.variableDeclaration
 import org.modelix.modelql.gen.jetbrains.mps.baseLanguage.visibility
+import org.modelix.modelql.gen.jetbrains.mps.core.xml.addToLines
+import org.modelix.modelql.gen.jetbrains.mps.core.xml.document
+import org.modelix.modelql.gen.jetbrains.mps.core.xml.lines
+import org.modelix.modelql.gen.jetbrains.mps.core.xml.setDocument
 import org.modelix.modelql.gen.jetbrains.mps.lang.core.name
+import org.modelix.modelql.gen.jetbrains.mps.lang.core.setName
+import org.modelix.modelql.gen.jetbrains.mps.lang.editor.imageGen.node
+import org.modelix.modelql.gen.jetbrains.mps.lang.editor.imageGen.node_orNull
+import org.modelix.modelql.gen.jetbrains.mps.lang.editor.imageGen.setNode
 import org.modelix.modelql.untyped.children
 import org.modelix.modelql.untyped.conceptReference
+import org.modelix.modelql.untyped.descendants
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TypedModelQLTest {
     private lateinit var branch: IBranch
@@ -68,7 +94,7 @@ class TypedModelQLTest {
     @BeforeTest
     fun setup() {
         ApigenTestLanguages.registerAll()
-        val tree = CLTree(ObjectStoreCache(MapBaseStore()))
+        val tree = CLTree(ObjectStoreCache(MapBasedStore()))
         branch = PBranch(tree, IdGenerator.getInstance(1))
         val rootNode = branch.getRootNode()
         branch.runWrite {
@@ -101,6 +127,10 @@ class TypedModelQLTest {
                     }
                 }
             }
+            // Example for optional reference
+            rootNode.addNewChild("imageGen", -1, C_ImageGenerator.untyped())
+                .typed<ImageGenerator>()
+                .apply { node = cls1 }
         }
     }
 
@@ -131,7 +161,7 @@ class TypedModelQLTest {
     }
 
     @Test
-    fun testReferences() = runTest { httpClient ->
+    fun `get references`() = runTest { httpClient ->
         val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
         val usedVariables: Set<String> = client.query { root ->
             root.children("classes").ofConcept(C_ClassConcept)
@@ -147,7 +177,7 @@ class TypedModelQLTest {
     }
 
     @Test
-    fun testReferencesFqName() = runTest { httpClient ->
+    fun `get references - fqName`() = runTest { httpClient ->
         val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
         val usedVariables: Set<String> = client.query { root ->
             root.children("classes").ofConcept(C_ClassConcept)
@@ -170,7 +200,7 @@ class TypedModelQLTest {
     }
 
     @Test
-    fun testNodeSerialization() = runTest { httpClient ->
+    fun `node serialization`() = runTest { httpClient ->
         val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
         val result: List<StaticMethodDeclaration> = client.query { root ->
             root.children("classes").ofConcept(C_ClassConcept)
@@ -184,7 +214,7 @@ class TypedModelQLTest {
     }
 
     @Test
-    fun returnTypedNode() = runTest { httpClient ->
+    fun `return typed node`() = runTest { httpClient ->
         val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
         val result: List<StaticMethodDeclaration> = client.query { root ->
             root.children("classes").ofConcept(C_ClassConcept)
@@ -194,5 +224,150 @@ class TypedModelQLTest {
                 .toList()
         }
         assertEquals("plus", branch.computeRead { result[0].name })
+    }
+
+    @Test
+    fun `set property`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+        val expected = "myRenamedMethod"
+        client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .first()
+                .setName(expected.asMono())
+        }
+        val actual = client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .first()
+        }
+        assertEquals(expected, actual.name)
+    }
+
+    @Test
+    fun `set reference`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+
+        val oldValue = client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .descendants()
+                .ofConcept(C_ParameterDeclaration)
+                .first()
+                .name
+        }
+        val expected = "b"
+        client.query { root ->
+            val descendants = root.children("classes").ofConcept(C_ClassConcept)
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .descendants()
+
+            val target = descendants.ofConcept(C_ParameterDeclaration)
+                .filter { it.name.equalTo(expected) }
+                .first()
+
+            descendants.ofConcept(C_VariableReference)
+                .first()
+                .setVariableDeclaration(target)
+        }
+
+        val actual = client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .descendants()
+                .ofConcept(C_VariableReference)
+                .first()
+        }
+        assertNotEquals(expected, oldValue)
+        assertEquals(expected, actual.variableDeclaration.name)
+    }
+
+    @Test
+    fun `set reference - null`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+        val oldValue = client.query { root ->
+            root.children("imageGen").ofConcept(C_ImageGenerator).first().node
+        }
+
+        client.query { root ->
+            root.children("imageGen").ofConcept(C_ImageGenerator).first().setNode(null)
+        }
+
+        val actual = client.query { root ->
+            root.children("imageGen").ofConcept(C_ImageGenerator).first().node_orNull
+        }
+        assertNotNull(oldValue)
+        assertNull(actual)
+    }
+
+    @Test
+    fun `add new child`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+
+        val oldNumChildren = client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .first()
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .count()
+        }
+
+        client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .first()
+                .addToMember(C_StaticMethodDeclaration)
+        }
+
+        val children = client.query { root ->
+            root.children("classes").ofConcept(C_ClassConcept)
+                .first()
+                .member
+                .ofConcept(C_StaticMethodDeclaration)
+                .toList()
+        }
+
+        assertEquals(oldNumChildren + 1, children.size)
+        assertEquals(C_StaticMethodDeclaration.untyped().getUID(), children.last().untyped().concept?.getUID())
+    }
+
+    @Test
+    fun `add new child - default concept`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+        client.query { root ->
+            root.descendants().ofConcept(C_XmlComment)
+                .first()
+                .addToLines()
+        }
+
+        val actual = client.query { root ->
+            root.descendants().ofConcept(C_XmlComment)
+                .first()
+                .lines
+                .first()
+        }
+
+        assertTrue { actual.instanceOf(C_XmlCommentLine) }
+    }
+
+    @Test
+    fun `set child`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+
+        client.query { root ->
+            root.descendants().ofConcept(C_ReturnStatement)
+                .first()
+                .setExpression(C_MinusExpression)
+        }
+
+        val actual = client.query { root ->
+            root.descendants().ofConcept(C_ReturnStatement).first().expression
+        }
+        assertNotNull(actual)
+        assertTrue(actual.instanceOf(C_MinusExpression))
     }
 }

--- a/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTest.kt
+++ b/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTest.kt
@@ -26,6 +26,10 @@ import jetbrains.mps.baseLanguage.C_StaticMethodDeclaration
 import jetbrains.mps.baseLanguage.C_VariableReference
 import jetbrains.mps.baseLanguage.ClassConcept
 import jetbrains.mps.baseLanguage.StaticMethodDeclaration
+import jetbrains.mps.core.xml.C_XmlComment
+import jetbrains.mps.core.xml.C_XmlCommentLine
+import jetbrains.mps.core.xml.C_XmlDocument
+import jetbrains.mps.core.xml.C_XmlFile
 import jetbrains.mps.lang.editor.imageGen.C_ImageGenerator
 import jetbrains.mps.lang.editor.imageGen.ImageGenerator
 import org.modelix.apigen.test.ApigenTestLanguages
@@ -131,6 +135,12 @@ class TypedModelQLTest {
             rootNode.addNewChild("imageGen", -1, C_ImageGenerator.untyped())
                 .typed<ImageGenerator>()
                 .apply { node = cls1 }
+
+            // Example for single non-abstract child
+            rootNode.addNewChild("xmlFile", -1, C_XmlFile.untyped())
+
+            // Example for mulitple non-abstract child
+            rootNode.addNewChild("xmlComment", -1, C_XmlComment.untyped())
         }
     }
 
@@ -369,5 +379,23 @@ class TypedModelQLTest {
         }
         assertNotNull(actual)
         assertTrue(actual.instanceOf(C_MinusExpression))
+    }
+
+    @Test
+    fun `set child - default concept`() = runTest { httpClient ->
+        val client = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+        client.query { root ->
+            root.descendants().ofConcept(C_XmlFile)
+                .first()
+                .setDocument()
+        }
+
+        val actual = client.query { root ->
+            root.descendants().ofConcept(C_XmlFile)
+                .first()
+                .document
+        }
+
+        assertTrue { actual.instanceOf(C_XmlDocument) }
     }
 }

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
@@ -302,7 +302,10 @@ internal sealed class ProcessedLink(name: String, uid: String?, optional: Boolea
 }
 
 internal class ProcessedChildLink(name: String, uid: String?, optional: Boolean, var multiple: Boolean, type: ProcessedConceptReference, deprecationMessage: String?) :
-    ProcessedLink(name, uid, optional, type, deprecationMessage)
+    ProcessedLink(name, uid, optional, type, deprecationMessage) {
+
+    fun adderMethodName() = "addTo" + generatedName.take(1).uppercase() + generatedName.drop(1)
+}
 
 internal class ProcessedReferenceLink(name: String, uid: String?, optional: Boolean, type: ProcessedConceptReference, deprecationMessage: String?) :
     ProcessedLink(name, uid, optional, type, deprecationMessage)

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/MetaModelGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/MetaModelGenerator.kt
@@ -466,12 +466,18 @@ class MetaModelGenerator(
                             )
                             val returnType = IMonoStep::class.asTypeName().parameterizedBy(targetType)
                             val receiverType = IMonoStep::class.asTypeName().parameterizedBy(concept.nodeWrapperInterfaceType())
+                            val conceptParameter = ParameterSpec.builder("concept", ITypedConcept::class.asTypeName()).apply {
+                                if (!feature.type.resolved.abstract) {
+                                    defaultValue("%T", feature.type.resolved.conceptWrapperInterfaceClass())
+                                }
+                            }.build()
+
                             if (feature.multiple) {
                                 addFunction(
                                     FunSpec.builder(feature.adderMethodName())
                                         .returns(returnType)
                                         .receiver(receiverType)
-                                        .addParameter("concept", ITypedConcept::class.asTypeName())
+                                        .addParameter(conceptParameter)
                                         .addParameter(
                                             ParameterSpec.builder("index", Int::class.asTypeName())
                                                 .defaultValue("-1")
@@ -490,7 +496,7 @@ class MetaModelGenerator(
                                     FunSpec.builder(feature.setterName())
                                         .returns(returnType)
                                         .receiver(receiverType)
-                                        .addParameter("concept", ITypedConcept::class.asTypeName())
+                                        .addParameter(conceptParameter)
                                         .addStatement(
                                             "return %T.setChild(this, %T.%N, concept)",
                                             TypedModelQL::class.asTypeName(),

--- a/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
+++ b/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
@@ -168,8 +168,9 @@ object TypedModelQL {
         return input.map { referenceOrNull(it, link) }
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun <SourceT : ITypedNode, TargetT : ITypedNode> setReference(input: IMonoStep<SourceT>, link: ITypedReferenceLink<TargetT>, target: IMonoStep<TargetT?>?): IMonoStep<SourceT> {
-        val targetOrNull = target?.untyped() ?: nullMono<INode>()
+        val targetOrNull = target?.untyped() ?: nullMono<String>() as IMonoStep<INode?> // cast is necessary since nullMono<INode> cannot be serialized
         input.untyped().setReference(link.untyped(), targetOrNull)
         return input
     }

--- a/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
+++ b/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
@@ -59,12 +59,14 @@ import org.modelix.modelql.core.flatMap
 import org.modelix.modelql.core.inSet
 import org.modelix.modelql.core.map
 import org.modelix.modelql.core.mapIfNotNull
+import org.modelix.modelql.core.nullMono
 import org.modelix.modelql.core.orNull
 import org.modelix.modelql.core.stepOutputSerializer
 import org.modelix.modelql.core.toBoolean
 import org.modelix.modelql.core.toInt
 import org.modelix.modelql.core.upcast
 import org.modelix.modelql.untyped.UntypedModelQL
+import org.modelix.modelql.untyped.addNewChild
 import org.modelix.modelql.untyped.children
 import org.modelix.modelql.untyped.conceptReference
 import org.modelix.modelql.untyped.descendants
@@ -75,7 +77,9 @@ import org.modelix.modelql.untyped.ofConcept
 import org.modelix.modelql.untyped.property
 import org.modelix.modelql.untyped.query
 import org.modelix.modelql.untyped.reference
+import org.modelix.modelql.untyped.remove
 import org.modelix.modelql.untyped.setProperty
+import org.modelix.modelql.untyped.setReference
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 
@@ -140,6 +144,17 @@ object TypedModelQL {
         return input.untyped().flatMap { it.children(link.untyped().key()) }.typedUnsafe(link.getTypedChildConcept().getInstanceInterface())
     }
 
+    fun <ParentT : ITypedNode, ChildT : ITypedNode> addNewChild(input: IMonoStep<ParentT>, link: ITypedChildListLink<ChildT>, index: Int = -1, concept: ITypedConcept): IMonoStep<ChildT> {
+        val conceptRef = ConceptReference(concept.untyped().getUID())
+        return input.untyped().addNewChild(link.untyped(), index, conceptRef).typedUnsafe(link.getTypedChildConcept().getInstanceInterface())
+    }
+
+    fun <ParentT : ITypedNode, ChildT : ITypedNode> setChild(input: IMonoStep<ParentT>, link: ITypedSingleChildLink<ChildT>, concept: ITypedConcept): IMonoStep<ChildT> {
+        val conceptRef = ConceptReference(concept.untyped().getUID())
+        input.untyped().children(link.untyped().key()).firstOrNull().mapIfNotNull { it.remove() }
+        return input.untyped().addNewChild(link.untyped(), conceptRef).typedUnsafe(link.getTypedChildConcept().getInstanceInterface())
+    }
+
     fun <SourceT : ITypedNode, TargetT : ITypedNode> reference(input: IMonoStep<SourceT>, link: ITypedReferenceLink<TargetT>): IMonoStep<TargetT> {
         return input.untyped().reference(link.untyped().key()).typedUnsafe<TargetT>(link.getTypedTargetConcept().getInstanceInterface())
     }
@@ -151,6 +166,12 @@ object TypedModelQL {
     }
     fun <SourceT : ITypedNode, TargetT : ITypedNode> referenceOrNull(input: IFluxStep<SourceT>, link: ITypedReferenceLink<TargetT>): IFluxStep<TargetT?> {
         return input.map { referenceOrNull(it, link) }
+    }
+
+    fun <SourceT : ITypedNode, TargetT : ITypedNode> setReference(input: IMonoStep<SourceT>, link: ITypedReferenceLink<TargetT>, target: IMonoStep<TargetT?>?): IMonoStep<SourceT> {
+        val targetOrNull = target?.untyped() ?: nullMono<INode>()
+        input.untyped().setReference(link.untyped(), targetOrNull)
+        return input
     }
 }
 


### PR DESCRIPTION
Adds the ability to perform write operations in ModelQL queries.
As the MetaModelGenerator class has organically grown to a significant size, [MODELIX-667](https://issues.modelix.org/issue/MODELIX-667) was created as a followup ticket.