### PR TITLE
fix(ts-model-api): publish the contents of the `dist` directory

### DIFF
--- a/ts-model-api/build.gradle.kts
+++ b/ts-model-api/build.gradle.kts
@@ -58,7 +58,7 @@ tasks.named("npm_run_generateKotlin") {
 val copyBuildTypeScriptForPackaging = tasks.create<Copy>("copyBuildTypeScriptForPackaging") {
   dependsOn(npmRunBuild)
   from(projectDir)
-  include("dist")
+  include("dist/**")
   into(layout.buildDirectory.dir("typeScriptForPackaging"))
 }
 


### PR DESCRIPTION
The old pattern only included the directory `dist` without its content.