### PR TITLE
ci: test the publish workflow in PRs if changed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
+  # Test this workflow in PRs in case it changed
+  pull_request:
+    paths:
+      - .github/workflows/publish.yml
 
 jobs:
   newRelease:
@@ -26,8 +30,16 @@ jobs:
           java-version: '11'
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Use tag as version
-        run: echo "${GITHUB_REF#refs/*/}" > version.txt
+      - name: Configure the project version
+        env:
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+        run: |-
+          if [[ "$IS_PR" = 'true' ]]; then
+            echo "0.0.1-SNAPSHOT" > version.txt
+          else
+            echo "${GITHUB_REF#refs/*/}" > version.txt
+          fi
+          cat version.txt
         # Perform the build in a separate call to avoid trying to publish
         # something where the build already failed partially. This could happen
         # due to the use of the --continue flag in the publish step.
@@ -46,20 +58,26 @@ jobs:
         # Usually, the artifact that cannot be uploaded is strangely already
         # in the repo. As the result, by ignoring the exception, we should end
         # up with a working release in most cases.
-        run: >-
-          ./gradlew --build-cache publish
-          --continue
-          --info
-          -PciBuild=true
-          -Partifacts.itemis.cloud.user=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_USER }}
-          -Partifacts.itemis.cloud.pw=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_PW }}
-          -Pgpr.user=${{ github.actor }}
-          -Pgpr.key=${{ secrets.GITHUB_TOKEN }}
-          -Pgpr.universalkey=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }}
-          -Porg.gradle.internal.http.connectionTimeout=180000
-          -Porg.gradle.internal.http.socketTimeout=180000
+        run: |-
+          if [[ "$IS_PR" = 'true' ]]; then
+            TARGET=publishToMavenLocal
+          else
+            TARGET=publish
+          fi
+          ./gradlew --build-cache $TARGET \
+            --continue \
+            --info \
+            -PciBuild=true \
+            -Partifacts.itemis.cloud.user=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_USER }} \
+            -Partifacts.itemis.cloud.pw=${{ secrets.ARTIFACTS_ITEMIS_CLOUD_PW }} \
+            -Pgpr.user=${{ github.actor }} \
+            -Pgpr.key=${{ secrets.GITHUB_TOKEN }} \
+            -Pgpr.universalkey=${{ secrets.GHP_UNIVERSAL_PUBLISH_TOKEN }} \
+            -Porg.gradle.internal.http.connectionTimeout=180000 \
+            -Porg.gradle.internal.http.socketTimeout=180000
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ARTIFACTS_ITEMIS_CLOUD_NPM_TOKEN }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -67,6 +85,9 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
       - name: Build and Publish Docker
+        # As publishing is currently baked into the scripts, we can't test this
+        # in PRs
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
           DOCKER_HUB_KEY: ${{ secrets.DOCKER_HUB_KEY }}


### PR DESCRIPTION
This PR runs the GitHub Actions publish workflow in case we have changed it in a PR. Without this, testing changes to this workflow is guess work until a release appeared. The workflow has been modified to only publish to maven local in PR runs to avoid spamming repositories with artificial testing releases. That way, we don't test everything about publishing, but a complete misconfiguration of the publishing tasks or pipeline should become visible. Docker publishing is not tested and skipped here as I couldn't find an easy way to not push things to our repos.