### PR TITLE
writing on ModelClientV2 failed when more than 10 changes were done

### DIFF
--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
@@ -373,7 +373,10 @@ private fun computeDelta(keyValueStore: IKeyValueStore, versionHash: String, bas
 
         // record read access on the version data itself
         val baseVersion = CLVersion(baseVersionHash, store)
-        baseVersion.operations
+
+        // The operations may not be available on the client, but then they don't need to be part of the delta anyway.
+        // Ignoring that case should be safe.
+        runCatching { baseVersion.operations }
 
         val oldTree = baseVersion.getTree()
         val bulkQuery = store.newBulkQuery()


### PR DESCRIPTION
A test in the legacy-sync-plugin at https://github.com/modelix/modelix.mps-plugins/blob/d88add8f9b275e63d8eade850947fe892ad1ce7f/mps-legacy-sync-plugin/src/test/kotlin/ProjectCanBeCopiedAndSyncOnCloudTest.kt#L117 failed with the following exception:

```
java.lang.RuntimeException: Entry FR7gq*m60NNRgYGjc4qAtd-ND9uZvJryjBiXAQwzsNFQ not found
	at org.modelix.model.lazy.WrittenEntry.getValue(WrittenEntry.kt:26)
	at org.modelix.model.lazy.KVEntryReference.getValue(KVEntryReference.kt:43)
	at org.modelix.model.lazy.CLVersion.getOperations(CLVersion.kt:156)
	at org.modelix.model.lazy.CLVersionKt$computeDelta$oldAndNewEntries$1.invoke(CLVersion.kt:334)
	at org.modelix.model.lazy.CLVersionKt$computeDelta$oldAndNewEntries$1.invoke(CLVersion.kt:302)
	at org.modelix.model.lazy.CLVersionKt.trackAccessedEntries(CLVersion.kt:397)
	at org.modelix.model.lazy.CLVersionKt.computeDelta(CLVersion.kt:302)
	at org.modelix.model.lazy.CLVersionKt.computeDelta(CLVersion.kt:294)
	at org.modelix.model.client2.ModelClientV2.push(ModelClientV2.kt:205)
	at org.modelix.model.client2.ModelClientV2Kt.runWrite(ModelClientV2.kt:531)
	at org.modelix.model.client2.ModelClientV2Kt$runWrite$1.invokeSuspend(ModelClientV2.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:280)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at io.ktor.server.testing.TestApplicationKt.testApplication(TestApplication.kt:329)
	at io.ktor.server.testing.TestApplicationKt.testApplication(TestApplication.kt:287)
	at SyncPluginTestBase.runTestWithModelServer(SyncPluginTestBase.kt:112)
	at SyncPluginTestBase.runTestWithSyncService(SyncPluginTestBase.kt:131)
	at ProjectCanBeCopiedAndSyncOnCloudTest.testInitialSyncToServer(ProjectCanBeCopiedAndSyncOnCloudTest.kt:38)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at com.intellij.testFramework.UsefulTestCase.lambda$runBare$11(UsefulTestCase.java:479)
	at com.intellij.testFramework.UsefulTestCase.runTestRunnable(UsefulTestCase.java:404)
	at com.intellij.testFramework.HeavyPlatformTestCase.runTestRunnable(HeavyPlatformTestCase.java:644)
	at com.intellij.testFramework.HeavyPlatformTestCase.lambda$runBareImpl$24(HeavyPlatformTestCase.java:567)
	at com.intellij.testFramework.HeavyPlatformTestCase.runBareRunnable(HeavyPlatformTestCase.java:613)
	at com.intellij.testFramework.HeavyPlatformTestCase.runBareImpl(HeavyPlatformTestCase.java:589)
	at com.intellij.testFramework.HeavyPlatformTestCase.lambda$runBare$22(HeavyPlatformTestCase.java:533)
	at com.intellij.testFramework.UsefulTestCase.lambda$wrapTestRunnable$13(UsefulTestCase.java:500)
	at com.intellij.testFramework.HeavyPlatformTestCase.runBare(HeavyPlatformTestCase.java:533)
	at com.intellij.testFramework.UsefulTestCase.runBare(UsefulTestCase.java:479)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy1/jdk.proxy1.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```