### PR TITLE
MODELIX-719 Performance of IModelClient2.pull

### DIFF
--- a/model-server/src/test/kotlin/org/modelix/model/server/PullPerformanceTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/PullPerformanceTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server
+
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.resources.Resources
+import io.ktor.server.routing.IgnoreTrailingSlash
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.server.websocket.WebSockets
+import kotlinx.coroutines.coroutineScope
+import org.modelix.authorization.installAuthentication
+import org.modelix.model.api.IChildLink
+import org.modelix.model.api.IConceptReference
+import org.modelix.model.api.INode
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client2.ModelClientV2
+import org.modelix.model.client2.runWriteOnBranch
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.server.handlers.KeyValueLikeModelServer
+import org.modelix.model.server.handlers.ModelReplicationServer
+import org.modelix.model.server.handlers.RepositoriesManager
+import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.model.server.store.LocalModelClient
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class PullPerformanceTest {
+    private fun runTest(block: suspend ApplicationTestBuilder.(storeClientWithStatistics: StoreClientWithStatistics) -> Unit) = testApplication {
+        val storeClientWithStatistics = StoreClientWithStatistics(InMemoryStoreClient())
+        val repositoriesManager = RepositoriesManager(LocalModelClient(storeClientWithStatistics))
+        application {
+            installAuthentication(unitTestMode = true)
+            install(ContentNegotiation) {
+                json()
+            }
+            install(WebSockets)
+            install(Resources)
+            install(IgnoreTrailingSlash)
+            ModelReplicationServer(repositoriesManager).init(this)
+            KeyValueLikeModelServer(repositoriesManager).init(this)
+        }
+
+        coroutineScope {
+            block(storeClientWithStatistics)
+        }
+    }
+
+    /**
+     * Tests the performance of the `GET /v2/repositories/{repository}/branches/{branch}` endpoint.
+     * Many small request to an IgniteStoreClient lead to a poor performance. This test ensure that bulk requests are
+     * used for loading a model.
+     */
+    @Test
+    fun `bulk requests are used`() = runTest { storeClientWithStatistics ->
+        val rand = Random(1056343)
+        val url = "http://localhost/v2"
+        val preparingModelClient = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+        val repositoryId = RepositoryId("repo1")
+        preparingModelClient.initRepository(repositoryId)
+        preparingModelClient.runWriteOnBranch(repositoryId.getBranchReference()) { branch ->
+            val rootNode = branch.getRootNode()
+            repeat(10_000) {
+                val randomNode = rootNode.getRandomNode(rand)
+                randomNode.addNewChild(IChildLink.fromName("roleA"), -1, null as IConceptReference?)
+            }
+        }
+
+        val requestingModelClient = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+        val totalRequestsBeforePull = storeClientWithStatistics.getTotalRequests()
+        requestingModelClient.pull(repositoryId.getBranchReference(), null)
+        val totalRequestsAfterPull = storeClientWithStatistics.getTotalRequests()
+        val actualRequestCount = totalRequestsAfterPull - totalRequestsBeforePull
+
+        // The request count when not using a bulk query is a couple ten thousand.
+        // Using a bulk query reduces the number of separate requests to the underling store to much fewer.
+        assertTrue(actualRequestCount < 20, "Too many request: $actualRequestCount")
+    }
+}
+
+private fun INode.getRandomNode(rand: Random): INode {
+    val node = this
+    val children = node.allChildren.toList()
+    val index = rand.nextInt(children.size + 1)
+    return if (index < children.size) {
+        children.get(index).getRandomNode(rand)
+    } else {
+        node
+    }
+}

--- a/model-server/src/test/kotlin/org/modelix/model/server/StoreClientWithStatistics.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/StoreClientWithStatistics.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server
+
+import org.modelix.model.server.store.IStoreClient
+import java.util.concurrent.atomic.AtomicLong
+
+class StoreClientWithStatistics(val store: IStoreClient) : IStoreClient by store {
+    private val totalRequests = AtomicLong()
+
+    fun getTotalRequests() = totalRequests.get()
+
+    override fun get(key: String): String? {
+        totalRequests.incrementAndGet()
+        return store.get(key)
+    }
+
+    override fun getAll(keys: List<String>): List<String?> {
+        totalRequests.incrementAndGet()
+        return store.getAll(keys)
+    }
+
+    override fun getAll(keys: Set<String>): Map<String, String?> {
+        totalRequests.incrementAndGet()
+        return store.getAll(keys)
+    }
+
+    override fun getAll(): Map<String, String?> {
+        totalRequests.incrementAndGet()
+        return store.getAll()
+    }
+}


### PR DESCRIPTION
All objects of the model were loaded individually from the database. These many small requests resulted in a poor performance when running a bulk sync on an existing large model. Batch requests are now used to reduce the overhead.