### PR TITLE
MODELIX-714 ModelQl query on model-server fails with "issue getting concept"

### DIFF
--- a/model-api-gen-gradle-test/ci.sh
+++ b/model-api-gen-gradle-test/ci.sh
@@ -2,6 +2,19 @@
 
 set -e
 (
-  cd "$(dirname "$0")"
-  ./gradlew build
+  TEST_DIR="$(dirname "$(readlink -f "$0")")"
+  cd "$TEST_DIR/../"
+  if [ "${CI}" != "true" ]; then
+    trap cleanup INT TERM EXIT
+    cleanup () {
+      kill "${MODEL_SERVER_PID}"
+      exit
+    }
+  fi
+  ./gradlew :model-server:run --console=plain --args="-inmemory -port 28102" &
+  MODEL_SERVER_PID=$!
+
+  curl -X GET --retry 30 --retry-connrefused --retry-delay 1 http://localhost:28102/health
+  cd "$TEST_DIR"
+  ./gradlew build --console=plain --stacktrace
 )

--- a/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTestWithLightModelServer.kt
+++ b/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTestWithLightModelServer.kt
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelix.modelql.typed
+
+import io.ktor.server.testing.testApplication
+import org.modelix.apigen.test.ApigenTestLanguages
+import org.modelix.model.api.IBranch
+import org.modelix.model.api.PBranch
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.persistent.MapBasedStore
+import org.modelix.model.server.light.LightModelServer
+import org.modelix.modelql.client.ModelQLClient
+import kotlin.test.BeforeTest
+
+class TypedModelQLTestWithLightModelServer : TypedModelQLTest() {
+    private lateinit var branch: IBranch
+
+    override fun runTest(block: suspend (ModelQLClient) -> Unit) = testApplication {
+        application {
+            LightModelServer(80, branch.getRootNode()).apply { installHandlers() }
+        }
+        val httpClient = createClient {
+        }
+        val modelQlClient = ModelQLClient.builder().url("http://localhost/query").httpClient(httpClient).build()
+        block(modelQlClient)
+    }
+
+    @BeforeTest
+    fun setup() {
+        ApigenTestLanguages.registerAll()
+        val tree = CLTree(ObjectStoreCache(MapBasedStore()))
+        branch = PBranch(tree, IdGenerator.getInstance(1))
+        branch.runWrite {
+            createTestData(branch.getRootNode())
+        }
+    }
+}

--- a/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLWithModelServerTest.kt
+++ b/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLWithModelServerTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.modelql.typed
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.TestInstance
+import org.modelix.apigen.test.ApigenTestLanguages
+import org.modelix.model.ModelFacade
+import org.modelix.model.client2.ModelClientV2
+import org.modelix.model.client2.runWrite
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.modelql.client.ModelQLClient
+import kotlin.test.BeforeTest
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TypedModelQLWithModelServerTest : TypedModelQLTest() {
+    private var testRun = 0
+    private val modelClient = ModelClientV2.builder().url("http://localhost:28102/v2/").build().also { runBlocking { it.init() } }
+    private val branchRef
+        get() = ModelFacade.createBranchReference(RepositoryId("modelql-test$testRun"), "master")
+
+    override fun runTest(block: suspend (ModelQLClient) -> Unit) {
+        val modelQlClient = ModelQLClient.builder()
+            .url("http://localhost:28102/v2/repositories/${branchRef.repositoryId.id}/branches/${branchRef.branchName}/query")
+            .build()
+
+        runBlocking { block(modelQlClient) }
+    }
+
+    init {
+        ApigenTestLanguages.registerAll()
+    }
+
+    @BeforeTest
+    fun setup() {
+        testRun++
+        runBlocking {
+            modelClient.runWrite(branchRef) {
+                createTestData(it)
+            }
+        }
+    }
+}

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -323,8 +323,17 @@ fun INode.resolveProperty(role: String): IProperty {
         ?: throw RuntimeException("Property '$role' not found in concept ${c.getLongName()}")
 }
 
