### PR TITLE
fix(bulk-model-sync-gradle): deprecate registerLanguage

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
@@ -152,7 +152,6 @@ class ModelSyncGradlePlugin : Plugin<Project> {
         val importIntoModelServer = project.tasks.register(importTaskName, ImportIntoModelServer::class.java) {
             it.dependsOn(previousTask)
             it.inputDir.set(jsonDir)
-            it.registeredLanguages.set(syncDirection.registeredLanguages)
             val serverTarget = syncDirection.target as ServerTarget
 
             it.url.set(serverTarget.url)

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
@@ -17,6 +17,7 @@
 package org.modelix.model.sync.bulk.gradle.config
 
 import org.gradle.api.Action
+import org.modelix.kotlin.utils.DeprecationInfo
 import org.modelix.model.api.ILanguage
 import java.io.File
 
@@ -40,7 +41,6 @@ data class SyncDirection(
     internal var source: SyncEndpoint? = null,
     internal var target: SyncEndpoint? = null,
     internal val includedModules: Set<String> = mutableSetOf(),
-    internal val registeredLanguages: Set<ILanguage> = mutableSetOf(),
     internal val includedModulePrefixes: Set<String> = mutableSetOf(),
     internal var continueOnError: Boolean = false,
 ) {
@@ -76,9 +76,9 @@ data class SyncDirection(
         (includedModulePrefixes as MutableSet).add(prefix)
     }
 
-    fun registerLanguage(language: ILanguage) {
-        (registeredLanguages as MutableSet).add(language)
-    }
+    @Deprecated("Registering languages is not necessary. This call can be safely removed.", ReplaceWith(""))
+    @DeprecationInfo(since = "2024-01-08")
+    fun registerLanguage(language: ILanguage) {}
 
     fun enableContinueOnError(state: Boolean) {
         continueOnError = state

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -28,8 +28,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.modelix.model.ModelFacade
-import org.modelix.model.api.ILanguage
-import org.modelix.model.api.ILanguageRepository
 import org.modelix.model.api.INode
 import org.modelix.model.api.PNodeAdapter
 import org.modelix.model.client2.ModelClientV2
@@ -58,9 +56,6 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
     val url: Property<String> = of.property(String::class.java)
 
     @Input
-    val registeredLanguages: SetProperty<ILanguage> = of.setProperty(ILanguage::class.java)
-
-    @Input
     val includedModules: SetProperty<String> = of.setProperty(String::class.java)
 
     @Input
@@ -74,10 +69,6 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
 
     @TaskAction
     fun import() {
-        registeredLanguages.get().forEach {
-            ILanguageRepository.default.registerLanguage(it)
-        }
-
         val inputDir = inputDir.get().asFile
         val repoId = RepositoryId(repositoryId.get())
 

--- a/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
@@ -63,10 +63,6 @@ This means that only a minimal amount of write operations is used to update the 
 |Action<LocalTarget>
 |Defines a local target (MPS).
 
-|`registerLanguage`
-|ILanguage
-|Registers the given language and all of its concepts for the synchronisation process.
-
 |`includeModule`
 |String
 |Includes the module specified by the given fully qualified name in the synchronisation process.


### PR DESCRIPTION
Registering is not needed for the sync as only the untyped api is used.