### PR TITLE
fix(model-server): respond with all objects if no base version was given

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -37,6 +37,7 @@ import org.modelix.model.lazy.KVEntryReference
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.lazy.computeDelta
 import org.modelix.model.metameta.MetaModelBranch
+import org.modelix.model.persistent.CPVersion
 import org.modelix.model.server.store.IStoreClient
 import org.modelix.model.server.store.LocalModelClient
 import org.modelix.model.server.store.pollEntry
@@ -236,16 +237,23 @@ class RepositoriesManager(val client: LocalModelClient) {
                 val version = CLVersion(versionHash, objectStore)
                 // Use a bulk query to make as few request to the underlying store as possible.
                 val bulkQuery = objectStore.newBulkQuery()
+                // It is unsatisfactory that we have to keep already emitted hashes in memory.
+                // But without changing the underlying model,
+                // we have to do this to not emit objects more than once.
+                val seenHashes = mutableSetOf<String>()
                 fun emitObjects(entry: KVEntryReference<*>) {
                     bulkQuery.get(entry).onSuccess {
                         channel.trySend(entry.getHash() to it!!.serialize())
-                        for (referencedEntry in it!!.getReferencedEntries()) {
-                            emitObjects(referencedEntry)
+                        for (referencedEntry in it.getReferencedEntries()) {
+                            val wasSeenBefore = !seenHashes.add(referencedEntry.getHash())
+                            // Do not emit the object if we already emitted it.
+                            if (!wasSeenBefore) {
+                                emitObjects(referencedEntry)
+                            }
                         }
                     }
                 }
-                channel.send(versionHash to kvStore.get(versionHash)!!)
-                emitObjects(version.treeHash!!)
+                emitObjects(KVEntryReference(versionHash, CPVersion.DESERIALIZER))
                 (bulkQuery as? BulkQuery)?.process()
             }
         }

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.modelix.model.server.handlers
+
+import io.ktor.client.request.get
+import io.ktor.http.appendPathSegments
+import io.ktor.http.takeFrom
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.resources.Resources
+import io.ktor.server.routing.IgnoreTrailingSlash
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.server.websocket.WebSockets
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import org.modelix.authorization.installAuthentication
+import org.modelix.model.api.IConceptReference
+import org.modelix.model.client2.ModelClientV2
+import org.modelix.model.client2.readVersionDelta
+import org.modelix.model.client2.runWrite
+import org.modelix.model.client2.useVersionStreamFormat
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.model.server.store.LocalModelClient
+import kotlin.test.Test
+import kotlin.test.fail
+
+class ModelReplicationServerTest {
+
+    private fun runTest(block: suspend ApplicationTestBuilder.(scope: CoroutineScope) -> Unit) = testApplication {
+        application {
+            installAuthentication(unitTestMode = true)
+            install(ContentNegotiation) {
+                json()
+            }
+            install(WebSockets)
+            install(Resources)
+            install(IgnoreTrailingSlash)
+            val repositoriesManager = RepositoriesManager(LocalModelClient(InMemoryStoreClient()))
+            ModelReplicationServer(repositoriesManager).init(this)
+            KeyValueLikeModelServer(repositoriesManager).init(this)
+        }
+
+        coroutineScope {
+            block(this)
+        }
+    }
+
+    @Test
+    fun `pulling delta does not return objects twice`() = runTest {
+        // Arrange
+        val url = "http://localhost/v2"
+        val modelClient = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
+        val repositoryId = RepositoryId("repo1")
+        val branchId = repositoryId.getBranchReference("my-branch")
+        // By calling modelClient.runWrite twice, we create to versions.
+        // Those two versions will share objects.
+        modelClient.runWrite(branchId) { root ->
+            root.addNewChild("aChild", -1, null as IConceptReference?)
+        }
+        modelClient.runWrite(branchId) { root ->
+            root.addNewChild("aChild", -1, null as IConceptReference?)
+        }
+
+        // Act
+        val response = client.get {
+            url {
+                takeFrom(url)
+                appendPathSegments("repositories", repositoryId.id, "branches", branchId.branchName)
+            }
+            useVersionStreamFormat()
+        }
+        val versionDelta = response.readVersionDelta()
+
+        // Assert
+        val seenHashes = mutableSetOf<String>()
+        versionDelta.getObjectsAsFlow().collect { (hash, _) ->
+            val wasSeenBefore = !seenHashes.add(hash)
+            if (wasSeenBefore) {
+                // We should not send the same object (with the same hash more than once)
+                // even if we got with versions that share data.
+                fail("Hash $hash sent more than once.")
+            }
+        }
+    }
+}


### PR DESCRIPTION
In an optimization, only some of the referenced objects were emitted.

Making this this optimization correct emits more objects.


Also for not seending duplicate objects we have to keep a set of send object hashes while streaming objects.