### PR TITLE
feat(model-server): make the Ignite cache size configurable

### DIFF
--- a/model-server/src/main/resources/org/modelix/model/server/store/database.properties
+++ b/model-server/src/main/resources/org/modelix/model/server/store/database.properties
@@ -3,3 +3,5 @@ jdbc.url=jdbc:postgresql://localhost:54333/
 jdbc.schema=modelix
 jdbc.user=modelix
 jdbc.pw=modelix
+# Size of the ignite cache in bytes. Defaults to 100 Mb.
+ignite.cache.size=104857600

--- a/model-server/src/main/resources/org/modelix/model/server/store/ignite.xml
+++ b/model-server/src/main/resources/org/modelix/model/server/store/ignite.xml
@@ -66,7 +66,7 @@
                 <!-- Redefining the default region's settings -->
                 <property name="defaultDataRegionConfiguration">
                     <bean class="org.apache.ignite.configuration.DataRegionConfiguration">
-                        <property name="maxSize" value="#{100L * 1024 * 1024}"/>
+                        <property name="maxSize" value="${ignite.cache.size}"/>
                         <!--<property name="evictionThreshold" value="0.5"/>-->
                         <property name="pageEvictionMode" value="RANDOM_LRU" />
                         <property name="emptyPagesPoolSize" value="2000" />


### PR DESCRIPTION
Adds the database JVM property ignite.cache.size, which can be used to control the off heap Ignite cache size when using Postgres as a backend. The property defaults to the previous 100 Mb size.

Using the properties was a lot easier than providing a custom command line argument with the existing Spring XML config property configuration. Moreover, this is also more consistent as all database-related settings are controlled via properties.

I have skipped adding documentation because of the coordinated effort for documenting the model-server configuration planned in https://issues.modelix.org/issue/MODELIX-575 .