### PR TITLE
ci(bulk-model-sync-gradle): replace sleep with health-check

### DIFF
--- a/bulk-model-sync-gradle-test/ci.sh
+++ b/bulk-model-sync-gradle-test/ci.sh
@@ -21,14 +21,8 @@ fi
 
 ./gradlew runModelServer --console=plain &
 MODEL_SERVER_PID=$!
-sleep 5
 
-#CI needs more time
-if [ "${CI}" = "true" ]; then
-  sleep 20
-fi
-
-curl -X POST http://127.0.0.1:28309/v2/repositories/ci-test/init
+curl -X GET --retry 30 --retry-connrefused --retry-delay 1 http://localhost:28309/health
 
 ./gradlew runSyncTestPush --console=plain --stacktrace
 ./gradlew test --tests 'PushTest'


### PR DESCRIPTION
Waiting was flakey and the POST is no longer needed as MODELIX-615 has been resolved.