### PR TITLE
Introduce ordered property for child links

### DIFF
--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -154,7 +154,12 @@ class ModelImporter(private val root: INode, private val continueOnError: Boolea
                         originalIdToExisting[expectedId] = newChild
                         newChild
                     } else {
+                        // The existing child node is not only moved to a new index,
+                        // it is potentially moved to a new parent and role.
                         node.moveChild(role, index, existingNode)
+                        // If the old parent and old role synchronized before the move operation,
+                        // the existing child node would have been marked as to be deleted.
+                        // Now that it is used, it should not be deleted.
                         nodesToRemove.remove(existingNode)
                         existingNode
                     }
@@ -166,6 +171,9 @@ class ModelImporter(private val root: INode, private val continueOnError: Boolea
                 syncNode(childNode, expected, progressReporter)
             }
 
+            // At this point, all n expected children for this role are created and correctly sorted.
+            // This means the first n children are correct.
+            // Any child beyond that is an unexpected child has to be marked for removal.
             nodesToRemove += node.getChildren(role).drop(expectedNodes.size)
         }
     }

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -23,6 +23,7 @@ import org.modelix.model.api.INodeReference
 import org.modelix.model.api.INodeResolutionScope
 import org.modelix.model.api.SerializedNodeReference
 import org.modelix.model.api.getDescendants
+import org.modelix.model.api.isChildRoleOrdered
 import org.modelix.model.api.remove
 import org.modelix.model.data.ModelData
 import org.modelix.model.data.NodeData
@@ -118,15 +119,15 @@ class ModelImporter(private val root: INode, private val continueOnError: Boolea
         }
     }
 
