### PR TITLE
ci: restrict release workflow to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ jobs:
   release:
     name: Run semantic release
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
While the schedule trigger only works on the default branch, the workflow_dispatch trigger can still be run on other branches. This is a precaution to not accidentally run it on a different branch.