### PR TITLE
Configure HTTP timeouts in bulk sync.

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -40,6 +40,7 @@ import org.modelix.model.sync.bulk.ModelImporter
 import org.modelix.model.sync.bulk.importFilesAsRootChildren
 import org.modelix.model.sync.bulk.isModuleIncluded
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.minutes
 
 abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : DefaultTask() {
 
@@ -78,7 +79,12 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
         val repoId = RepositoryId(repositoryId.get())
 
         val branchRef = ModelFacade.createBranchReference(repoId, branchName.get())
-        val client = ModelClientV2.builder().url(url.get()).build()
+        val client = ModelClientV2.builder()
+            .url(url.get())
+            // Processing large chunks of data on import might take some time. Therefore, extend the request timeout to
+            // let the model-server do the import.
+            .requestTimeout(5.minutes)
+            .build()
         val files = inputDir.listFiles()?.filter {
             it.extension == "json" && isModuleIncluded(it.nameWithoutExtension, includedModules.get(), includedModulePrefixes.get())
         }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -56,6 +56,7 @@ import org.modelix.model.persistent.MapBasedStore
 import org.modelix.model.server.api.v2.VersionDelta
 import org.modelix.modelql.client.ModelQLClient
 import org.modelix.modelql.core.IMonoStep
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class ModelClientV2(
@@ -338,6 +339,8 @@ abstract class ModelClientV2Builder {
     protected var baseUrl: String = "https://localhost/model/v2"
     protected var authTokenProvider: (() -> String?)? = null
     protected var userId: String? = null
+    protected var connectTimeout: Duration = 1.seconds
+    protected var requestTimeout: Duration = 30.seconds
 
     fun build(): ModelClientV2 {
         return ModelClientV2(
@@ -367,6 +370,16 @@ abstract class ModelClientV2Builder {
         return this
     }
 
+    fun connectTimeout(timeout: Duration): ModelClientV2Builder {
+        this.connectTimeout = timeout
+        return this
+    }
+
+    fun requestTimeout(timeout: Duration): ModelClientV2Builder {
+        this.requestTimeout = timeout
+        return this
+    }
+
     protected open fun configureHttpClient(config: HttpClientConfig<*>) {
         config.apply {
             expectSuccess = true
@@ -375,8 +388,8 @@ abstract class ModelClientV2Builder {
                 json()
             }
             install(HttpTimeout) {
-                connectTimeoutMillis = 1.seconds.inWholeMilliseconds
-                requestTimeoutMillis = 30.seconds.inWholeMilliseconds
+                connectTimeoutMillis = connectTimeout.inWholeMilliseconds
+                requestTimeoutMillis = requestTimeout.inWholeMilliseconds
             }
             install(HttpRequestRetry) {
                 retryOnExceptionOrServerErrors(maxRetries = 3)


### PR DESCRIPTION
Makes previously hard-coded HTTP timeouts for the model client configurable and increases the timeout for the bulk sync, where we see timeouts hitting with large models.