### PR TITLE
fix: initialize the server ID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         additional_dependencies: ["@commitlint/config-angular"]
         args: ["--config", "./commitlint.config.js"]
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.10.0
+    rev: v2.12.0
     hooks:
       - id: pretty-format-kotlin
         args:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -28,8 +28,9 @@ module.exports = {
       ],
     ],
     "subject-case": [0, 'never'],
-    // No need to restrict the body line length. That only gives issues with URLs etc.
-    "body-max-line-length": [0, 'always']
+    // No need to restrict the body and footer line length. That only gives issues with URLs etc.
+    "body-max-line-length": [0, 'always'],
+    "footer-max-line-length": [0, 'always']
   },
   ignores: [
     (message) => message.includes('skip-lint')

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
@@ -75,6 +75,15 @@ class KeyValueLikeModelServer(val repositoriesManager: RepositoriesManager) {
     val storeClient: IStoreClient get() = repositoriesManager.client.store
 
     fun init(application: Application) {
+        // Functionally, it does not matter if the server ID
+        // is created eagerly on startup or lazily on the first request,
+        // as long as the same server ID is returned from the same server.
+        //
+        // The server ID is initialized eagerly because adding special conditions in the affected
+        // request to initialize it lazily, would make the code less robust.
+        // Each change in the logic of RepositoriesManager#maybeInitAndGetSeverId would need
+        // the special conditions in the affected requests to be updated.
+        repositoriesManager.maybeInitAndGetSeverId()
         application.apply {
             modelServerModule()
         }

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -85,7 +85,14 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
             call.respondText(storeClient.generateId("clientId").toString())
         }
         get("server-id") {
-            call.respondText(repositoriesManager.getServerId())
+            // Currently, the server ID is initialized in KeyValueLikeModelServer eagerly on startup.
+            // Should KeyValueLikeModelServer be removed or change,
+            // RepositoriesManager#maybeInitAndGetSeverId will initialize the server ID lazily on the first request.
+            //
+            // Functionally, it does not matter if the server ID is created eagerly or lazily,
+            // as long as the same server ID is returned from the same server.
+            val serverId = repositoriesManager.maybeInitAndGetSeverId()
+            call.respondText(serverId)
         }
         get("user-id") {
             call.respondText(call.getUserName() ?: call.request.origin.remoteHost)

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -44,7 +44,16 @@ class RepositoriesManager(val client: LocalModelClient) {
         return client.store.generateId("$KEY_PREFIX:${repositoryId.id}:clientId")
     }
 
-    fun getServerId(): String {
+    /**
+     * Used to retrieve the server ID. If needed, the server ID is created and stored.
+     *
+     * If a server ID was not created yet, it is generated and saved in the database.
+     * It gets stored under the current and all legacy database keys.
+     *
+     * If the server ID was created previously but is only stored under a legacy database key,
+     * it also gets stored under the current and all legacy database keys.
+     */
+    fun maybeInitAndGetSeverId(): String {
         return store.runTransaction {
             var serverId = store[SERVER_ID_KEY]
             if (serverId == null) {

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientTest.kt
@@ -29,6 +29,7 @@ import org.modelix.model.server.store.LocalModelClient
 import java.util.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 
@@ -49,8 +50,7 @@ class ModelClientTest {
         val numKeys = numListenersPerClient * 2
 
         val rand = Random(67845)
-        val url = "http://localhost/"
-        val clients = (0 until numClients).map { RestWebModelClient(baseUrl = url, providedClient = client) }
+        val clients = (0 until numClients).map { createModelClient() }
         val listeners: MutableList<Listener> = ArrayList()
         val expected: MutableMap<String, String> = HashMap()
         for (client in clients.withIndex()) {
@@ -102,6 +102,20 @@ class ModelClientTest {
         for (client in clients) {
             client.dispose()
         }
+    }
+
+    @Test
+    fun `can retrieve server id initially`() = runTest {
+        val modelClient = createModelClient()
+
+        val serverId = modelClient.get("server-id")
+
+        assertNotNull(serverId)
+    }
+
+    private fun ApplicationTestBuilder.createModelClient(): RestWebModelClient {
+        val url = "http://localhost/"
+        return RestWebModelClient(baseUrl = url, providedClient = client)
     }
 
     inner class Listener(var key: String, private val client: RestWebModelClient, val clientIndex: Int, val listenerIndex: Int) : IKeyListener {


### PR DESCRIPTION
Clients using the v1 API expect server ID to be set.

See https://github.com/modelix/modelix.mps-plugins/blob/70293ee28914c4c5987f0cd67a500806a8a26411/mps-legacy-sync-plugin/src/main/java/org/modelix/model/mpsplugin/ModelServerConnection.kt#L168
See `ModelServerConnection#onConnect` in https://github.com/modelix/modelix.mps/blob/c594b1cc45222a3e8860d1bfb6468cd5bbb1bb77/mps/org.modelix.model.mpsplugin/models/org.modelix.model.mpsplugin.mps