### PR TITLE
ci: enable info logging in publish workflow as a debugging aid

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,13 @@ jobs:
       - name: Use tag as version
         run: echo "${GITHUB_REF#refs/*/}" > version.txt
       - name: Build and Publish Artifacts
+        # We run gradle with --info to debug the ongoing random publishing
+        # issues. Gradle would log upload retries on info level:
+        # https://github.com/gradle/gradle/blob/2e843f089f969940e505e69eb0742ed4fbf67993/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java#L64
+        # Maybe retries are the source of our duplicate publication attempts.
         run: >-
           ./gradlew --build-cache build publish
+          --info
           -PciBuild=true
           -Partifacts.itemis.cloud.user=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_USER }}
           -Partifacts.itemis.cloud.pw=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_PW }}


### PR DESCRIPTION
To find out why publishing sporadically fails, this commit enabled Gradle info logging in the publish workflow. Gradle would log HTTP request retries on this level and maybe they are the source of our sporadic redeployment issues. Info level should be safe to stay enabled as it does not leak credentials or something else.