-    private fun syncChildren(node: INode, data: NodeData, progressReporter: ProgressReporter) {
-        val allRoles = (data.children.map { it.role } + node.allChildren.map { it.roleInParent }).distinct()
+    private fun syncChildren(existingParent: INode, expectedParent: NodeData, progressReporter: ProgressReporter) {
+        val allRoles = (expectedParent.children.map { it.role } + existingParent.allChildren.map { it.roleInParent }).distinct()
         for (role in allRoles) {
-            val expectedNodes = data.children.filter { it.role == role }
-            val existingNodes = node.getChildren(role).toList()
+            val expectedNodes = expectedParent.children.filter { it.role == role }
+            val existingNodes = existingParent.getChildren(role).toList()
 
             // optimization that uses the bulk operation .addNewChildren
             if (existingNodes.isEmpty() && expectedNodes.all { originalIdToExisting[it.originalId()] == null }) {
-                node.addNewChildren(role, -1, expectedNodes.map { it.concept?.let { ConceptReference(it) } }).zip(expectedNodes).forEach { (newChild, expected) ->
+                existingParent.addNewChildren(role, -1, expectedNodes.map { it.concept?.let { ConceptReference(it) } }).zip(expectedNodes).forEach { (newChild, expected) ->
                     val expectedId = checkNotNull(expected.originalId()) { "Specified node '$expected' has no id" }
                     newChild.setPropertyValue(NodeData.idPropertyKey, expectedId)
                     originalIdToExisting[expectedId] = newChild
@@ -142,21 +143,38 @@ class ModelImporter(private val root: INode, private val continueOnError: Boolea
                 continue
             }
 
-            expectedNodes.forEachIndexed { index, expected ->
-                val nodeAtIndex = node.getChildren(role).toList().getOrNull(index)
+            val isOrdered = existingParent.isChildRoleOrdered(role)
+
+            expectedNodes.forEachIndexed { indexInImport, expected ->
+                val existingChildren = existingParent.getChildren(role).toList()
                 val expectedId = checkNotNull(expected.originalId()) { "Specified node '$expected' has no id" }
+                // newIndex is the index on which to import the expected child.
+                // It might be -1 if the child does not exist and should be added at the end.
+                val newIndex = if (isOrdered) {
+                    indexInImport
+                } else {
+                    // The `existingChildren` are only searched once for the expected element before changing.
+                    // Therefore, indexing existing children will not be more efficient than iterating once.
+                    // (For the moment, this is fine because as we expect unordered children to be the exception,
+                    // Reusable indexing would be possible if we switch from
+                    // a depth-first import to a breadth-first import.)
+                    existingChildren
+                        .indexOfFirst { existingChild -> existingChild.originalId() == expected.originalId() }
+                }
+                // existingChildren.getOrNull handles `-1` as needed by returning `null`.
+                val nodeAtIndex = existingChildren.getOrNull(newIndex)
                 val expectedConcept = expected.concept?.let { s -> ConceptReference(s) }
                 val childNode = if (nodeAtIndex?.originalId() != expectedId) {
                     val existingNode = originalIdToExisting[expectedId]
                     if (existingNode == null) {
-                        val newChild = node.addNewChild(role, index, expectedConcept)
+                        val newChild = existingParent.addNewChild(role, newIndex, expectedConcept)
                         newChild.setPropertyValue(NodeData.idPropertyKey, expectedId)
                         originalIdToExisting[expectedId] = newChild
                         newChild
                     } else {
                         // The existing child node is not only moved to a new index,
                         // it is potentially moved to a new parent and role.
-                        node.moveChild(role, index, existingNode)
+                        existingParent.moveChild(role, newIndex, existingNode)
                         // If the old parent and old role synchronized before the move operation,
                         // the existing child node would have been marked as to be deleted.
                         // Now that it is used, it should not be deleted.
@@ -171,10 +189,10 @@ class ModelImporter(private val root: INode, private val continueOnError: Boolea
                 syncNode(childNode, expected, progressReporter)
             }
 
-            // At this point, all n expected children for this role are created and correctly sorted.
-            // This means the first n children are correct.
-            // Any child beyond that is an unexpected child has to be marked for removal.
-            nodesToRemove += node.getChildren(role).drop(expectedNodes.size)
+            val expectedNodesIds = expectedNodes.map(NodeData::originalId).toSet()
+            // Do not use existingNodes, but call node.getChildren(role) because
+            // the recursive synchronization in the meantime already removed some nodes from node.getChildren(role).
+            nodesToRemove += existingParent.getChildren(role).filterNot { existingNode -> expectedNodesIds.contains(existingNode.originalId()) }
         }
     }
 

--- a/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelImporterOrderPropertyTest.kt
+++ b/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelImporterOrderPropertyTest.kt
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.sync.bulk
+
+import org.junit.jupiter.api.Test
+import org.modelix.model.api.IBranch
+import org.modelix.model.api.INode
+import org.modelix.model.api.PBranch
+import org.modelix.model.api.SimpleChildLink
+import org.modelix.model.api.SimpleConcept
+import org.modelix.model.api.SimpleLanguage
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.data.ModelData
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.persistent.MapBasedStore
+import org.modelix.model.withAutoTransactions
+import kotlin.test.assertEquals
+
+/**
+ * Tests the parts of the import algorithm,
+ * that checks whether is a child node is in an ordered or unordered role
+ * and that handles the importing children with of unordered roles.
+ */
+class ModelImporterOrderPropertyTest {
+    object TestLanguage : SimpleLanguage("TestLanguage", uid = "testLanguage") {
+
+        override var includedConcepts = arrayOf<SimpleConcept>(AConcept)
+
+        object AConcept : SimpleConcept(
+            conceptName = "aConcept",
+            uid = "uid1",
+        ) {
+            // The child links in this concept are special, because they are unordered.
+            val childLink1 = SimpleChildLink(
+                simpleName = "aChildLink1",
+                isMultiple = true,
+                isOptional = true,
+                isOrdered = false,
+                targetConcept = AConcept,
+                uid = "uid2",
+            ).also(this::addChildLink)
+
+            val childLink2 = SimpleChildLink(
+                simpleName = "aChildLink2",
+                isMultiple = true,
+                isOptional = true,
+                isOrdered = false,
+                targetConcept = AConcept,
+                uid = "uid3",
+            ).also(this::addChildLink)
+
+            init {
+                addConcept(this)
+            }
+        }
+    }
+
+    init {
+        TestLanguage.register()
+    }
+
+    private fun loadModelIntoBranch(modelData: ModelData): IBranch {
+        val store = ObjectStoreCache(MapBasedStore())
+        val tree = CLTree(
+            data = null,
+            repositoryId_ = null,
+            store_ = store,
+            useRoleIds = true,
+        )
+        val idGenerator = IdGenerator.getInstance(1)
+        val pBranch = PBranch(tree, idGenerator)
+
+        pBranch.runWrite {
+            modelData.load(pBranch)
+        }
+
+        return pBranch.withAutoTransactions()
+    }
+
+    @Test
+    fun `nodes in unordered child link are added and removed`() {
+        // language=json
+        val dataBeforeImportJson = """
+        {
+          "root": {
+            "id": "root1",
+            "children": [
+              {
+                "id": "parent1",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child3",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataBeforeImport = ModelData.fromJson(dataBeforeImportJson)
+        val branch = loadModelIntoBranch(dataBeforeImport)
+        val modelImporter = ModelImporter(branch.getRootNode())
+
+        // language=json
+        val dataToImportJson = """
+        {
+          "root": {
+            "id": "root1",
+            "children": [
+              {
+                "id": "parent1",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child4",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataToImport = ModelData.fromJson(dataToImportJson)
+        modelImporter.import(dataToImport)
+
+        val childIds = branch.getRootNode().allChildren.single()
+            .getChildren(TestLanguage.AConcept.childLink1).toList()
+            .map(INode::originalId).toSet()
+        // child3 is removed
+        // child4 is added
+        assertEquals(setOf("child1", "child2", "child4"), childIds)
+    }
+
+    @Test
+    fun `nodes in unordered child link can change child link inside same parent`() {
+        // language=json
+        val dataBeforeImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "id": "parent1",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataBeforeImport = ModelData.fromJson(dataBeforeImportJson)
+        val branch = loadModelIntoBranch(dataBeforeImport)
+        val modelImporter = ModelImporter(branch.getRootNode())
+
+        // language=json
+        val dataToImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "id": "parent1",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid3"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataToImport = ModelData.fromJson(dataToImportJson)
+        modelImporter.import(dataToImport)
+
+        val parent = branch.getRootNode().allChildren.single()
+        val childLink1NodeIds = parent.getChildren(TestLanguage.AConcept.childLink1).toList()
+            .map(INode::originalId).toSet()
+        val childLink2NodesIds = parent.getChildren(TestLanguage.AConcept.childLink2).toList()
+            .map(INode::originalId).toSet()
+        assertEquals(setOf("child2"), childLink1NodeIds)
+        // child1 moved from childLink1Nodes to childLink2Nodes
+        assertEquals(setOf("child1"), childLink2NodesIds)
+    }
+
+    @Test
+    fun `nodes in unordered child link can change parent`() {
+        // language=json
+        val dataBeforeImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "id": "parent1",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              },
+              {
+                "id": "parent2",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataBeforeImport = ModelData.fromJson(dataBeforeImportJson)
+        val branch = loadModelIntoBranch(dataBeforeImport)
+        val modelImporter = ModelImporter(branch.getRootNode())
+
+        // language=json
+        val dataToImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "id": "parent1",
+                "concept": "uid1",
+                "children": [
+                  {
+                    "id": "child1",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  },
+                  {
+                    "id": "child2",
+                    "concept": "uid1",
+                    "role": "uid2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataToImport = ModelData.fromJson(dataToImportJson)
+        modelImporter.import(dataToImport)
+
+        val childNodeIds = branch.getRootNode().allChildren.single()
+            .getChildren(TestLanguage.AConcept.childLink1).toList()
+            .map(INode::originalId).toSet()
+        // child1 and child2 have now in the same parent
+        assertEquals(setOf("child1", "child2"), childNodeIds)
+    }
+
+    @Test
+    fun `children without resolvable role are ordered`() {
+        // language=json
+        val dataBeforeImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "id": "child1",
+                "role": "unknownRole"
+              },
+              {
+                "id": "child2",
+                "role": "unknownRole"
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataBeforeImport = ModelData.fromJson(dataBeforeImportJson)
+        val branch = loadModelIntoBranch(dataBeforeImport)
+        val modelImporter = ModelImporter(branch.getRootNode())
+
+        // language=json
+        val dataToImportJson = """
+        {
+          "root": {
+            "children": [
+              {
+                "id": "child2",
+                "role": "unknownRole"
+              },
+              {
+                "id": "child1",
+                "role": "unknownRole"
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+        val dataToImport = ModelData.fromJson(dataToImportJson)
+        modelImporter.import(dataToImport)
+
+        val childIdsOrdered = branch.getRootNode().getChildren("unknownRole").toList()
+            .map(INode::originalId)
+
+        // For child1 and child 2 their role cannot be resolved.
+        // Therefore, they are reordered.
+        assertEquals(listOf("child2", "child1"), childIdsOrdered)
+    }
+}

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
@@ -30,6 +30,16 @@ interface IChildLink : ILink {
     companion object {
         fun fromName(name: String): IChildLink = ChildLinkFromName(name)
     }
+
+    /**
+     * Whether children with this role are returned in a meaningful order and whether they are allowed to be reordered.
+     *
+     * Children returned for an unordered role might be returned in a different order in subsequent request.
+     * If a child role is not ordered, implementations of [[INode.moveChild]] are allowed to fail
+     * when instructed to move a node in between existing nodes.
+     */
+    val isOrdered
+        get() = true
 }
 
 data class ChildLinkFromName(override val name: String) : LinkFromName(), IChildLink {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -380,6 +380,21 @@ fun INode.tryResolveProperty(role: String): IProperty? {
         ?: allLinks.find { it.getSimpleName() == role }
         ?: allLinks.find { it.getUID() == role }
 }
+
+/**
+ * Resolves whether the child link is ordered or not.
+ *
+ * Assume children to be ordered by default.
+ * Unordered children are the special case that can be declared by setting [[IChildLink.isOrdered]] to `false`.
+ */
+fun INode.isChildRoleOrdered(role: String?): Boolean {
+    return if (role == null) {
+        true
+    } else {
+        this.tryResolveChildLink(role)?.isOrdered ?: true
+    }
+}
+
 fun INode.resolvePropertyOrFallback(role: String): IProperty {
     return tryResolveProperty(role) ?: IProperty.fromName(role)
 }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
@@ -19,6 +19,7 @@ class SimpleChildLink(
     override val isOptional: Boolean,
     override val targetConcept: IConcept,
     private val uid: String? = null,
+    override val isOrdered: Boolean = true,
 ) : IChildLink {
     var owner: SimpleConcept? = null
     override val childConcept: IConcept = targetConcept


### PR DESCRIPTION
Child links that are unordered are handled specially when importing using the bulk-model-sync. 
 Such unordered children are not being reorder in when imported.