+/**
+ * Attempts to resolve the child link.
+ * @return resolved child link
+ *         or null, if this concept has no child link or an exception was thrown during concept resolution
+ */
 fun INode.tryResolveChildLink(role: String): IChildLink? {
-    val c = this.concept ?: return null
+    val c = try {
+        this.concept ?: return null
+    } catch (e: RuntimeException) {
+        return null
+    }
     val allLinks = c.getAllChildLinks()
     return allLinks.find { it.key(this) == role }
         ?: allLinks.find { it.getSimpleName() == role }
@@ -334,8 +343,18 @@ fun INode.resolveChildLinkOrFallback(role: String?): IChildLink {
     if (role == null) return NullChildLink
     return tryResolveChildLink(role) ?: IChildLink.fromName(role)
 }
+
+/**
+ * Attempts to resolve the reference link.
+ * @return resolved reference link
+ *         or null, if this node has no reference link or an exception was thrown during concept resolution
+ */
 fun INode.tryResolveReferenceLink(role: String): IReferenceLink? {
-    val c = this.concept ?: return null
+    val c = try {
+        this.concept ?: return null
+    } catch (e: RuntimeException) {
+        return null
+    }
     val allLinks = c.getAllReferenceLinks()
     return allLinks.find { it.key(this) == role }
         ?: allLinks.find { it.getSimpleName() == role }
@@ -344,8 +363,18 @@ fun INode.tryResolveReferenceLink(role: String): IReferenceLink? {
 fun INode.resolveReferenceLinkOrFallback(role: String): IReferenceLink {
     return tryResolveReferenceLink(role) ?: IReferenceLink.fromName(role)
 }
+
+/**
+ * Attempts to resolve the property.
+ * @return resolved property
+ *         or null, if this node has no concept or an exception was thrown during concept resolution
+ */
 fun INode.tryResolveProperty(role: String): IProperty? {
-    val c = this.concept ?: return null
+    val c = try {
+        this.concept ?: return null
+    } catch (e: RuntimeException) {
+        return null
+    }
     val allLinks = c.getAllProperties()
     return allLinks.find { it.key(this) == role }
         ?: allLinks.find { it.getSimpleName() == role }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -137,7 +137,7 @@ class ModelClientV2(
                 takeFrom(baseUrl)
                 appendPathSegments("repositories")
             }
-        }.bodyAsText().lines().map { RepositoryId(it) }
+        }.bodyAsText().lines().filter { it.isNotEmpty() }.map { RepositoryId(it) }
     }
 
     override suspend fun listBranches(repository: RepositoryId): List<BranchReference> {
@@ -146,7 +146,7 @@ class ModelClientV2(
                 takeFrom(baseUrl)
                 appendPathSegmentsEncodingSlash("repositories", repository.id, "branches")
             }
-        }.bodyAsText().lines().map { repository.getBranchReference(it) }
+        }.bodyAsText().lines().filter { it.isNotEmpty() }.map { repository.getBranchReference(it) }
     }
 
     @Deprecated("repository ID is required for permission checks")

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/OfConceptStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/OfConceptStep.kt
@@ -36,7 +36,7 @@ class OfConceptStep(val conceptUIDs: Set<String>) : MonoTransformingStep<INode?,
     override fun createFlow(input: StepFlow<INode?>, context: IFlowInstantiationContext): StepFlow<INode> {
         return input.filter {
             val value = it.value
-            value != null && conceptUIDs.contains(value.concept?.getUID())
+            value != null && conceptUIDs.contains(value.getConceptReference()?.getUID())
         } as StepFlow<INode>
     }
 


### PR DESCRIPTION
These edge cases were not caught by the tests, because the client and server share the same `TypedLanguagesRegistry` as it is a a singleton.
In production the model-server would have no knowledge about the used languages, but it has them in our test.
If we wanted to test these cases automatically, we would probably have to test this with a real model-server, which would be quite expensive.