### PR TITLE
Introduce delete repository endpoint

### DIFF
--- a/api/model-server.yaml
+++ b/api/model-server.yaml
@@ -314,6 +314,18 @@ paths:
           $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/versionDelta'
+  /v2/repositories/{repository}/delete:
+    post:
+      operationId: deleteRepository
+      parameters:
+        - name: repository
+          in: "path"
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: '#/components/responses/200'
   /v2/repositories/{repository}/versions/{versionHash}:
     get:
       operationId: getRepositoryVersionHash

--- a/api/model-server.yaml
+++ b/api/model-server.yaml
@@ -324,8 +324,10 @@ paths:
           schema:
             type: string
       responses:
-        "200":
-          $ref: '#/components/responses/200'
+        "204":
+          $ref: '#/components/responses/204'
+        "404":
+          $ref: '#/components/responses/404'
   /v2/repositories/{repository}/versions/{versionHash}:
     get:
       operationId: getRepositoryVersionHash

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -41,7 +41,7 @@ interface IModelClientV2 {
 
     suspend fun initRepository(repository: RepositoryId): IVersion
     suspend fun listRepositories(): List<RepositoryId>
-
+    suspend fun deleteRepository(repository: RepositoryId): Boolean
     suspend fun listBranches(repository: RepositoryId): List<BranchReference>
 
     @Deprecated("repository ID is required for permission checks")

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -146,7 +146,7 @@ class ModelClientV2(
                 takeFrom(baseUrl)
                 appendPathSegmentsEncodingSlash("repositories", repository.id, "delete")
             }
-        }.status == HttpStatusCode.OK
+        }.status == HttpStatusCode.NoContent
     }
 
     override suspend fun listBranches(repository: RepositoryId): List<BranchReference> {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -140,6 +140,15 @@ class ModelClientV2(
         }.bodyAsText().lines().map { RepositoryId(it) }
     }
 
