### PR TITLE
Add an option to eagerly warm up the Ignite cache on model-server start

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/CmdLineArgs.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/CmdLineArgs.kt
@@ -21,6 +21,9 @@ internal class CmdLineArgs {
     @Parameter(names = ["-inmemory", "--inmemory"], description = "Use in-memory storage", converter = BooleanConverter::class)
     var inmemory = false
 
+    @Parameter(names = ["--load-cache-on-start"], description = "Populate the Ignite cache on start. Blocks startup until the cache is warmed up.", converter = BooleanConverter::class)
+    var loadCacheOnStart = false
+
     @Parameter(names = ["--local-persistence"], description = "Use ignite with local disk persistence", converter = BooleanConverter::class)
     var localPersistence = false
 

--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -89,6 +89,7 @@ object Main {
         LOG.info("Max memory (bytes): " + Runtime.getRuntime().maxMemory())
         LOG.info("Server process started")
         LOG.info("In memory: " + cmdLineArgs.inmemory)
+        LOG.info("Load cache on start: " + cmdLineArgs.loadCacheOnStart)
         LOG.info("Path to secret file: " + cmdLineArgs.secretFile)
         LOG.info("Path to JDBC configuration file: " + cmdLineArgs.jdbcConfFile)
         LOG.info("Schema initialization: " + cmdLineArgs.schemaInit)
@@ -132,9 +133,14 @@ object Main {
                         )
                 }
             } else if (cmdLineArgs.localPersistence) {
+                // Loading the cache with an in-memory backend does not make much sense. Therefore, the option is
+                // ignored in this case.
                 storeClient = IgniteStoreClient(cmdLineArgs.jdbcConfFile, inmemory = true)
             } else {
-                storeClient = IgniteStoreClient(cmdLineArgs.jdbcConfFile)
+                storeClient = IgniteStoreClient(
+                    cmdLineArgs.jdbcConfFile,
+                    loadCacheOnStart = cmdLineArgs.loadCacheOnStart,
+                )
                 if (cmdLineArgs.schemaInit) {
                     val dataSource: DataSource = Ignition.loadSpringBean<DataSource>(
                         Main::class.java.getResource("ignite.xml"),

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
@@ -28,6 +28,15 @@ import java.util.stream.Collectors
 
 private val LOG = KotlinLogging.logger { }
 
+/**
+ * Instantiate an IgniteStoreClient
+ *
+ * @param jdbcConfFile adopt the configuration specified. If it is not specified, configuration
+ *                     from ignite.xml is used
+ * @param inmemory If true, an in-memory backend is used instead of connecting to a JDBC database.
+ * @param loadCacheOnStart If true, the configured Ignite cache is populated eagerly on start. This blocks the current
+ *                         thread until the cache is warmed up.
+ */
 class IgniteStoreClient(
     jdbcConfFile: File? = null,
     inmemory: Boolean = false,
@@ -40,12 +49,6 @@ class IgniteStoreClient(
         ignite.message().send(ENTRY_CHANGED_TOPIC, it)
     }
 
-    /**
-     * Istantiate an IgniteStoreClient
-     *
-     * @param jdbcConfFile adopt the configuration specified. If it is not specified, configuration
-     * from ignite.xml is used
-     */
     init {
         if (jdbcConfFile != null) {
             // Given that systemPropertiesMode is set to 2 (SYSTEM_PROPERTIES_MODE_OVERRIDE) in

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
@@ -33,7 +33,6 @@ class IgniteStoreClient(
     inmemory: Boolean = false,
     loadCacheOnStart: Boolean = false,
 ) : IStoreClient, AutoCloseable {
-    private val ENTRY_CHANGED_TOPIC = "entryChanged"
     private lateinit var ignite: Ignite
     private val cache: IgniteCache<String, String?>
     private val changeNotifier = ChangeNotifier(this)
@@ -169,6 +168,7 @@ class IgniteStoreClient(
 
     companion object {
         private val LOG = mu.KotlinLogging.logger {}
+        private const val ENTRY_CHANGED_TOPIC = "entryChanged"
     }
 }
 


### PR DESCRIPTION
Adds a command line option for controlling whether the ignite cache is populated eagerly on model-server start. When enabled, the model-server only becomes responsive once the cache is populated from the database.

This option is implemented as populating the cache this way is a lot faster than pulling a branch at the moment. For instance, in one project, populating the cache using the loadCache method takes only a about 20 seconds whereas pulling the data using the REST API as a means of warming up the cache takes about 13 minutes.