### PR TITLE
feat(model-server)!: Use ENTRYPOINT instead of CMD in the provided Docker image

### DIFF
--- a/model-server/Dockerfile
+++ b/model-server/Dockerfile
@@ -4,4 +4,4 @@ EXPOSE 28101
 COPY run-model-server.sh /usr/modelix-model/
 COPY build/dependency-libs/ /usr/modelix-model/model-server/build/libs/
 COPY build/libs/ /usr/modelix-model/model-server/build/libs/
-CMD ["./run-model-server.sh"]
+ENTRYPOINT ["./run-model-server.sh"]


### PR DESCRIPTION

This follows best practices for Docker images.
> You can use the exec form of ENTRYPOINT to set fairly stable default commands and arguments and then use either form of CMD to set additional defaults that are more likely to be changed.
See https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example

Using a ENTRYPOINT in model-server docker container makes passing arguments easier.
For example,
`docker run modelix/model-server ./run-model-server.sh -inmemory`
would be simplified to
`docker run modelix/model-server -inmemory`

BREAKING CHANGE: The previous entry point was the default `ENTRYPOINT ["/bin/sh", "-c"]`.
Now it is `ENTRYPOINT ["./run-model-server.sh"]`.
If you used `docker run modelix/model-server ./run-model-server.sh <args>` to pass arguments,
you now have to use `docker run modelix/model-server <args>`.
If you used any other process, you now have to override the entry point with the `--entrypoint` option.
See https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime