### PR TITLE
MODELIX-752 Improve model-server query performance by caching the model in memory

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -44,6 +44,8 @@ interface INode {
      */
     val concept: IConcept?
 
+    fun tryGetConcept(): IConcept? = getConceptReference()?.tryResolve()
+
     /**
      * Role of this node in its parent node if it exists,or null otherwise.
      */
@@ -329,11 +331,7 @@ fun INode.resolveProperty(role: String): IProperty {
  *         or null, if this concept has no child link or an exception was thrown during concept resolution
  */
 fun INode.tryResolveChildLink(role: String): IChildLink? {
-    val c = try {
-        this.concept ?: return null
-    } catch (e: RuntimeException) {
-        return null
-    }
+    val c = this.tryGetConcept() ?: return null
     val allLinks = c.getAllChildLinks()
     return allLinks.find { it.key(this) == role }
         ?: allLinks.find { it.getSimpleName() == role }
@@ -350,11 +348,7 @@ fun INode.resolveChildLinkOrFallback(role: String?): IChildLink {
  *         or null, if this node has no reference link or an exception was thrown during concept resolution
  */
 fun INode.tryResolveReferenceLink(role: String): IReferenceLink? {
-    val c = try {
-        this.concept ?: return null
-    } catch (e: RuntimeException) {
-        return null
-    }
+    val c = this.tryGetConcept() ?: return null
     val allLinks = c.getAllReferenceLinks()
     return allLinks.find { it.key(this) == role }
         ?: allLinks.find { it.getSimpleName() == role }
@@ -370,11 +364,7 @@ fun INode.resolveReferenceLinkOrFallback(role: String): IReferenceLink {
  *         or null, if this node has no concept or an exception was thrown during concept resolution
  */
 fun INode.tryResolveProperty(role: String): IProperty? {
-    val c = try {
-        this.concept ?: return null
-    } catch (e: RuntimeException) {
-        return null
-    }
+    val c = this.tryGetConcept() ?: return null
     val allLinks = c.getAllProperties()
     return allLinks.find { it.key(this) == role }
         ?: allLinks.find { it.getSimpleName() == role }
@@ -417,4 +407,3 @@ fun INode.getContainmentLink() = if (this is INodeEx) {
 fun INode.getRoot(): INode = parent?.getRoot() ?: this
 fun INode.isInstanceOf(superConcept: IConcept?): Boolean = concept.let { it != null && it.isSubConceptOf(superConcept) }
 fun INode.isInstanceOfSafe(superConcept: IConcept): Boolean = tryGetConcept()?.isSubConceptOf(superConcept) ?: false
-fun INode.tryGetConcept(): IConcept? = getConceptReference()?.tryResolve()

--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
 //                implementation("org.json:json:20230618")
                 implementation(libs.trove4j)
                 implementation(libs.apache.commons.collections)
+                implementation(libs.kotlin.coroutines.core)
 //
 //                implementation("com.google.oauth-client:google-oauth-client:1.34.1")
 //                implementation("com.google.oauth-client:google-oauth-client-jetty:1.34.1")

--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
 //                implementation(libs.guava)
 //                implementation(libs.apache.commons.io)
 //                implementation("org.json:json:20230618")
-//                implementation(libs.trove4j)
+                implementation(libs.trove4j)
                 implementation(libs.apache.commons.collections)
 //
 //                implementation("com.google.oauth-client:google-oauth-client:1.34.1")

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/BulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/BulkQuery.kt
@@ -53,7 +53,7 @@ class BulkQuery(private val store: IDeserializingKeyValueStore) : IBulkQuery {
         return Value(value)
     }
 
-    fun process() {
+    override fun process() {
         if (processing) {
             throw RuntimeException("Already processing")
         }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
@@ -444,7 +444,7 @@ class CLTree : ITree, IBulkTree {
                     return changesOnly
                 }
 
-                override fun entryAdded(key: Long, value: KVEntryReference<CPNode>?) {
+                override fun entryAdded(key: Long, value: KVEntryReference<CPNode>) {
                     if (visitor is ITreeChangeVisitorEx) {
                         createElement(value, bulkQuery).map { element ->
                             visitor.nodeAdded(element!!.id)
@@ -452,7 +452,7 @@ class CLTree : ITree, IBulkTree {
                     }
                 }
 
-                override fun entryRemoved(key: Long, value: KVEntryReference<CPNode>?) {
+                override fun entryRemoved(key: Long, value: KVEntryReference<CPNode>) {
                     if (visitor is ITreeChangeVisitorEx) {
                         oldVersion.createElement(value, bulkQuery).map { element ->
                             visitor.nodeRemoved(element!!.id)
@@ -460,7 +460,7 @@ class CLTree : ITree, IBulkTree {
                     }
                 }
 
-                override fun entryChanged(key: Long, oldValue: KVEntryReference<CPNode>?, newValue: KVEntryReference<CPNode>?) {
+                override fun entryChanged(key: Long, oldValue: KVEntryReference<CPNode>, newValue: KVEntryReference<CPNode>) {
                     oldVersion.createElement(oldValue, bulkQuery).map { oldElement ->
                         createElement(newValue, bulkQuery).map { newElement ->
                             if (oldElement!!::class != newElement!!::class) {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
@@ -344,19 +344,19 @@ private fun computeDelta(keyValueStore: IKeyValueStore, versionHash: String, bas
                 oldTree.nodesMap!!,
                 object : CPHamtNode.IChangeVisitor {
                     override fun visitChangesOnly(): Boolean = false
-                    override fun entryAdded(key: Long, value: KVEntryReference<CPNode>?) {
+                    override fun entryAdded(key: Long, value: KVEntryReference<CPNode>) {
                         changedNodeIds += key
                         if (value != null) bulkQuery.get(value)
                     }
 
-                    override fun entryRemoved(key: Long, value: KVEntryReference<CPNode>?) {
+                    override fun entryRemoved(key: Long, value: KVEntryReference<CPNode>) {
                         changedNodeIds += key
                     }
 
                     override fun entryChanged(
                         key: Long,
-                        oldValue: KVEntryReference<CPNode>?,
-                        newValue: KVEntryReference<CPNode>?,
+                        oldValue: KVEntryReference<CPNode>,
+                        newValue: KVEntryReference<CPNode>,
                     ) {
                         changedNodeIds += key
                         if (newValue != null) bulkQuery.get(newValue)

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
@@ -18,6 +18,7 @@ package org.modelix.model.lazy
 import org.modelix.model.persistent.IKVValue
 
 interface IBulkQuery {
+    fun process()
     fun <I, O> map(input_: Iterable<I>, f: (I) -> Value<O>): Value<List<O>>
     fun <T> constant(value: T): Value<T>
     operator fun <T : IKVValue> get(hash: KVEntryReference<T>): Value<T?>

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonBulkQuery.kt
@@ -31,6 +31,10 @@ class NonBulkQuery(private val store: IDeserializingKeyValueStore) : IBulkQuery 
         return constant(hash.getValue(store))
     }
 
+    override fun process() {
+        // all requests are processed immediately
+    }
+
     class Value<T>(private val value: T) : IBulkQuery.Value<T> {
         override fun execute(): T {
             return value

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonCachingObjectStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonCachingObjectStore.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.lazy
+
+import org.modelix.model.IKeyValueStore
+
+class NonCachingObjectStore(override val keyValueStore: IKeyValueStore) : IDeserializingKeyValueStore {
+
+    override fun <T> getAll(hashes_: Iterable<String>, deserializer: (String, String) -> T): Iterable<T> {
+        val hashes = hashes_.toList()
+        val serialized: Map<String, String?> = keyValueStore.getAll(hashes_)
+        return hashes.map { hash ->
+            val value = checkNotNull(serialized[hash]) { "Entry not found: $hash" }
+            deserializer(hash, value)
+        }
+    }
+
+    override fun <T> get(hash: String, deserializer: (String) -> T): T? {
+        return keyValueStore.get(hash)?.let(deserializer)
+    }
+
+    override fun put(hash: String, deserialized: Any, serialized: String) {
+        keyValueStore.put(hash, serialized)
+    }
+
+    override fun prefetch(hash: String) {
+        keyValueStore.prefetch(hash)
+    }
+}

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtInternal.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtInternal.kt
@@ -169,7 +169,7 @@ class CPHamtInternal(
         return create(newBitmap, newChildren)
     }
 
-    override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>?) -> Unit): IBulkQuery.Value<Unit> {
+    override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>) -> Unit): IBulkQuery.Value<Unit> {
         return bulkQuery.map(data.children.asIterable()) { bulkQuery.get(it) }.mapBulk { children ->
             bulkQuery.map(children) { it!!.visitEntries(bulkQuery, visitor) }.map { }
         }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtLeaf.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtLeaf.kt
@@ -67,7 +67,7 @@ class CPHamtLeaf(
         return bulkQuery.constant(if (key == this.key) value else null)
     }
 
-    override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>?) -> Unit): IBulkQuery.Value<Unit> {
+    override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>) -> Unit): IBulkQuery.Value<Unit> {
         return bulkQuery.constant(visitor(key, value))
     }
 
@@ -83,17 +83,18 @@ class CPHamtLeaf(
             }
         } else {
             var oldValue: KVEntryReference<CPNode>? = null
-            val bp = { k: Long?, v: KVEntryReference<CPNode>? ->
+            val bp = { k: Long, v: KVEntryReference<CPNode> ->
                 if (k == key) {
                     oldValue = v
                 } else {
-                    visitor.entryRemoved(k!!, v)
+                    visitor.entryRemoved(k, v)
                 }
             }
             oldNode!!.visitEntries(bulkQuery, bp).onSuccess {
+                val oldValue = oldValue
                 if (oldValue == null) {
                     visitor.entryAdded(key, value)
-                } else if (oldValue?.getHash() !== value.getHash()) {
+                } else if (oldValue.getHash() !== value.getHash()) {
                     visitor.entryChanged(key, oldValue, value)
                 }
             }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
@@ -69,14 +69,14 @@ abstract class CPHamtNode : IKVValue {
     abstract fun get(key: Long, shift: Int, bulkQuery: IBulkQuery): IBulkQuery.Value<KVEntryReference<CPNode>?>
     abstract fun put(key: Long, value: KVEntryReference<CPNode>?, shift: Int, store: IDeserializingKeyValueStore): CPHamtNode?
     abstract fun remove(key: Long, shift: Int, store: IDeserializingKeyValueStore): CPHamtNode?
-    abstract fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>?) -> Unit): IBulkQuery.Value<Unit>
+    abstract fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>) -> Unit): IBulkQuery.Value<Unit>
     abstract fun visitChanges(oldNode: CPHamtNode?, shift: Int, visitor: IChangeVisitor, bulkQuery: IBulkQuery)
     fun visitChanges(oldNode: CPHamtNode?, visitor: IChangeVisitor, bulkQuery: IBulkQuery) = visitChanges(oldNode, 0, visitor, bulkQuery)
     interface IChangeVisitor {
         fun visitChangesOnly(): Boolean
-        fun entryAdded(key: Long, value: KVEntryReference<CPNode>?)
-        fun entryRemoved(key: Long, value: KVEntryReference<CPNode>?)
-        fun entryChanged(key: Long, oldValue: KVEntryReference<CPNode>?, newValue: KVEntryReference<CPNode>?)
+        fun entryAdded(key: Long, value: KVEntryReference<CPNode>)
+        fun entryRemoved(key: Long, value: KVEntryReference<CPNode>)
+        fun entryChanged(key: Long, oldValue: KVEntryReference<CPNode>, newValue: KVEntryReference<CPNode>)
     }
 
     companion object {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtSingle.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtSingle.kt
@@ -112,7 +112,7 @@ class CPHamtSingle(
         return bulkQuery[child].map { childData -> childData!! }
     }
 
-    override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>?) -> Unit): IBulkQuery.Value<Unit> {
+    override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>) -> Unit): IBulkQuery.Value<Unit> {
         return getChild(bulkQuery).mapBulk { it.visitEntries(bulkQuery, visitor) }
     }
 

--- a/model-datastructure/src/jvmMain/kotlin/org/modelix/model/InMemoryModel.kt
+++ b/model-datastructure/src/jvmMain/kotlin/org/modelix/model/InMemoryModel.kt
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model
+
+import gnu.trove.map.TLongObjectMap
+import gnu.trove.map.hash.TLongObjectHashMap
+import org.modelix.model.api.ConceptReference
+import org.modelix.model.api.IBranch
+import org.modelix.model.api.IConcept
+import org.modelix.model.api.IConceptReference
+import org.modelix.model.api.ILanguageRepository
+import org.modelix.model.api.INode
+import org.modelix.model.api.INodeReference
+import org.modelix.model.api.ITree
+import org.modelix.model.api.NodeReference
+import org.modelix.model.api.PNodeReference
+import org.modelix.model.api.resolveInCurrentContext
+import org.modelix.model.area.IArea
+import org.modelix.model.area.IAreaListener
+import org.modelix.model.area.IAreaReference
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.KVEntryReference
+import org.modelix.model.lazy.NonCachingObjectStore
+import org.modelix.model.persistent.CPHamtNode
+import org.modelix.model.persistent.CPNode
+import org.modelix.model.persistent.CPNodeRef
+import kotlin.system.measureTimeMillis
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
+
+private val LOG = mu.KotlinLogging.logger { }
+
+class IncrementalInMemoryModel {
+    private var lastModel: InMemoryModel? = null
+
+    @Synchronized
+    fun getModel(tree: CLTree): InMemoryModel {
+        val reusable = lastModel?.takeIf { it.branchId == tree.getId() }
+        val newModel = if (reusable == null) {
+            InMemoryModel.load(tree)
+        } else {
+            reusable.loadIncremental(tree)
+        }
+        lastModel = newModel
+        return newModel
+    }
+}
+
+class InMemoryModel private constructor(
+    val branchId: String,
+    val loadedMapRef: KVEntryReference<CPHamtNode>,
+    val nodeMap: TLongObjectMap<CPNode>,
+) {
+
+    companion object {
+        fun load(tree: CLTree): InMemoryModel {
+            return load(tree.getId(), tree.data.idToHash, tree.store.keyValueStore)
+        }
+
+        fun load(branchId: String, slowMapRef: KVEntryReference<CPHamtNode>, store: IKeyValueStore): InMemoryModel {
+            val fastMap: TLongObjectMap<CPNode> = TLongObjectHashMap()
+            val bulkQuery = NonCachingObjectStore(store).newBulkQuery()
+            LOG.info { "Start loading model into memory" }
+            val duration = measureTimeMillis {
+                bulkQuery.get(slowMapRef).onSuccess { slowMap ->
+                    slowMap!!.visitEntries(bulkQuery) { nodeId, nodeDataRef ->
+                        bulkQuery.get(nodeDataRef).onSuccess { nodeData ->
+                            if (nodeData != null) {
+                                fastMap.put(nodeId, nodeData)
+                            }
+                        }
+                    }
+                }
+                bulkQuery.process()
+            }.milliseconds
+            LOG.info { "Done loading model into memory after ${duration.toDouble(DurationUnit.SECONDS)} s" }
+            return InMemoryModel(branchId, slowMapRef, fastMap)
+        }
+    }
+
+    fun loadIncremental(tree: CLTree): InMemoryModel {
+        return loadIncremental(tree.data.idToHash, tree.store.keyValueStore)
+    }
+    fun loadIncremental(slowMapRef: KVEntryReference<CPHamtNode>, store: IKeyValueStore): InMemoryModel {
+        if (slowMapRef.getHash() == loadedMapRef.getHash()) return this
+
+        val fastMap: TLongObjectMap<CPNode> = TLongObjectHashMap()
+        val bulkQuery = NonCachingObjectStore(store).newBulkQuery()
+        LOG.debug { "Model update started" }
+        fastMap.putAll(nodeMap)
+        val duration = measureTimeMillis {
+            bulkQuery.map(listOf(slowMapRef, loadedMapRef)) { bulkQuery.get(it) }.onSuccess {
+                val newSlowMap = it[0]!!
+                val oldSlowMap = it[1]!!
+                newSlowMap.visitChanges(
+                    oldSlowMap,
+                    object : CPHamtNode.IChangeVisitor {
+                        override fun visitChangesOnly(): Boolean = false
+                        override fun entryAdded(key: Long, value: KVEntryReference<CPNode>) {
+                            bulkQuery.get(value).onSuccess { nodeData ->
+                                if (nodeData != null) {
+                                    fastMap.put(key, nodeData)
+                                }
+                            }
+                        }
+                        override fun entryRemoved(key: Long, value: KVEntryReference<CPNode>) {
+                            fastMap.remove(key)
+                        }
+                        override fun entryChanged(
+                            key: Long,
+                            oldValue: KVEntryReference<CPNode>,
+                            newValue: KVEntryReference<CPNode>,
+                        ) {
+                            bulkQuery.get(newValue).onSuccess { nodeData ->
+                                if (nodeData != null) {
+                                    fastMap.put(key, nodeData)
+                                }
+                            }
+                        }
+                    },
+                    bulkQuery,
+                )
+            }
+            bulkQuery.process()
+        }.milliseconds
+        LOG.info { "Done updating model after ${duration.toDouble(DurationUnit.SECONDS)} s" }
+        return InMemoryModel(branchId, slowMapRef, fastMap)
+    }
+
+    fun getNodeData(nodeId: Long): CPNode = nodeMap.get(nodeId)
+    fun getNode(nodeId: Long): InMemoryNode = InMemoryNode(this, nodeId)
+
+    fun getArea() = Area()
+
+    inner class Area : IArea {
+        override fun getRoot(): INode {
+            return getNode(ITree.ROOT_ID)
+        }
+
+        override fun resolveConcept(ref: IConceptReference): IConcept? {
+            TODO("Not yet implemented")
+        }
+
+        override fun resolveNode(ref: INodeReference): INode? {
+            return resolveOriginalNode(ref)
+        }
+
+        override fun resolveOriginalNode(ref: INodeReference): INode? {
+            return when (ref) {
+                is PNodeReference -> getNode(ref.id).takeIf { ref.branchId == branchId }
+                is InMemoryNode -> ref
+                is NodeReference -> PNodeReference.tryDeserialize(ref.serialized)?.let { resolveOriginalNode(it) }
+                else -> null
+            }
+        }
+
+        override fun resolveBranch(id: String): IBranch? {
+            TODO("Not yet implemented")
+        }
+
+        override fun collectAreas(): List<IArea> {
+            TODO("Not yet implemented")
+        }
+
+        override fun getReference(): IAreaReference {
+            TODO("Not yet implemented")
+        }
+
+        override fun resolveArea(ref: IAreaReference): IArea? {
+            TODO("Not yet implemented")
+        }
+
+        override fun <T> executeRead(f: () -> T): T {
+            return f()
+        }
+
+        override fun <T> executeWrite(f: () -> T): T {
+            throw UnsupportedOperationException("read-only")
+        }
+
+        override fun canRead(): Boolean {
+            return true
+        }
+
+        override fun canWrite(): Boolean {
+            return false
+        }
+
+        override fun addListener(l: IAreaListener) {
+            TODO("Not yet implemented")
+        }
+
+        override fun removeListener(l: IAreaListener) {
+            TODO("Not yet implemented")
+        }
+    }
+}
+
+data class InMemoryNode(val model: InMemoryModel, val nodeId: Long) : INode, INodeReference {
+    fun getNodeData(): CPNode = model.getNodeData(nodeId)
+
+    override fun serialize(): String {
+        return PNodeReference(nodeId, model.branchId).serialize()
+    }
+
+    override fun getPropertyValue(role: String): String? = getNodeData().getPropertyValue(role)
+
+    override fun setPropertyValue(role: String, value: String?): Unit = throw UnsupportedOperationException("read-only")
+
+    override fun getArea(): IArea {
+        return model.getArea()
+    }
+
+    override val isValid: Boolean
+        get() = model.nodeMap.containsKey(nodeId)
+    override val reference: INodeReference
+        get() = this
+    override val concept: IConcept?
+        get() = getConceptReference()?.let { ILanguageRepository.resolveConcept(it) }
+    override val roleInParent: String?
+        get() = getNodeData().roleInParent
+    override val parent: INode?
+        get() = getNodeData().parentId.takeIf { it != 0L }?.let { InMemoryNode(model, it) }
+
+    override fun getConceptReference(): IConceptReference? {
+        return getNodeData().concept?.let { ConceptReference(it) }
+    }
+
+    override fun getChildren(role: String?): Iterable<INode> {
+        return allChildren.filter { it.roleInParent == role }
+    }
+
+    override val allChildren: Iterable<INode>
+        get() = getNodeData().getChildrenIds().map { InMemoryNode(model, it) }
+
+    override fun moveChild(role: String?, index: Int, child: INode) {
+        throw UnsupportedOperationException("read-only")
+    }
+
+    override fun addNewChild(role: String?, index: Int, concept: IConcept?): INode {
+        throw UnsupportedOperationException("read-only")
+    }
+
+    override fun removeChild(child: INode) {
+        throw UnsupportedOperationException("read-only")
+    }
+
+    override fun getReferenceTarget(role: String): INode? {
+        val targetRef = getNodeData().getReferenceTarget(role)
+        return when {
+            targetRef == null -> null
+            targetRef.isLocal -> InMemoryNode(model, targetRef.elementId)
+            targetRef is CPNodeRef.ForeignRef -> NodeReference(targetRef.serializedRef).resolveInCurrentContext()
+            else -> throw UnsupportedOperationException("Unsupported reference: $targetRef")
+        }
+    }
+
+    override fun getReferenceTargetRef(role: String): INodeReference? {
+        val targetRef = getNodeData().getReferenceTarget(role)
+        return when {
+            targetRef == null -> null
+            targetRef.isLocal -> InMemoryNode(model, targetRef.elementId).reference
+            targetRef is CPNodeRef.ForeignRef -> NodeReference(targetRef.serializedRef)
+            else -> throw UnsupportedOperationException("Unsupported reference: $targetRef")
+        }
+    }
+
+    override fun setReferenceTarget(role: String, target: INode?) {
+        throw UnsupportedOperationException("read-only")
+    }
+
+    override fun getPropertyRoles(): List<String> {
+        return getNodeData().propertyRoles.toList()
+    }
+
+    override fun getReferenceRoles(): List<String> {
+        return getNodeData().referenceRoles.toList()
+    }
+}

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -47,6 +47,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.modelix.api.public.Paths
 import org.modelix.authorization.getUserName
+import org.modelix.model.IncrementalInMemoryModel
+import org.modelix.model.api.ITree
 import org.modelix.model.api.PBranch
 import org.modelix.model.api.TreePointer
 import org.modelix.model.api.getRootNode
@@ -264,6 +266,7 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
             TODO()
         }
 
+        val inMemoryModel = IncrementalInMemoryModel()
         post<Paths.postRepositoryBranchQuery> {
             fun ApplicationCall.repositoryId() = RepositoryId(parameters["repository"]!!)
             fun PipelineContext<Unit, ApplicationCall>.repositoryId() = call.repositoryId()
@@ -273,21 +276,32 @@ class ModelReplicationServer(val repositoriesManager: RepositoriesManager) {
 
             val branchRef = branchRef()
             val version = repositoriesManager.getVersion(branchRef)
+            LOG.trace("Running query on {} @ {}", branchRef, version)
             val initialTree = version!!.getTree()
             val branch = OTBranch(PBranch(initialTree, repositoriesManager.client.idGenerator), repositoriesManager.client.idGenerator, repositoriesManager.client.storeCache)
-            ModelQLServer.handleCall(call, branch.getRootNode(), branch.getArea())
 
-            val (ops, newTree) = branch.operationsAndTree
-            if (newTree != initialTree) {
-                val newVersion = CLVersion.createRegularVersion(
-                    id = repositoriesManager.client.idGenerator.generate(),
-                    author = getUserName(),
-                    tree = newTree as CLTree,
-                    baseVersion = version,
-                    operations = ops.map { it.getOriginalOp() }.toTypedArray(),
-                )
-                repositoriesManager.mergeChanges(branchRef, newVersion.getContentHash())
-            }
+            ModelQLServer.handleCall(call, { writeAccess ->
+                if (writeAccess) {
+                    branch.getRootNode() to branch.getArea()
+                } else {
+                    val model = inMemoryModel.getModel(initialTree)
+                    model.getNode(ITree.ROOT_ID) to model.getArea()
+                }
+            }, {
+                // writing the new version has to happen before call.respond is invoked, otherwise subsequent queries
+                // from the same client may still be executed on the old version.
+                val (ops, newTree) = branch.getPendingChanges()
+                if (newTree != initialTree) {
+                    val newVersion = CLVersion.createRegularVersion(
+                        id = repositoriesManager.client.idGenerator.generate(),
+                        author = getUserName(),
+                        tree = newTree as CLTree,
+                        baseVersion = version,
+                        operations = ops.map { it.getOriginalOp() }.toTypedArray(),
+                    )
+                    repositoriesManager.mergeChanges(branchRef, newVersion.getContentHash())
+                }
+            })
         }
 
         post<Paths.postRepositoryVersionHashQuery> {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
 import org.apache.commons.collections4.map.LRUMap
 import org.modelix.model.IKeyValueStore
+import org.modelix.model.InMemoryModels
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.IReadTransaction
@@ -51,6 +52,7 @@ class RepositoriesManager(val client: LocalModelClient) {
     private val store: IStoreClient get() = client.store
     private val kvStore: IKeyValueStore get() = client.asyncStore
     private val objectStore: IDeserializingKeyValueStore get() = client.storeCache
+    val inMemoryModels = InMemoryModels()
 
     fun generateClientId(repositoryId: RepositoryId): Long {
         return client.store.generateId("$KEY_PREFIX:${repositoryId.id}:clientId")

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -214,8 +214,10 @@ class RepositoriesManager(val client: LocalModelClient) {
     }
 
     fun getVersionHash(branch: BranchReference): String? {
-        return store[branchKey(branch)]
-            ?: store[legacyBranchKey(branch)]?.also { store.put(branchKey(branch), it, true) }
+        return store.runTransaction {
+            store[branchKey(branch)]
+                ?: store[legacyBranchKey(branch)]?.also { store.put(branchKey(branch), it, true) }
+        }
     }
 
     private fun putVersionHash(branch: BranchReference, hash: String?) {

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IDefaultNodeAdapter.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IDefaultNodeAdapter.kt
@@ -32,6 +32,8 @@ interface IDefaultNodeAdapter : IDeprecatedNodeDefaults {
     override val isValid: Boolean
         get() = true
 
+    override fun tryGetConcept(): IConcept? = concept
+
     override fun getConceptReference(): IConceptReference? {
         return concept?.getReference()
     }

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
@@ -44,6 +44,10 @@ data class MPSNode(val node: SNode) : IDeprecatedNodeDefaults {
     override val parent: INode?
         get() = node.parent?.let { MPSNode(it) } ?: node.model?.let { MPSModelAsNode(it) }
 
+    override fun tryGetConcept(): IConcept {
+        return MPSConcept(node.concept)
+    }
+
     override fun getConceptReference(): ConceptReference {
         return concept.getReference() as ConceptReference
     }


### PR DESCRIPTION
The versioning feature of our model data structure has the cost of a slower performance. To achieve a comparable performance to the light-model-server the whole model is now loaded into memory using a more efficient map implementation.

The model is update incrementally whenever the branch changes.

In the future we may be able to improve the performance by introducing indices and parallelizing the query execution (using IBulkQuery) and then might not need this in-memory model anymore.