### PR TITLE
ci: fix dependabot docker directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,6 @@ updates:
       interval: "daily"
   - package-ecosystem: "docker"
     open-pull-requests-limit: 20
-    directory: "/"
+    directory: "/model-server"
     schedule:
       interval: "daily"


### PR DESCRIPTION
followup for #403 as dependabot cannot find the Dockerfile