### PR TITLE
feat(bulk-model-sync-gradle): make request timeout configurable

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
@@ -106,6 +106,7 @@ class ModelSyncGradlePlugin : Plugin<Project> {
             it.revision.set(serverSource.revision)
             it.includedModules.set(syncDirection.includedModules)
             it.includedModulePrefixes.set(syncDirection.includedModulePrefixes)
+            it.requestTimeoutSeconds.set(serverSource.requestTimeoutSeconds)
         }
         return exportFromModelServer
     }
@@ -160,6 +161,7 @@ class ModelSyncGradlePlugin : Plugin<Project> {
             it.includedModules.set(syncDirection.includedModules)
             it.includedModulePrefixes.set(syncDirection.includedModulePrefixes)
             it.continueOnError.set(syncDirection.continueOnError)
+            it.requestTimeoutSeconds.set(serverTarget.requestTimeoutSeconds)
         }
 
         project.tasks.register("runSync${syncDirection.name.replaceFirstChar { it.uppercaseChar() }}") {

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
@@ -130,10 +130,13 @@ data class LocalTarget(
     }
 }
 
+private const val DEFAULT_REQUEST_TIMEOUT_SECONDS = 5 * 60
+
 sealed interface ServerEndpoint : SyncEndpoint {
     var url: String?
     var repositoryId: String?
     var branchName: String?
+    var requestTimeoutSeconds: Int
 
     override fun getValidationErrors(): List<String> {
         val errors = mutableListOf<String>()
@@ -148,6 +151,7 @@ data class ServerSource(
     override var url: String? = null,
     override var repositoryId: String? = null,
     override var branchName: String? = null,
+    override var requestTimeoutSeconds: Int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
     var revision: String? = null,
 ) : ServerEndpoint {
     override fun getValidationErrors(): List<String> {
@@ -179,6 +183,7 @@ data class ServerTarget(
     override var url: String? = null,
     override var repositoryId: String? = null,
     override var branchName: String? = null,
+    override var requestTimeoutSeconds: Int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
 ) : ServerEndpoint {
     override fun getValidationErrors(): List<String> {
         val errors = mutableListOf<String>()

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ExportFromModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ExportFromModelServer.kt
@@ -40,6 +40,7 @@ import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.sync.bulk.ModelExporter
 import org.modelix.model.sync.bulk.isModuleIncluded
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 abstract class ExportFromModelServer @Inject constructor(of: ObjectFactory) : DefaultTask() {
 
@@ -67,10 +68,14 @@ abstract class ExportFromModelServer @Inject constructor(of: ObjectFactory) : De
     @Input
     val includedModulePrefixes: SetProperty<String> = of.setProperty(String::class.java)
 
+    @Input
+    val requestTimeoutSeconds: Property<Int> = of.property(Int::class.java)
+
     @TaskAction
     fun export() {
         val modelClient = ModelClientV2PlatformSpecificBuilder()
             .url(url.get())
+            .requestTimeout(requestTimeoutSeconds.get().seconds)
             .build()
         modelClient.use { client ->
             runBlocking { client.init() }

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -40,7 +40,7 @@ import org.modelix.model.sync.bulk.ModelImporter
 import org.modelix.model.sync.bulk.importFilesAsRootChildren
 import org.modelix.model.sync.bulk.isModuleIncluded
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : DefaultTask() {
 
@@ -69,6 +69,9 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
     @Input
     val continueOnError: Property<Boolean> = of.property(Boolean::class.java)
 
+    @Input
+    val requestTimeoutSeconds: Property<Int> = of.property(Int::class.java)
+
     @TaskAction
     fun import() {
         registeredLanguages.get().forEach {
@@ -81,9 +84,7 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
         val branchRef = ModelFacade.createBranchReference(repoId, branchName.get())
         val client = ModelClientV2.builder()
             .url(url.get())
-            // Processing large chunks of data on import might take some time. Therefore, extend the request timeout to
-            // let the model-server do the import.
-            .requestTimeout(5.minutes)
+            .requestTimeout(requestTimeoutSeconds.get().seconds)
             .build()
         val files = inputDir.listFiles()?.filter {
             it.extension == "json" && isModuleIncluded(it.nameWithoutExtension, includedModules.get(), includedModulePrefixes.get())

--- a/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
@@ -143,6 +143,10 @@ If the target branch does not exist on the model-server, it will be created.
 |String
 |Source model-server revision. Can be used instead of `repositoryId` and `branchName`. Only available in ServerSource.
 
+|`requestTimeoutSeconds`
+|Integer
+|The request timeout measured in seconds to apply when performing HTTP requests towards the model-server. Default: 5 minutes
+
 |===
 
 == Example


### PR DESCRIPTION
Depending on the size of the model, the import into the model-server might have some long-running HTTP calls. As the default timeout was not sufficient in all cases, it can now be configured by users of the task.