### PR TITLE
fix(mps-model-adapters): do not fail when moving children in model

### DIFF
--- a/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelImporterUnorderedChildrenTest.kt
+++ b/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelImporterUnorderedChildrenTest.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.sync.bulk
+
+import org.junit.jupiter.api.Test
+import org.modelix.model.api.IBranch
+import org.modelix.model.api.INode
+import org.modelix.model.api.PBranch
+import org.modelix.model.api.SimpleChildLink
+import org.modelix.model.api.SimpleConcept
+import org.modelix.model.api.SimpleLanguage
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.data.ModelData
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.persistent.MapBasedStore
+import org.modelix.model.withAutoTransactions
+import kotlin.test.assertEquals
+
+class ModelImporterUnorderedChildrenTest {
+    object TestLanguage : SimpleLanguage("TestLanguage", uid = "testLanguage") {
+
+        override var includedConcepts = arrayOf<SimpleConcept>(AConcept)
+
+        object AConcept : SimpleConcept(
+            conceptName = "aConcept",
+            uid = "uid1",
+        ) {
+            init {
+                addConcept(this)
+                SimpleChildLink(
+                    simpleName = "aChildLink1",
+                    isMultiple = true,
+                    isOptional = true,
+                    isUnordered = true,
+                    targetConcept = AConcept,
+                    uid = "uid2",
+                ).also(this::addChildLink)
+                SimpleChildLink(
+                    simpleName = "aChildLink2",
+                    isMultiple = true,
+                    isOptional = true,
+                    isUnordered = true,
+                    targetConcept = AConcept,
+                    uid = "uid3",
+                ).also(this::addChildLink)
+            }
+        }
+    }
+
+    init {
+        TestLanguage.register()
+    }
+
+    private fun loadModelIntoBranch(modelData: ModelData): IBranch {
+        val store = ObjectStoreCache(MapBasedStore())
+        val tree = CLTree(
+            data = null,
+            repositoryId_ = null,
+            store_ = store,
+            useRoleIds = true,
+        )
+        val idGenerator = IdGenerator.getInstance(1)
+        val pBranch = PBranch(tree, idGenerator)
+
+        pBranch.runWrite {
+            modelData.load(pBranch)
+        }
+
+        return pBranch.withAutoTransactions()
+    }
+
+    @Test
+    fun `does not reorder children`() {
+        // language=json
+        val dataBeforeImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child3",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataBeforeImport = ModelData.fromJson(dataBeforeImportJson)
+        val branch = loadModelIntoBranch(dataBeforeImport)
+        val modelImporter = ModelImporter(branch.getRootNode())
+
+        // language=json
+        val dataToImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child4",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataToImport = ModelData.fromJson(dataToImportJson)
+        modelImporter.import(dataToImport)
+
+        val children = branch.getRootNode().allChildren.first().allChildren.toList()
+        // child1 and child 2 should not be reordered
+        // child3 is removed
+        // child4 is added at the end
+        assertEquals(listOf("child1", "child2", "child4"), children.map(INode::originalId))
+    }
+
+    @Test
+    fun `does not reorder children but change role`() {
+        // language=json
+        val dataBeforeImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child3",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataBeforeImport = ModelData.fromJson(dataBeforeImportJson)
+        val branch = loadModelIntoBranch(dataBeforeImport)
+        val modelImporter = ModelImporter(branch.getRootNode())
+
+        // language=json
+        val dataToImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child4",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid3"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataToImport = ModelData.fromJson(dataToImportJson)
+        modelImporter.import(dataToImport)
+
+        val children = branch.getRootNode().allChildren.first().allChildren.toList()
+        // child4 is added after existing child2
+        // child1 with the role "uid2" should be removed
+        // child1 with the role "uid3" should be added at the end
+        assertEquals(listOf("child2", "child4", "child1"), children.map(INode::originalId))
+        assertEquals("uid3", children[2].getContainmentLink()!!.getUID())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,3 +115,5 @@ modelix-buildtools-gradle = { group = "org.modelix.mps", name = "build-tools-gra
 modelix-buildtools-lib = { group = "org.modelix.mps", name = "build-tools-lib", version.ref = "modelixBuildtools"}
 
 micrometer-registry-prometheus = { group = "io.micrometer", name = "micrometer-registry-prometheus", version.ref = "micrometer"}
+
+mockk = { group = "io.mockk", name = "mockk", version = "1.13.9" }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
@@ -38,7 +38,11 @@ object BuiltinLanguages {
                 addConcept(this)
             }
 
-            val virtualPackage by property("ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1193676396447")
+            val virtualPackage = SimpleProperty(
+                "virtualPackage",
+                uid = "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1193676396447",
+            ).also(this::addProperty)
+
             val smodelAttribute by childLink("ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/5169995583184591170").multiple()
                 .optional().type { Attribute }
         }
@@ -63,7 +67,10 @@ object BuiltinLanguages {
 
         object INamedConcept : SimpleConcept(conceptName = "INamedConcept") {
             init { addConcept(this) }
-            val name by property("ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001")
+            val name = SimpleProperty(
+                "name",
+                uid = "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468/1169194664001",
+            ).also(this::addProperty)
         }
     }
 
@@ -88,8 +95,15 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val id by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/2615330535972958738")
-            val stereotype by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/3832696962605996173")
+            val id = SimpleProperty(
+                "id",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/2615330535972958738",
+            ).also(this::addProperty)
+
+            val stereotype = SimpleProperty(
+                "stereotype",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/3832696962605996173",
+            ).also(this::addProperty)
 
             val rootNodes = SimpleChildLink(
                 simpleName = "rootNodes",
@@ -121,9 +135,20 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val id by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/4225291329823310560")
-            val moduleVersion by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242370")
-            val compileInMPS by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242373")
+            val id = SimpleProperty(
+                "id",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/4225291329823310560",
+            ).also(this::addProperty)
+
+            val moduleVersion = SimpleProperty(
+                "moduleVersion",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242370",
+            ).also(this::addProperty)
+
+            val compileInMPS = SimpleProperty(
+                "compileInMPS",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242373",
+            ).also(this::addProperty)
 
             val models = SimpleChildLink(
                 simpleName = "models",
@@ -242,7 +267,10 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val virtualFolder by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/4201834143491306084/4201834143491306085")
+            val virtualFolder = SimpleProperty(
+                "virtualFolder",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/4201834143491306084/4201834143491306085",
+            ).also(this::addProperty)
         }
 
         object ModuleReference : SimpleConcept(
@@ -283,8 +311,15 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val uuid by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/8958347146611575311/8958347146611575314")
-            val name by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/8958347146611575311/8958347146611575315")
+            val uuid = SimpleProperty(
+                "uuid",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/8958347146611575311/8958347146611575314",
+            ).also(this::addProperty)
+
+            val name = SimpleProperty(
+                "name",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/8958347146611575311/8958347146611575315",
+            ).also(this::addProperty)
         }
 
         object SingleLanguageDependency : SimpleConcept(
@@ -294,7 +329,10 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val version by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242429/2206727074858242435")
+            val version = SimpleProperty(
+                "version",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242429/2206727074858242435",
+            ).also(this::addProperty)
         }
 
         object DevkitDependency : SimpleConcept(
@@ -320,8 +358,15 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val generated by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242406/2206727074858242407")
-            val path by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242406/2206727074858242409")
+            val generated = SimpleProperty(
+                "generated",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242406/2206727074858242407",
+            ).also(this::addProperty)
+
+            val path = SimpleProperty(
+                "path",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242406/2206727074858242409",
+            ).also(this::addProperty)
         }
 
         object ModuleDependency : SimpleConcept(
@@ -331,12 +376,35 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val reexport by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858242416")
-            val uuid by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858242418")
-            val name by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858242421")
-            val explicit by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858750565")
-            val version by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858750570")
-            val scope by property("0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/8438396892798826745")
+            val reexport = SimpleProperty(
+                "reexport",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858242416",
+            ).also(this::addProperty)
+
+            val uuid = SimpleProperty(
+                "uuid",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858242418",
+            ).also(this::addProperty)
+
+            val name = SimpleProperty(
+                "name",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858242421",
+            ).also(this::addProperty)
+
+            val explicit = SimpleProperty(
+                "explicit",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858750565",
+            ).also(this::addProperty)
+
+            val version = SimpleProperty(
+                "version",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/2206727074858750570",
+            ).also(this::addProperty)
+
+            val scope = SimpleProperty(
+                "scope",
+                uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/2206727074858242415/8438396892798826745",
+            ).also(this::addProperty)
         }
     }
 
@@ -368,7 +436,10 @@ object BuiltinLanguages {
         ) {
             init { addConcept(this) }
 
-            val id by property("b6980ebd-f01d-459d-a952-38740f6313b4/7113393488488348864/7113393488488348870")
+            val id = SimpleProperty(
+                "id",
+                uid = "b6980ebd-f01d-459d-a952-38740f6313b4/7113393488488348864/7113393488488348870",
+            ).also(this::addProperty)
 
             val branches = SimpleChildLink(
                 simpleName = "branches",
@@ -393,20 +464,6 @@ object BuiltinLanguages {
         MPSRepositoryConcepts,
         ModelixRuntimelang,
     )
-}
-
-private fun SimpleConcept.property(uid: String) = object {
-    private lateinit var name: String
-    private lateinit var owner: SimpleConcept
-    private val instance: IProperty by lazy {
-        SimpleProperty(name, uid = uid).also { owner.addProperty(it) }
-    }
-
-    operator fun getValue(ownerConcept: SimpleConcept, kotlinProperty: KProperty<*>): IProperty {
-        this.owner = ownerConcept
-        this.name = kotlinProperty.name
-        return instance
-    }
 }
 
 private fun SimpleConcept.childLink(uid: String) = object {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
@@ -16,8 +16,6 @@
 
 package org.modelix.model.api
 
-import kotlin.reflect.KProperty
-
 /**
  * TODO if you add a new Concept to a language, do not forget to add it to the language's included concepts field.
  * Otherwise the concept will not be eagerly added to the Language, when registering the language in the ILanguageRegistry.
@@ -43,8 +41,13 @@ object BuiltinLanguages {
                 uid = "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/1193676396447",
             ).also(this::addProperty)
 
-            val smodelAttribute by childLink("ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/5169995583184591170").multiple()
-                .optional().type { Attribute }
+            val smodelAttribute = SimpleChildLink(
+                simpleName = "smodelAttribute",
+                isMultiple = true,
+                isOptional = true,
+                targetConcept = Attribute,
+                uid = "ceab5195-25ea-4f22-9b92-103b95ca8c0c/1133920641626/5169995583184591170",
+            ).also(this::addChildLink)
         }
 
         object Attribute : SimpleConcept(
@@ -111,21 +114,23 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = jetbrains_mps_lang_core.BaseConcept,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/474657388638618900",
-            )
+            ).also(this::addChildLink)
+
             val modelImports = SimpleChildLink(
                 simpleName = "modelImports",
                 isMultiple = true,
                 isOptional = true,
                 targetConcept = ModelReference,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/6402965165736931000",
-            )
+            ).also(this::addChildLink)
+
             val usedLanguages = SimpleChildLink(
                 simpleName = "usedLanguages",
                 isMultiple = true,
                 isOptional = true,
                 targetConcept = SingleLanguageDependency,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618892/5381564949800872334",
-            )
+            ).also(this::addChildLink)
         }
 
         object Module : SimpleConcept(
@@ -156,28 +161,31 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = Model,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/474657388638618898",
-            )
+            ).also(this::addChildLink)
+
             val facets = SimpleChildLink(
                 simpleName = "facets",
                 isMultiple = true,
                 isOptional = true,
                 targetConcept = ModuleFacet,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242412",
-            )
+            ).also(this::addChildLink)
+
             val dependencies = SimpleChildLink(
                 simpleName = "dependencies",
                 isMultiple = true,
                 isOptional = true,
                 targetConcept = ModuleDependency,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242425",
-            )
+            ).also(this::addChildLink)
+
             val languageDependencies = SimpleChildLink(
                 simpleName = "languageDependencies",
                 isMultiple = true,
                 isOptional = true,
                 targetConcept = LanguageDependency,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618895/2206727074858242439",
-            )
+            ).also(this::addChildLink)
         }
 
         object Solution : SimpleConcept(
@@ -217,7 +225,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = Module,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618902/474657388638618903",
-            )
+            ).also(this::addChildLink)
 
             val projects = SimpleChildLink(
                 simpleName = "projects",
@@ -225,7 +233,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = Project,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618902/7064605579395546636",
-            )
+            ).also(this::addChildLink)
 
             val tempModules = SimpleChildLink(
                 simpleName = "tempModules",
@@ -233,7 +241,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = Module,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/474657388638618902/8226136427470548682",
-            )
+            ).also(this::addChildLink)
         }
 
         object Project : SimpleConcept(
@@ -249,7 +257,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = Module,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/4008363636171860313/4008363636171860450",
-            )
+            ).also(this::addChildLink)
 
             val projectModules = SimpleChildLink(
                 simpleName = "projectModules",
@@ -257,7 +265,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = ProjectModule,
                 uid = "0a7577d1-d4e5-431d-98b1-fae38f9aee80/4008363636171860313/4201834143491306088",
-            )
+            ).also(this::addChildLink)
         }
 
         object ProjectModule : SimpleConcept(
@@ -426,7 +434,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = RepositoryInfo,
                 uid = "b6980ebd-f01d-459d-a952-38740f6313b4/7113393488488348863/7113393488488348866",
-            )
+            ).also(this::addChildLink)
         }
 
         object RepositoryInfo : SimpleConcept(
@@ -447,7 +455,7 @@ object BuiltinLanguages {
                 isOptional = true,
                 targetConcept = BranchInfo,
                 uid = "b6980ebd-f01d-459d-a952-38740f6313b4/7113393488488348864/7113393488488348868",
-            )
+            ).also(this::addChildLink)
         }
 
         object BranchInfo : SimpleConcept(
@@ -464,33 +472,4 @@ object BuiltinLanguages {
         MPSRepositoryConcepts,
         ModelixRuntimelang,
     )
-}
-
-private fun SimpleConcept.childLink(uid: String) = object {
-    private lateinit var name: String
-    private lateinit var owner: SimpleConcept
-    private var multiple: Boolean = true
-    private var optional: Boolean = true
-    private lateinit var targetConcept: () -> IConcept
-    private val instance: IChildLink by lazy {
-        SimpleChildLink(
-            simpleName = name,
-            uid = uid,
-            isMultiple = multiple,
-            isOptional = optional,
-            targetConcept = targetConcept(),
-        ).also { owner.addChildLink(it) }
-    }
-
-    operator fun getValue(ownerConcept: SimpleConcept, kotlinProperty: KProperty<*>): IChildLink {
-        this.owner = ownerConcept
-        this.name = kotlinProperty.name
-        return instance
-    }
-
-    fun mandatory() = this.also { this.optional = false }
-    fun optional() = this.also { this.optional = true }
-    fun single() = this.also { this.multiple = false }
-    fun multiple() = this.also { this.multiple = true }
-    fun type(targetConcept: () -> IConcept) = also { this.targetConcept = targetConcept }
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
@@ -30,6 +30,15 @@ interface IChildLink : ILink {
     companion object {
         fun fromName(name: String): IChildLink = ChildLinkFromName(name)
     }
+
+    /**
+     * // TODO Olekz write why we need it.
+     * // TODO invert and rename "can be ordered".
+     * The order of elements contained by such children can be changed.
+     * The value is undefined for singular links.
+     */
+    val isUnordered
+        get() = false
 }
 
 data class ChildLinkFromName(override val name: String) : LinkFromName(), IChildLink {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
@@ -18,6 +18,7 @@ class SimpleChildLink(
     override val isMultiple: Boolean,
     override val isOptional: Boolean,
     override val targetConcept: IConcept,
+    override val isUnordered: Boolean = false,
     private val uid: String? = null,
 ) : IChildLink {
     var owner: SimpleConcept? = null

--- a/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
@@ -27,4 +27,11 @@ class BuiltinLanguagesTest {
 
         assertEquals(4, properties.size)
     }
+
+    @Test
+    fun childLinksAreAdded() {
+        val childLinks = BuiltinLanguages.MPSRepositoryConcepts.Model.getOwnChildLinks()
+
+        assertEquals(3, childLinks.size)
+    }
 }

--- a/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023-2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BuiltinLanguagesTest {
+
+    @Test
+    fun propertiesAreAdded() {
+        val properties = BuiltinLanguages.MPSRepositoryConcepts.Model.getAllProperties()
+
+        assertEquals(4, properties.size)
+    }
+}

--- a/mps-model-adapters/build.gradle.kts
+++ b/mps-model-adapters/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
 
 val mpsVersion = project.findProperty("mps.version")?.toString().takeIf { !it.isNullOrBlank() } ?: "2021.1.4"
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 dependencies {
     api(project(":model-api"))
 
@@ -15,6 +21,15 @@ dependencies {
 
     implementation(kotlin("stdlib"))
     implementation(libs.kotlin.logging)
+
+    testImplementation(libs.junit)
+    testImplementation(kotlin("test"))
+    testImplementation(libs.mockk)
+    testImplementation("com.jetbrains:mps-openapi:$mpsVersion")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 group = "org.modelix.mps"

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSChildLink.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSChildLink.kt
@@ -43,4 +43,8 @@ data class MPSChildLink(val link: SContainmentLinkAdapter) : IChildLink {
 
     override val isOptional: Boolean
         get() = link.isOptional
+
+    // TODO probably not needed
+    override val isUnordered: Boolean
+        get() = link.isUnordered
 }

--- a/mps-model-adapters/src/test/kotlin/org/modelix/model/mpsadapters/MPSModelAsNodeTest.kt
+++ b/mps-model-adapters/src/test/kotlin/org/modelix/model/mpsadapters/MPSModelAsNodeTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.mpsadapters
+
+import io.mockk.mockk
+import org.jetbrains.mps.openapi.model.SModel
+import org.modelix.model.api.BuiltinLanguages
+import org.modelix.model.api.INode
+import kotlin.test.Test
+
+class MPSModelAsNodeTest {
+
+    @Test
+    fun testMoveChildDoesNotFail() {
+        val sModel = mockk<SModel>()
+        val iNode = mockk<INode>()
+
+        val modelAdapter = MPSModelAsNode(sModel)
+
+        println(modelAdapter.concept)
+        println(modelAdapter.concept)
+        // Assert the move can be called safely
+        modelAdapter.moveChild(BuiltinLanguages.MPSRepositoryConcepts.Model.modelImports, -1, iNode)
+    }
+}


### PR DESCRIPTION
This is the specific fix with rudimentary testing.

I am working on setting up proper integration tests.
To achieve that, I am doing some exploration, and it will take longer than this fix.
See https://github.com/modelix/modelix.core/compare/main...MODELIX-742-integration-tests

I assume that `moveChild` might also cause issues in other implementations of `IDefaultNodeAdapter`.
Also, `addNewChild` seems broken and could affect the sync.
This also something I will test.