### PR TITLE
ci: set log level to INFO in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Build and Publish Artifacts
         run: >-
           ./gradlew --build-cache build publish
+          --info
           -PciBuild=true
           -Partifacts.itemis.cloud.user=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_USER }}
           -Partifacts.itemis.cloud.pw=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_PW }}


### PR DESCRIPTION
We try to see if a retry is related to the failing publish workflows. https://issues.modelix.org/issue/MODELIX-612/Stabilize-publishing-pipeline

A retry would be logged at log level INFO.
https://github.com/gradle/gradle/blob/master/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkOperationBackOffAndRetry.java#L64

We do not use DEBUG because the DEBUG log level can expose security sensitive information to the console. https://docs.gradle.org/current/userguide/logging.html