+    override suspend fun deleteRepository(repository: RepositoryId): Boolean {
+        return httpClient.post {
+            url {
+                takeFrom(baseUrl)
+                appendPathSegmentsEncodingSlash("repositories", repository.id, "delete")
+            }
+        }.status == HttpStatusCode.OK
+    }
+
     override suspend fun listBranches(repository: RepositoryId): List<BranchReference> {
         return httpClient.get {
             url {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -141,12 +141,17 @@ class ModelClientV2(
     }
 
     override suspend fun deleteRepository(repository: RepositoryId): Boolean {
-        return httpClient.post {
-            url {
-                takeFrom(baseUrl)
-                appendPathSegmentsEncodingSlash("repositories", repository.id, "delete")
-            }
-        }.status == HttpStatusCode.NoContent
+        try {
+            return httpClient.post {
+                url {
+                    takeFrom(baseUrl)
+                    appendPathSegmentsEncodingSlash("repositories", repository.id, "delete")
+                }
+            }.status == HttpStatusCode.NoContent
+        } catch (ex: Exception) {
+            LOG.error(ex) { ex.message }
+            return false
+        }
     }
 
     override suspend fun listBranches(repository: RepositoryId): List<BranchReference> {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -169,8 +169,13 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
             fun ApplicationCall.repositoryId() = RepositoryId(parameters["repository"]!!)
             fun PipelineContext<Unit, ApplicationCall>.repositoryId() = call.repositoryId()
 
-            repositoriesManager.removeRepository(repositoryId())
-            call.respond(HttpStatusCode.OK)
+            val repositoryId = repositoryId()
+            if (!repositoriesManager.repositoryExists(repositoryId)) {
+                call.respond(HttpStatusCode.NotFound)
+            } else {
+                repositoriesManager.removeRepository(repositoryId)
+                call.respond(HttpStatusCode.NoContent)
+            }
         }
 
         post<Paths.postRepositoryBranch> {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -170,11 +170,11 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
             fun PipelineContext<Unit, ApplicationCall>.repositoryId() = call.repositoryId()
 
             val repositoryId = repositoryId()
-            if (!repositoriesManager.repositoryExists(repositoryId)) {
-                call.respond(HttpStatusCode.NotFound)
-            } else {
-                repositoriesManager.removeRepository(repositoryId)
+            val foundAndDeleted = repositoriesManager.removeRepository(repositoryId)
+            if (foundAndDeleted) {
                 call.respond(HttpStatusCode.NoContent)
+            } else {
+                call.respond(HttpStatusCode.NotFound)
             }
         }
 

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -165,6 +165,14 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
             call.respondDelta(initialVersion.getContentHash(), null)
         }
 
+        post<Paths.deleteRepository> {
+            fun ApplicationCall.repositoryId() = RepositoryId(parameters["repository"]!!)
+            fun PipelineContext<Unit, ApplicationCall>.repositoryId() = call.repositoryId()
+
+            repositoriesManager.removeRepository(repositoryId())
+            call.respond(HttpStatusCode.OK)
+        }
+
         post<Paths.postRepositoryBranch> {
             fun ApplicationCall.repositoryId() = RepositoryId(parameters["repository"]!!)
             fun PipelineContext<Unit, ApplicationCall>.repositoryId() = call.repositoryId()

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -145,8 +145,12 @@ class RepositoriesManager(val client: LocalModelClient) {
         }
     }
 
-    fun removeRepository(repository: RepositoryId) {
-        store.runTransaction {
+    fun removeRepository(repository: RepositoryId): Boolean {
+        return store.runTransaction {
+            if (!repositoryExists(repository)) {
+                return@runTransaction false
+            }
+
             for (branchName in getBranchNames(repository)) {
                 putVersionHash(repository.getBranchReference(branchName), null)
             }
@@ -154,6 +158,8 @@ class RepositoriesManager(val client: LocalModelClient) {
             val existingRepositories = getRepositories()
             val remainingRepositories = existingRepositories - repository
             store.put(REPOSITORIES_LIST_KEY, remainingRepositories.joinToString("\n") { it.id })
+
+            true
         }
     }
 

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -174,9 +174,8 @@ class ModelClientV2Test {
         val client = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
         val repositoryId = RepositoryId(UUID.randomUUID().toString())
         client.initRepository(repositoryId)
-
         client.deleteRepository(repositoryId)
-        // repository should not exist here
+
         val success = client.deleteRepository(repositoryId)
 
         assertEquals(false, success)

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -173,8 +173,6 @@ class ModelClientV2Test {
         val url = "http://localhost/v2"
         val client = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
         val repositoryId = RepositoryId(UUID.randomUUID().toString())
-        client.initRepository(repositoryId)
-        client.deleteRepository(repositoryId)
 
         val success = client.deleteRepository(repositoryId)
 

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -36,6 +36,7 @@ import org.modelix.model.server.handlers.ModelReplicationServer
 import org.modelix.model.server.store.InMemoryStoreClient
 import org.modelix.modelql.core.count
 import org.modelix.modelql.untyped.allChildren
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -153,5 +154,31 @@ class ModelClientV2Test {
         modelClient.setClientProvideUserId(null)
 
         assertEquals("localhost", modelClient.getUserId())
+    }
+
+    @Test
+    fun `newly created repository can be removed`() = runTest {
+        val url = "http://localhost/v2"
+        val client = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+        val repositoryId = RepositoryId(UUID.randomUUID().toString())
+        client.initRepository(repositoryId)
+
+        val success = client.deleteRepository(repositoryId)
+
+        assertEquals(true, success)
+    }
+
+    @Test
+    fun `non-existing repository cannot be removed`() = runTest {
+        val url = "http://localhost/v2"
+        val client = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+        val repositoryId = RepositoryId(UUID.randomUUID().toString())
+        client.initRepository(repositoryId)
+
+        client.deleteRepository(repositoryId)
+        // repository should not exist here
+        val success = client.deleteRepository(repositoryId)
+
+        assertEquals(false, success)
     }
 }


### PR DESCRIPTION
This MR proposes a /delete endpoint on the model server that could remove a repository. The endpoint is also available in the ModelClientV2. 

The feature was originally proposed by @nkoester in #237 (see its removal in [f97d2e8](https://github.com/modelix/modelix.core/pull/237/commits/f97d2e8b699089ec3d8e5d4dd50fa0e19e4b9225)).