### PR TITLE
ci: configure dev deps prefix for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps)"
   - package-ecosystem: "npm"
     open-pull-requests-limit: 20
     directory: "/ts-model-api"
@@ -32,13 +34,19 @@ updates:
     directory: "/vue-model-api"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps)"
   - package-ecosystem: "npm"
     open-pull-requests-limit: 20
     directory: "/model-api-gen-gradle-test/typescript-generation"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps)"
   - package-ecosystem: "npm"
     open-pull-requests-limit: 20
     directory: "/model-api-gen-gradle-test/vue-integration"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build(deps)"


### PR DESCRIPTION
The default has a different commit scope for dev dependencies, we want to have these unified.