### PR TITLE
ci: bump node version in release workflow

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache Node packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache Node packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
semantic-release now requires at least version 20. Missed that when merging the bump PR with all the red from the invalid commit messages.