### PR TITLE
MODELIX-709 Use dependabot for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: "/model-server"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 20
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,30 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  # We use the default versioning strategy for npm (increase for apps and widen for libraries),
+  # so that clients are free to select an appropriate version from the allowed range, when they use one of the libraries.
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 20
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 20
+    directory: "/ts-model-api"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 20
+    directory: "/vue-model-api"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 20
+    directory: "/model-api-gen-gradle-test/typescript-generation"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 20
+    directory: "/model-api-gen-gradle-test/vue-integration"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Unfortunately dependabot currently does not support adding multiple directories, so the config is a bit repetitive.