### PR TITLE
MODELIX-637: SyncQueue fixes

### DIFF
--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncService.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncService.kt
@@ -8,6 +8,7 @@ import org.modelix.model.lazy.BranchReference
 import org.modelix.mps.sync.bindings.ModelBinding
 import org.modelix.mps.sync.bindings.ModuleBinding
 import java.net.URL
+import java.util.concurrent.CompletableFuture
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 interface SyncService {
@@ -37,7 +38,7 @@ interface IBinding {
 
     fun activate(callback: Runnable? = null)
 
-    fun deactivate(removeFromServer: Boolean, callback: Runnable? = null)
+    fun deactivate(removeFromServer: Boolean, callback: Runnable? = null): CompletableFuture<*>
 
     fun name(): String
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
@@ -109,10 +109,6 @@ class SyncServiceImpl(
         val bindings = runBlocking(coroutineScope.coroutineContext) {
             // TODO how to handle multiple replicated models at the same time?
             val replicatedModel = client.getReplicatedModel(branchReference)
-            // TODO when and how to dispose the replicated model and everything that depends on it?
-            replicatedModel.start()
-            replicatedModelByBranchReference[branchReference] = replicatedModel
-
             /**
              * TODO fixme:
              * (1) How to propagate replicated model to other places of code?
@@ -125,7 +121,10 @@ class SyncServiceImpl(
              * (3) We don't. We have to make sure that the places always have the latest replicated models from the registry. E.g. if we disconnect from the model server then we remove the replicated model (and thus break the registered event handlers), otherwise the event handlers as for the replicated model from the registry (based on some identifying metainfo for example, so to know which replicated model they need).
              */
             ReplicatedModelRegistry.model = replicatedModel
-            val branch = replicatedModel.getBranch()
+            replicatedModelByBranchReference[branchReference] = replicatedModel
+
+            // TODO when and how to dispose the replicated model and everything that depends on it?
+            val branch = replicatedModel.start()
 
             val targetProject = mpsProjectInjector.activeMpsProject!!
             val languageRepository = registerLanguages(targetProject)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/SyncServiceImpl.kt
@@ -23,9 +23,9 @@ import org.modelix.mps.sync.modelix.ModelixBranchListener
 import org.modelix.mps.sync.modelix.ReplicatedModelRegistry
 import org.modelix.mps.sync.mps.ActiveMpsProjectInjector
 import org.modelix.mps.sync.mps.RepositoryChangeListener
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.modelixToMps.initial.ITreeToSTreeTransformer
-import org.modelix.mps.sync.util.SyncQueue
 import java.net.ConnectException
 import java.net.URL
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/BindingsRegistry.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/BindingsRegistry.kt
@@ -22,13 +22,15 @@ import org.jetbrains.mps.openapi.model.SModelId
 import org.jetbrains.mps.openapi.module.SModule
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.mps.sync.IBinding
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 object BindingsRegistry {
 
-    private val modelBindingsByModule = mutableMapOf<SModule, LinkedHashSet<ModelBinding>>()
-    private val moduleBindings = LinkedHashSet<ModuleBinding>()
+    private val modelBindingsByModule = ConcurrentHashMap<SModule, LinkedHashSet<ModelBinding>>()
+    private val moduleBindings = Collections.synchronizedSet(LinkedHashSet<ModuleBinding>())
 
     val bindings = LinkedBlockingQueue<BindingWithOperation>()
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/BindingsRegistry.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/BindingsRegistry.kt
@@ -22,20 +22,20 @@ import org.jetbrains.mps.openapi.model.SModelId
 import org.jetbrains.mps.openapi.module.SModule
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.mps.sync.IBinding
-import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
+import org.modelix.mps.sync.util.synchronizedLinkedHashSet
+import org.modelix.mps.sync.util.synchronizedMap
 import java.util.concurrent.LinkedBlockingQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 object BindingsRegistry {
 
-    private val modelBindingsByModule = ConcurrentHashMap<SModule, LinkedHashSet<ModelBinding>>()
-    private val moduleBindings = Collections.synchronizedSet(LinkedHashSet<ModuleBinding>())
+    private val modelBindingsByModule = synchronizedMap<SModule, MutableSet<ModelBinding>>()
+    private val moduleBindings = synchronizedLinkedHashSet<ModuleBinding>()
 
     val bindings = LinkedBlockingQueue<BindingWithOperation>()
 
     fun addModelBinding(binding: ModelBinding) {
-        modelBindingsByModule.computeIfAbsent(binding.model.module!!) { LinkedHashSet() }.add(binding)
+        modelBindingsByModule.computeIfAbsent(binding.model.module!!) { synchronizedLinkedHashSet() }.add(binding)
         bindingAdded(binding)
     }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModelBinding.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModelBinding.kt
@@ -22,11 +22,12 @@ import jetbrains.mps.model.ModelDeleteHelper
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.IBranch
 import org.modelix.mps.sync.IBinding
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.incremental.ModelChangeListener
 import org.modelix.mps.sync.transformation.mpsToModelix.incremental.NodeChangeListener
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelBinding(
@@ -79,7 +80,7 @@ class ModelBinding(
         }
 
         // delete model
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE)) {
+        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MPS_TO_MODELIX) {
             try {
                 if (!removeFromServer) {
                     // to delete the files locally
@@ -92,7 +93,7 @@ class ModelBinding(
                 bindingsRegistry.addModelBinding(this)
                 throw ex
             }
-        }.continueWith(linkedSetOf(SyncLock.NONE)) {
+        }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
             bindingsRegistry.removeModelBinding(parentModule, this)
 
             if (!removeFromServer) {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModelBinding.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModelBinding.kt
@@ -48,8 +48,7 @@ class ModelBinding(
     private var isActivated = false
 
     override fun activate(callback: Runnable?) {
-        check(!isDisposed) { "${name()} is disposed." }
-        if (isActivated) {
+        if (isDisposed || isActivated) {
             return
         }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModelBinding.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModelBinding.kt
@@ -93,7 +93,7 @@ class ModelBinding(
                 bindingsRegistry.addModelBinding(this)
                 throw ex
             }
-        }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+        }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.NONE) {
             bindingsRegistry.removeModelBinding(parentModule, this)
 
             if (!removeFromServer) {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModuleBinding.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModuleBinding.kt
@@ -49,8 +49,7 @@ class ModuleBinding(
     private var isActivated = false
 
     override fun activate(callback: Runnable?) {
-        check(!isDisposed) { "${name()} is disposed." }
-        if (isActivated) {
+        if (isDisposed || isActivated) {
             return
         }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModuleBinding.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/bindings/ModuleBinding.kt
@@ -105,9 +105,7 @@ class ModuleBinding(
                 bindingsRegistry.addModuleBinding(this)
                 throw ex
             }
-        }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
-            // deactivate binding
-
+        }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.NONE) {
             nodeMap.remove(module)
 
             isDisposed = true

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ModelixBranchListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ModelixBranchListener.kt
@@ -28,18 +28,16 @@ import org.modelix.mps.sync.transformation.modelixToMps.incremental.ModelixTreeC
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelixBranchListener(
-    private val replicatedModel: ReplicatedModel,
-    private val project: MPSProject,
-    private val languageRepository: MPSLanguageRepository,
-    private val nodeMap: MpsToModelixMap,
-    private val syncQueue: SyncQueue,
+    replicatedModel: ReplicatedModel,
+    project: MPSProject,
+    languageRepository: MPSLanguageRepository,
+    nodeMap: MpsToModelixMap,
+    syncQueue: SyncQueue,
 ) : IBranchListener {
+
+    private val visitor = ModelixTreeChangeVisitor(replicatedModel, project, languageRepository, nodeMap, syncQueue)
+
     override fun treeChanged(oldTree: ITree?, newTree: ITree) {
-        if (oldTree != null) {
-            newTree.visitChanges(
-                oldTree,
-                ModelixTreeChangeVisitor(replicatedModel, project, languageRepository, nodeMap, syncQueue),
-            )
-        }
+        oldTree?.let { newTree.visitChanges(it, visitor) }
     }
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ModelixBranchListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ModelixBranchListener.kt
@@ -22,9 +22,9 @@ import org.modelix.model.api.IBranchListener
 import org.modelix.model.api.ITree
 import org.modelix.model.client2.ReplicatedModel
 import org.modelix.model.mpsadapters.MPSLanguageRepository
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.modelixToMps.incremental.ModelixTreeChangeVisitor
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelixBranchListener(

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ReplicatedModelRegistry.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/modelix/ReplicatedModelRegistry.kt
@@ -21,5 +21,6 @@ import org.modelix.model.client2.ReplicatedModel
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 object ReplicatedModelRegistry {
+    // TODO what shall happen if we switch ReplicatedModels? Some threads might still be working on the old ReplicatedModel. (with other words: search for all places where this field is referred to and think about if it can cause trouble if we change this reference to another one suddenly..)
     var model: ReplicatedModel? = null
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/ActiveMpsProjectInjector.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/ActiveMpsProjectInjector.kt
@@ -24,6 +24,8 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 object ActiveMpsProjectInjector {
+
+    // TODO what shall happen if we switch MPSProjects? Some threads might still be working on the old MPSProject. (with other words: search for all places where this field is referred to and think about if it can cause trouble if we change this reference to another one suddenly..)
     var activeMpsProject: MPSProject? = null
         private set
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/RepositoryChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/RepositoryChangeListener.kt
@@ -22,9 +22,9 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.ITree
 import org.modelix.mps.sync.bindings.BindingsRegistry
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.NodeSynchronizer
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class RepositoryChangeListener(

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
@@ -79,7 +79,10 @@ class SNodeFactory(
         val modelIsTheParent = parentModelId != null && model?.modelId == parentModelId
         val isRootNode = concept.isRootable && modelIsTheParent
 
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
+        syncQueue.enqueueBlocking(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+        ) {
             if (isRootNode) {
                 model?.addRootNode(sNode)
             } else {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
@@ -32,9 +32,10 @@ import org.modelix.model.api.INode
 import org.modelix.model.api.PropertyFromName
 import org.modelix.model.mpsadapters.MPSLanguageRepository
 import org.modelix.model.mpsadapters.MPSReferenceLink
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.mappedMpsNodeID
 import org.modelix.mps.sync.util.nodeIdAsLong
 
@@ -78,7 +79,7 @@ class SNodeFactory(
         val modelIsTheParent = parentModelId != null && model?.modelId == parentModelId
         val isRootNode = concept.isRootable && modelIsTheParent
 
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ)) {
+        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
             if (isRootNode) {
                 model?.addRootNode(sNode)
             } else {
@@ -118,7 +119,7 @@ class SNodeFactory(
             val property = PropertyFromName(sProperty.name)
             val value = source.getPropertyValue(property)
 
-            syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE)) {
+            syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
                 target.setProperty(sProperty, value)
             }
         }
@@ -138,7 +139,7 @@ class SNodeFactory(
     }
 
     fun resolveReferences() {
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE)) {
+        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
             resolvableReferences.forEach {
                 val source = it.source
                 val reference = it.reference

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
@@ -144,13 +144,11 @@ class SNodeFactory(
     }
 
     fun resolveReferences() {
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
-            resolvableReferences.forEach {
-                val source = it.source
-                val reference = it.reference
-                val target = nodeMap.getNode(it.targetNodeId)
-                source.setReferenceTarget(reference, target)
-            }
+        resolvableReferences.forEach {
+            val source = it.source
+            val reference = it.reference
+            val target = nodeMap.getNode(it.targetNodeId)
+            source.setReferenceTarget(reference, target)
         }
     }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/factories/SNodeFactory.kt
@@ -98,7 +98,12 @@ class SNodeFactory(
         nodeMap.put(sNode, nodeId)
 
         // 3. set properties
-        setProperties(iNode, sNode)
+        syncQueue.enqueueBlocking(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+        ) {
+            setProperties(iNode, sNode)
+        }
 
         // 4. set references
         prepareLinkReferences(iNode)
@@ -121,10 +126,7 @@ class SNodeFactory(
         target.concept.properties.forEach { sProperty ->
             val property = PropertyFromName(sProperty.name)
             val value = source.getPropertyValue(property)
-
-            syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
-                target.setProperty(sProperty, value)
-            }
+            target.setProperty(sProperty, value)
         }
     }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/util/ModelRenameHelper.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/util/ModelRenameHelper.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.mps.sync.mps.util
+
+import com.intellij.openapi.diagnostic.logger
+import jetbrains.mps.extapi.model.EditableSModelBase
+import jetbrains.mps.extapi.module.SModuleBase
+import jetbrains.mps.extapi.persistence.FileDataSource
+import jetbrains.mps.persistence.DataSourceFactoryNotFoundException
+import jetbrains.mps.persistence.DefaultModelRoot
+import jetbrains.mps.persistence.NoSourceRootsInModelRootException
+import jetbrains.mps.persistence.SourceRootDoesNotExistException
+import jetbrains.mps.refactoring.Renamer
+import jetbrains.mps.smodel.SModelReference
+import jetbrains.mps.smodel.event.SModelFileChangedEvent
+import jetbrains.mps.smodel.event.SModelRenamedEvent
+import jetbrains.mps.vfs.IFile
+import org.jetbrains.mps.openapi.model.SModelName
+
+// TODO retest this class in and above MPS 2021.1, because some of its methods might have been removed from their original classes (see origin comments above the methods)
+class ModelRenameHelper(private val model: EditableSModelBase) {
+
+    val logger = logger<ModelRenameHelper>()
+
+    fun changeStereotype(stereotype: String?) {
+        beforeRename()
+
+        val oldName = model.reference.name.withoutStereotype()
+        val newName = SModelName(oldName.value, stereotype)
+        rename(newName, false)
+
+        afterRename()
+    }
+
+    // adopted from jetbrains.mps.ide.refactoring.RenameModelDialog.renameModel(model, newName)
+    fun renameModel(modelName: String) {
+        beforeRename()
+        rename(SModelName(modelName), model.source is FileDataSource)
+        afterRename()
+    }
+
+    private fun beforeRename() = model.repository.saveAll()
+
+    private fun afterRename() {
+        val modelRepository = model.repository
+        Renamer.updateModelAndModuleReferences(modelRepository)
+        modelRepository.saveAll()
+    }
+
+    // adopted from EditableSModelBase.rename(newModelName, changeFile)
+    private fun rename(newModelName: SModelName, changeFile: Boolean) {
+        val oldName = model.reference
+        fireBeforeModelRenamed(SModelRenamedEvent(model, oldName.modelName, newModelName.value))
+
+        val newModelReference = SModelReference(model.reference.moduleReference, model.reference.modelId, newModelName)
+        fireBeforeModelRenamed(newModelReference)
+        model.changeModelReference(newModelReference)
+        model.isChanged = true
+
+        try {
+            if (changeFile) {
+                if (model.source !is FileDataSource) {
+                    throw UnsupportedOperationException("cannot change model file on non-file data source")
+                }
+
+                val oldFile = (model.getSource() as FileDataSource).file
+                fireBeforeModelFileChanged(SModelFileChangedEvent(model, oldFile, null as IFile?))
+                val root = model.modelRoot
+                if (root is DefaultModelRoot) {
+                    root.rename(model.source as FileDataSource?, newModelName.value)
+                    model.updateTimestamp()
+                }
+
+                val newFile = (model.source as FileDataSource).file
+                if (oldFile.path != newFile.path) {
+                    fireModelFileChanged(SModelFileChangedEvent(model, oldFile, newFile))
+                }
+            }
+        } catch (var8: NoSourceRootsInModelRootException) {
+            logger.error(var8)
+        } catch (var8: SourceRootDoesNotExistException) {
+            logger.error(var8)
+        } catch (var8: DataSourceFactoryNotFoundException) {
+            logger.error(var8)
+        }
+
+        model.save()
+        fireModelRenamed(SModelRenamedEvent(model, oldName.modelName, newModelName.value))
+        fireModelRenamed(oldName)
+    }
+
+    // adopted from EditableSModelBase.fireBeforeModelRenamed(event)
+    private fun fireBeforeModelRenamed(event: SModelRenamedEvent) {
+        val iterator = model.modelListeners.iterator()
+        while (iterator.hasNext()) {
+            try {
+                iterator.next().beforeModelRenamed(event)
+            } catch (var5: Throwable) {
+                logger.error(var5)
+            }
+        }
+    }
+
+    // adopted from SModelBase.fireBeforeModelRenamed(newName)
+    private fun fireBeforeModelRenamed(newName: SModelReference) {
+        val module = model.module
+        if (module is SModuleBase) {
+            module.fireBeforeModelRenamed(model, newName)
+        }
+    }
+
+    // adopted from SModelDescriptorStub.fireBeforeModelFileChanged(event)
+    private fun fireBeforeModelFileChanged(event: SModelFileChangedEvent) {
+        val iterator = model.modelListeners.iterator()
+        while (iterator.hasNext()) {
+            try {
+                iterator.next().beforeModelFileChanged(event)
+            } catch (var5: Throwable) {
+                logger.error(var5)
+            }
+        }
+    }
+
+    // adopted from SModelDescriptorStub.fireModelFileChanged(event)
+    private fun fireModelFileChanged(event: SModelFileChangedEvent) {
+        val iterator = model.modelListeners.iterator()
+        while (iterator.hasNext()) {
+            try {
+                iterator.next().modelFileChanged(event)
+            } catch (var5: Throwable) {
+                logger.error(var5)
+            }
+        }
+    }
+
+    // adopted from SModelDescriptorStub.fireModelFileChanged(event)
+    private fun fireModelRenamed(event: SModelRenamedEvent) {
+        val iterator = model.modelListeners.iterator()
+        while (iterator.hasNext()) {
+            try {
+                iterator.next().modelRenamed(event)
+            } catch (var5: Throwable) {
+                logger.error(var5)
+            }
+        }
+    }
+
+    // adopted from SModelBase.fireModelRenamed(newName)
+    private fun fireModelRenamed(oldName: org.jetbrains.mps.openapi.model.SModelReference) {
+        val module = model.module
+        if (module is SModuleBase) {
+            module.fireModelRenamed(model, oldName)
+        }
+    }
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/util/ModelRenameHelper.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/util/ModelRenameHelper.kt
@@ -30,8 +30,10 @@ import jetbrains.mps.smodel.event.SModelFileChangedEvent
 import jetbrains.mps.smodel.event.SModelRenamedEvent
 import jetbrains.mps.vfs.IFile
 import org.jetbrains.mps.openapi.model.SModelName
+import org.modelix.kotlin.utils.UnstableModelixFeature
 
 // TODO retest this class in and above MPS 2021.1, because some of its methods might have been removed from their original classes (see origin comments above the methods)
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelRenameHelper(private val model: EditableSModelBase) {
 
     val logger = logger<ModelRenameHelper>()

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/util/SModelExt.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/mps/util/SModelExt.kt
@@ -29,8 +29,20 @@ fun SModel.addDevKit(devKitModuleReference: SModuleReference) {
 }
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+fun SModel.deleteDevKit(devKitModuleReference: SModuleReference) {
+    require(this is SModelDescriptorStub) { "Model ${this.modelId} must be an SModelDescriptorStub" }
+    this.deleteDevKit(devKitModuleReference)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 fun SModel.addLanguageImport(sLanguage: SLanguage, version: Int) {
     require(this is SModelDescriptorStub) { "Model ${this.modelId} must be an SModelDescriptorStub" }
     this.addLanguage(sLanguage)
     this.setLanguageImportVersion(sLanguage, version)
+}
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+fun SModel.deleteLanguage(sLanguage: SLanguage) {
+    require(this is SModelDescriptorStub) { "Model ${this.modelId} must be an SModelDescriptorStub" }
+    this.deleteLanguageId(sLanguage)
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/InspectionMode.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/InspectionMode.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.mps.sync.tasks
+
+import org.modelix.kotlin.utils.UnstableModelixFeature
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+enum class InspectionMode {
+    CHECK_EXECUTION_THREAD,
+    OFF,
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncDirection.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncDirection.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.mps.sync.tasks
+
+import org.modelix.kotlin.utils.UnstableModelixFeature
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+enum class SyncDirection {
+    MODELIX_TO_MPS,
+    MPS_TO_MODELIX,
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncDirection.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncDirection.kt
@@ -22,4 +22,5 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 enum class SyncDirection {
     MODELIX_TO_MPS,
     MPS_TO_MODELIX,
+    NONE, // other, non-sync tasks
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncLock.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncLock.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.modelix.mps.sync.util
+package org.modelix.mps.sync.tasks
 
 import org.modelix.kotlin.utils.UnstableModelixFeature
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncQueue.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncQueue.kt
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package org.modelix.mps.sync.util
+package org.modelix.mps.sync.tasks
 
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.util.containers.headTail
-import jetbrains.mps.util.containers.ConcurrentHashSet
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.client.SharedExecutors
 import org.modelix.mps.sync.modelix.ReplicatedModelRegistry
 import org.modelix.mps.sync.mps.ActiveMpsProjectInjector
 import org.modelix.mps.sync.mps.MpsCommandHelper
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
@@ -31,25 +31,27 @@ object SyncQueue {
 
     private val logger = logger<SyncQueue>()
 
-    private val activeSyncThreads = ConcurrentHashSet<Thread>()
+    private val activeSyncThreadsWithSyncDirection = ConcurrentHashMap<Thread, SyncDirection>()
     private val tasks = ConcurrentLinkedQueue<SyncTask>()
 
     fun enqueue(
         requiredLocks: LinkedHashSet<SyncLock>,
+        syncDirection: SyncDirection,
         checkExecutionThread: Boolean = false,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
-        val task = SyncTask(requiredLocks, action)
+        val task = SyncTask(requiredLocks, syncDirection, action)
         enqueue(task, checkExecutionThread)
         return ContinuableSyncTask(task, this)
     }
 
     fun enqueueBlocking(
         requiredLocks: LinkedHashSet<SyncLock>,
+        syncDirection: SyncDirection,
         checkExecutionThread: Boolean = false,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
-        val task = SyncTask(requiredLocks, action)
+        val task = SyncTask(requiredLocks, syncDirection, action)
         enqueueBlocking(task, checkExecutionThread)
         return ContinuableSyncTask(task, this)
     }
@@ -57,15 +59,20 @@ object SyncQueue {
     fun enqueue(task: SyncTask, checkExecutionThread: Boolean) {
         /**
          * If we have to check the execution thread, then do not schedule Task if it is initiated on a Thread that is
-         * running a synchronization. This might be a symptom of a "Table tennis" (ping-pong) effect in which a change
-         * in MPS triggers a change in Modelix which triggers a change in MPS again via the *ChangeListener and
-         * ModelixTreeChangeVisitor chains registered in MPS and in Modelix, respectively.
+         * running a synchronization and the sync direction is the opposite of what is running on the thread already.
+         * This might be a symptom of a "Table tennis" (ping-pong) effect in which a change in MPS triggers a change
+         * in Modelix which triggers a change in MPS again via the *ChangeListener and ModelixTreeChangeVisitor chains
+         * registered in MPS and in Modelix, respectively.
          *
          * Because the SyncTasks are executed on separate threads by the ExecutorService (see SharedExecutors.FIXED),
          * there is a very little chance of missing an intended change on other side. With other words: there is very
          * little chance that it makes sense that on the same thread two SyncTasks occur.
          */
-        if (checkExecutionThread && activeSyncThreads.contains(Thread.currentThread())) {
+        val runningSyncDirection = activeSyncThreadsWithSyncDirection[Thread.currentThread()]
+        val synchronizationInOppositeDirectionIsRunning =
+            runningSyncDirection != null && runningSyncDirection != task.syncDirection
+
+        if (checkExecutionThread && synchronizationInOppositeDirectionIsRunning) {
             task.result.complete(null)
         } else {
             tasks.add(task)
@@ -85,14 +92,10 @@ object SyncQueue {
     }
 
     private fun doFlush() {
-        activeSyncThreads.add(Thread.currentThread())
-
         while (!tasks.isEmpty()) {
             val task = tasks.poll()
             runWithLocks(task.sortedLocks, task)
         }
-
-        activeSyncThreads.remove(Thread.currentThread())
     }
 
     private fun runWithLocks(locks: LinkedHashSet<SyncLock>, task: SyncTask) {
@@ -107,7 +110,8 @@ object SyncQueue {
 
             runWithLock(lockHead) {
                 val currentThread = Thread.currentThread()
-                val wasAddedHere = activeSyncThreads.add(currentThread)
+                val wasAddedHere = activeSyncThreadsWithSyncDirection.containsKey(currentThread)
+                activeSyncThreadsWithSyncDirection[currentThread] = task.syncDirection
 
                 try {
                     val lockTail = lockHeadAndTail.second
@@ -122,8 +126,8 @@ object SyncQueue {
                     throw t
                 } finally {
                     if (wasAddedHere) {
-                        // do not remove threads that were registered somewhere else (i.e. above in the SyncQueue class)
-                        activeSyncThreads.remove(currentThread)
+                        // do not remove threads that were registered somewhere else
+                        activeSyncThreadsWithSyncDirection.remove(currentThread)
                     }
                 }
             }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncQueue.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncQueue.kt
@@ -37,26 +37,26 @@ object SyncQueue {
     fun enqueue(
         requiredLocks: LinkedHashSet<SyncLock>,
         syncDirection: SyncDirection,
-        checkExecutionThread: Boolean = false,
+        inspectionMode: InspectionMode = InspectionMode.OFF,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
         val task = SyncTask(requiredLocks, syncDirection, action)
-        enqueue(task, checkExecutionThread)
+        enqueue(task, inspectionMode)
         return ContinuableSyncTask(task)
     }
 
     fun enqueueBlocking(
         requiredLocks: LinkedHashSet<SyncLock>,
         syncDirection: SyncDirection,
-        checkExecutionThread: Boolean = false,
+        inspectionMode: InspectionMode = InspectionMode.OFF,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
         val task = SyncTask(requiredLocks, syncDirection, action)
-        enqueueBlocking(task, checkExecutionThread)
+        enqueueBlocking(task, inspectionMode)
         return ContinuableSyncTask(task)
     }
 
-    fun enqueue(task: SyncTask, checkExecutionThread: Boolean) {
+    fun enqueue(task: SyncTask, inspectionMode: InspectionMode) {
         /**
          * If we have to check the execution thread, then do not schedule Task if it is initiated on a Thread that is
          * running a synchronization and the sync direction is the opposite of what is running on the thread already.
@@ -68,7 +68,7 @@ object SyncQueue {
          * there is a very little chance of missing an intended change on other side. With other words: there is very
          * little chance that it makes sense that on the same thread two SyncTasks occur.
          */
-        if (checkExecutionThread) {
+        if (inspectionMode == InspectionMode.CHECK_EXECUTION_THREAD) {
             val taskSyncDirection = task.syncDirection
             val runningSyncDirection = activeSyncThreadsWithSyncDirection[Thread.currentThread()]
 
@@ -85,8 +85,8 @@ object SyncQueue {
         }
     }
 
-    private fun enqueueBlocking(task: SyncTask, checkExecutionThread: Boolean) {
-        enqueue(task, checkExecutionThread)
+    private fun enqueueBlocking(task: SyncTask, inspectionMode: InspectionMode) {
+        enqueue(task, inspectionMode)
         task.result.get()
     }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncQueue.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncQueue.kt
@@ -68,9 +68,11 @@ object SyncQueue {
          * there is a very little chance of missing an intended change on other side. With other words: there is very
          * little chance that it makes sense that on the same thread two SyncTasks occur.
          */
+        val taskSyncDirection = task.syncDirection
         val runningSyncDirection = activeSyncThreadsWithSyncDirection[Thread.currentThread()]
         val synchronizationInOppositeDirectionIsRunning =
-            runningSyncDirection != null && runningSyncDirection != task.syncDirection
+            taskSyncDirection != SyncDirection.NONE && // non-sync tasks have a green way
+                runningSyncDirection != null && runningSyncDirection != taskSyncDirection // otherwise drop tasks that would run in the opposite direction
 
         if (checkExecutionThread && synchronizationInOppositeDirectionIsRunning) {
             task.result.complete(null)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -41,7 +41,7 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
     ): ContinuableSyncTask {
         val result = SyncQueue.enqueue(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
-            val previousResult = getResult()
+            val previousResult = waitForResult()
             val task = SyncTask(requiredLocks, syncDirection, action, previousResult)
             SyncQueue.enqueue(task, inspectionMode)
 
@@ -51,7 +51,9 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
         return result
     }
 
-    fun getResult() = previousTask.result.get()
+    fun getResult() = previousTask.result
+
+    fun waitForResult() = getResult().get()
 }
 
 typealias SyncTaskAction = (Any?) -> Any?

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -41,9 +41,13 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
     ): ContinuableSyncTask {
         /**
          * WARNING: if you change enqueueBlocking to enqueue, then keep in mind that MPS might get frozen, because
-         * a non-running, but queued task might have taken the lock that is needed by the task (that is expected to be run next)
+         * a non-running, but queued task might have taken the lock that is needed by the task (that is expected
+         * to be run next)
+         *
+         * UPDATE: I'm (@benedekh) not entirely sure if we have to use enqueue or enqueueBlocking, because different
+         * tasks are blocked depending on which one we use.
          */
-        val result = SyncQueue.enqueueBlocking(linkedSetOf(SyncLock.NONE), syncDirection) {
+        val result = SyncQueue.enqueue(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
             val previousResult = waitForResult()
             val task = SyncTask(requiredLocks, syncDirection, action, previousResult)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -39,7 +39,7 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
         inspectionMode: InspectionMode = InspectionMode.OFF,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
-        val result = SyncQueue.enqueue(linkedSetOf(SyncLock.NONE), syncDirection) {
+        val result = SyncQueue.enqueueBlocking(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
             val previousResult = waitForResult()
             val task = SyncTask(requiredLocks, syncDirection, action, previousResult)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -39,6 +39,10 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
         inspectionMode: InspectionMode = InspectionMode.OFF,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
+        /**
+         * WARNING: if you change enqueueBlocking to enqueue, then keep in mind that MPS might get frozen, because
+         * a non-running, but queued task might have taken the lock that is needed by the task (that is expected to be run next)
+         */
         val result = SyncQueue.enqueueBlocking(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
             val previousResult = waitForResult()

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -36,14 +36,14 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
     fun continueWith(
         requiredLocks: LinkedHashSet<SyncLock>,
         syncDirection: SyncDirection,
-        checkExecutionThread: Boolean = false,
+        inspectionMode: InspectionMode = InspectionMode.OFF,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
         val result = SyncQueue.enqueue(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
             val previousResult = getResult()
             val task = SyncTask(requiredLocks, syncDirection, action, previousResult)
-            SyncQueue.enqueue(task, checkExecutionThread)
+            SyncQueue.enqueue(task, inspectionMode)
 
             task.result.get()
         }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -31,7 +31,7 @@ class SyncTask(
 }
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
-class ContinuableSyncTask(private val previousTask: SyncTask, private val syncQueue: SyncQueue) {
+class ContinuableSyncTask(private val previousTask: SyncTask) {
 
     fun continueWith(
         requiredLocks: LinkedHashSet<SyncLock>,
@@ -41,7 +41,7 @@ class ContinuableSyncTask(private val previousTask: SyncTask, private val syncQu
     ): ContinuableSyncTask {
         val result = SyncQueue.enqueue(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
-            val previousResult = previousTask.result.get()
+            val previousResult = getResult()
             val task = SyncTask(requiredLocks, syncDirection, action, previousResult)
             SyncQueue.enqueue(task, checkExecutionThread)
 
@@ -50,6 +50,8 @@ class ContinuableSyncTask(private val previousTask: SyncTask, private val syncQu
 
         return result
     }
+
+    fun getResult() = previousTask.result.get()
 }
 
 typealias SyncTaskAction = (Any?) -> Any?

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.modelix.mps.sync.util
+package org.modelix.mps.sync.tasks
 
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import java.util.concurrent.CompletableFuture
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class SyncTask(
     requiredLocks: LinkedHashSet<SyncLock>,
+    val syncDirection: SyncDirection,
     val action: SyncTaskAction,
     val previousTaskResult: Any? = null,
     val result: CompletableFuture<Any?> = CompletableFuture(),
@@ -34,14 +35,15 @@ class ContinuableSyncTask(private val previousTask: SyncTask, private val syncQu
 
     fun continueWith(
         requiredLocks: LinkedHashSet<SyncLock>,
+        syncDirection: SyncDirection,
         checkExecutionThread: Boolean = false,
         action: SyncTaskAction,
     ): ContinuableSyncTask {
-        val result = syncQueue.enqueue(linkedSetOf(SyncLock.NONE)) {
+        val result = SyncQueue.enqueue(linkedSetOf(SyncLock.NONE), syncDirection) {
             // blocking wait for the result of the previous task
             val previousResult = previousTask.result.get()
-            val task = SyncTask(requiredLocks, action, previousResult)
-            syncQueue.enqueue(task, checkExecutionThread)
+            val task = SyncTask(requiredLocks, syncDirection, action, previousResult)
+            SyncQueue.enqueue(task, checkExecutionThread)
 
             task.result.get()
         }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/tasks/SyncTask.kt
@@ -53,7 +53,7 @@ class ContinuableSyncTask(private val previousTask: SyncTask) {
 
     fun getResult() = previousTask.result
 
-    fun waitForResult() = getResult().get()
+    private fun waitForResult() = getResult().get()
 }
 
 typealias SyncTaskAction = (Any?) -> Any?

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
@@ -141,6 +141,12 @@ object MpsToModelixMap {
 
     fun getModule(modelixId: Long?) = modelixIdToModule[modelixId]
 
+    fun getOutgoingModelReference(modelixId: Long?) = modelixIdToModelWithOutgoingModelReference[modelixId]
+
+    fun getOutgoingModuleReferenceFromModel(modelixId: Long?) = modelixIdToModelWithOutgoingModuleReference[modelixId]
+
+    fun getOutgoingModuleReferenceFromModule(modelixId: Long?) = modelixIdToModuleWithOutgoingModuleReference[modelixId]
+
     fun remove(modelixId: Long) {
         // is related to node
         modelixIdToNode.remove(modelixId)?.let { nodeToModelixId.remove(it) }
@@ -211,10 +217,10 @@ object MpsToModelixMap {
 }
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
-data class ModelWithModelReference(private val model: SModel, private val modelReference: SModelReference)
+data class ModelWithModelReference(val source: SModel, val modelReference: SModelReference)
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
-data class ModelWithModuleReference(private val model: SModel, private val moduleReference: SModuleReference)
+data class ModelWithModuleReference(val source: SModel, val moduleReference: SModuleReference)
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
-data class ModuleWithModuleReference(private val module: SModule, private val moduleReference: SModuleReference)
+data class ModuleWithModuleReference(val source: SModule, val moduleReference: SModuleReference)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
@@ -25,6 +25,7 @@ import org.jetbrains.mps.openapi.module.SModule
 import org.jetbrains.mps.openapi.module.SModuleId
 import org.jetbrains.mps.openapi.module.SModuleReference
 import org.modelix.kotlin.utils.UnstableModelixFeature
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * WARNING:
@@ -34,26 +35,26 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 object MpsToModelixMap {
 
-    private val nodeToModelixId = mutableMapOf<SNode, Long>()
-    private val modelixIdToNode = mutableMapOf<Long, SNode>()
+    private val nodeToModelixId = ConcurrentHashMap<SNode, Long>()
+    private val modelixIdToNode = ConcurrentHashMap<Long, SNode>()
 
-    private val modelToModelixId = mutableMapOf<SModel, Long>()
-    private val modelixIdToModel = mutableMapOf<Long, SModel>()
+    private val modelToModelixId = ConcurrentHashMap<SModel, Long>()
+    private val modelixIdToModel = ConcurrentHashMap<Long, SModel>()
 
-    private val moduleToModelixId = mutableMapOf<SModule, Long>()
-    private val modelixIdToModule = mutableMapOf<Long, SModule>()
+    private val moduleToModelixId = ConcurrentHashMap<SModule, Long>()
+    private val modelixIdToModule = ConcurrentHashMap<Long, SModule>()
 
-    private val moduleWithOutgoingModuleReferenceToModelixId = mutableMapOf<ModuleWithModuleReference, Long>()
-    private val modelixIdToModuleWithOutgoingModuleReference = mutableMapOf<Long, ModuleWithModuleReference>()
+    private val moduleWithOutgoingModuleReferenceToModelixId = ConcurrentHashMap<ModuleWithModuleReference, Long>()
+    private val modelixIdToModuleWithOutgoingModuleReference = ConcurrentHashMap<Long, ModuleWithModuleReference>()
 
-    private val modelWithOutgoingModuleReferenceToModelixId = mutableMapOf<ModelWithModuleReference, Long>()
-    private val modelixIdToModelWithOutgoingModuleReference = mutableMapOf<Long, ModelWithModuleReference>()
+    private val modelWithOutgoingModuleReferenceToModelixId = ConcurrentHashMap<ModelWithModuleReference, Long>()
+    private val modelixIdToModelWithOutgoingModuleReference = ConcurrentHashMap<Long, ModelWithModuleReference>()
 
-    private val modelWithOutgoingModelReferenceToModelixId = mutableMapOf<ModelWithModelReference, Long>()
-    private val modelixIdToModelWithOutgoingModelReference = mutableMapOf<Long, ModelWithModelReference>()
+    private val modelWithOutgoingModelReferenceToModelixId = ConcurrentHashMap<ModelWithModelReference, Long>()
+    private val modelixIdToModelWithOutgoingModelReference = ConcurrentHashMap<Long, ModelWithModelReference>()
 
-    private val objectsRelatedToAModel = mutableMapOf<SModel, MutableSet<Any>>()
-    private val objectsRelatedToAModule = mutableMapOf<SModule, MutableSet<Any>>()
+    private val objectsRelatedToAModel = ConcurrentHashMap<SModel, MutableSet<Any>>()
+    private val objectsRelatedToAModule = ConcurrentHashMap<SModule, MutableSet<Any>>()
 
     val models = modelixIdToModel.values
     val modules = modelixIdToModule.values

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/cache/MpsToModelixMap.kt
@@ -25,7 +25,8 @@ import org.jetbrains.mps.openapi.module.SModule
 import org.jetbrains.mps.openapi.module.SModuleId
 import org.jetbrains.mps.openapi.module.SModuleReference
 import org.modelix.kotlin.utils.UnstableModelixFeature
-import java.util.concurrent.ConcurrentHashMap
+import org.modelix.mps.sync.util.synchronizedLinkedHashSet
+import org.modelix.mps.sync.util.synchronizedMap
 
 /**
  * WARNING:
@@ -35,26 +36,26 @@ import java.util.concurrent.ConcurrentHashMap
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 object MpsToModelixMap {
 
-    private val nodeToModelixId = ConcurrentHashMap<SNode, Long>()
-    private val modelixIdToNode = ConcurrentHashMap<Long, SNode>()
+    private val nodeToModelixId = synchronizedMap<SNode, Long>()
+    private val modelixIdToNode = synchronizedMap<Long, SNode>()
 
-    private val modelToModelixId = ConcurrentHashMap<SModel, Long>()
-    private val modelixIdToModel = ConcurrentHashMap<Long, SModel>()
+    private val modelToModelixId = synchronizedMap<SModel, Long>()
+    private val modelixIdToModel = synchronizedMap<Long, SModel>()
 
-    private val moduleToModelixId = ConcurrentHashMap<SModule, Long>()
-    private val modelixIdToModule = ConcurrentHashMap<Long, SModule>()
+    private val moduleToModelixId = synchronizedMap<SModule, Long>()
+    private val modelixIdToModule = synchronizedMap<Long, SModule>()
 
-    private val moduleWithOutgoingModuleReferenceToModelixId = ConcurrentHashMap<ModuleWithModuleReference, Long>()
-    private val modelixIdToModuleWithOutgoingModuleReference = ConcurrentHashMap<Long, ModuleWithModuleReference>()
+    private val moduleWithOutgoingModuleReferenceToModelixId = synchronizedMap<ModuleWithModuleReference, Long>()
+    private val modelixIdToModuleWithOutgoingModuleReference = synchronizedMap<Long, ModuleWithModuleReference>()
 
-    private val modelWithOutgoingModuleReferenceToModelixId = ConcurrentHashMap<ModelWithModuleReference, Long>()
-    private val modelixIdToModelWithOutgoingModuleReference = ConcurrentHashMap<Long, ModelWithModuleReference>()
+    private val modelWithOutgoingModuleReferenceToModelixId = synchronizedMap<ModelWithModuleReference, Long>()
+    private val modelixIdToModelWithOutgoingModuleReference = synchronizedMap<Long, ModelWithModuleReference>()
 
-    private val modelWithOutgoingModelReferenceToModelixId = ConcurrentHashMap<ModelWithModelReference, Long>()
-    private val modelixIdToModelWithOutgoingModelReference = ConcurrentHashMap<Long, ModelWithModelReference>()
+    private val modelWithOutgoingModelReferenceToModelixId = synchronizedMap<ModelWithModelReference, Long>()
+    private val modelixIdToModelWithOutgoingModelReference = synchronizedMap<Long, ModelWithModelReference>()
 
-    private val objectsRelatedToAModel = ConcurrentHashMap<SModel, MutableSet<Any>>()
-    private val objectsRelatedToAModule = ConcurrentHashMap<SModule, MutableSet<Any>>()
+    private val objectsRelatedToAModel = synchronizedMap<SModel, MutableSet<Any>>()
+    private val objectsRelatedToAModule = synchronizedMap<SModule, MutableSet<Any>>()
 
     val models = modelixIdToModel.values
     val modules = modelixIdToModule.values
@@ -105,13 +106,13 @@ object MpsToModelixMap {
     }
 
     private fun putObjRelatedToAModel(model: SModel, obj: Any?) {
-        objectsRelatedToAModel.computeIfAbsent(model) { mutableSetOf() }.add(obj!!)
+        objectsRelatedToAModel.computeIfAbsent(model) { synchronizedLinkedHashSet() }.add(obj!!)
         // just in case, the model has not been tracked yet. E.g. @descriptor models that are created locally but were not synchronized to the model server.
         putObjRelatedToAModule(model.module, model)
     }
 
     private fun putObjRelatedToAModule(module: SModule, obj: Any?) =
-        objectsRelatedToAModule.computeIfAbsent(module) { mutableSetOf() }.add(obj!!)
+        objectsRelatedToAModule.computeIfAbsent(module) { synchronizedLinkedHashSet() }.add(obj!!)
 
     operator fun get(node: SNode?) = nodeToModelixId[node]
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/incremental/ModelixTreeChangeVisitor.kt
@@ -28,6 +28,7 @@ import org.modelix.model.api.PropertyFromName
 import org.modelix.model.api.getNode
 import org.modelix.model.client2.ReplicatedModel
 import org.modelix.model.mpsadapters.MPSLanguageRepository
+import org.modelix.mps.sync.tasks.InspectionMode
 import org.modelix.mps.sync.tasks.SyncDirection
 import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
@@ -58,7 +59,11 @@ class ModelixTreeChangeVisitor(
     private val moduleTransformer = ModuleTransformer(nodeMap, syncQueue, project)
 
     override fun referenceChanged(nodeId: Long, role: String) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val sNode = nodeMap.getNode(nodeId)!!
             val sReferenceLink = sNode.concept.referenceLinks.find { it.name == role }
 
@@ -72,7 +77,11 @@ class ModelixTreeChangeVisitor(
     }
 
     override fun propertyChanged(nodeId: Long, role: String) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val sNode = nodeMap.getNode(nodeId)!!
             val sProperty = sNode.concept.properties.find { it.name == role }
 
@@ -85,7 +94,11 @@ class ModelixTreeChangeVisitor(
     }
 
     override fun nodeRemoved(nodeId: Long) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MPS_WRITE),
+            SyncDirection.MODELIX_TO_MPS,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val sNode = nodeMap.getNode(nodeId)
             sNode?.let {
                 it.delete()
@@ -112,7 +125,11 @@ class ModelixTreeChangeVisitor(
     }
 
     override fun nodeAdded(nodeId: Long) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val iNode = getNode(nodeId)
             if (iNode.isModule()) {
                 moduleTransformer.transformToModule(iNode)
@@ -136,7 +153,11 @@ class ModelixTreeChangeVisitor(
     }
 
     override fun childrenChanged(nodeId: Long, role: String?) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MPS_WRITE),
+            SyncDirection.MODELIX_TO_MPS,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             modelTransformer.resolveModelImports(project.repository)
             modelTransformer.clearResolvableModelImports()
 
@@ -146,7 +167,11 @@ class ModelixTreeChangeVisitor(
     }
 
     override fun containmentChanged(nodeId: Long) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val iNode = getNode(nodeId)
             val newParentId = iNode.parent?.nodeIdAsLong()
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/initial/ITreeToSTreeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/initial/ITreeToSTreeTransformer.kt
@@ -29,12 +29,13 @@ import org.modelix.mps.sync.IBinding
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.bindings.ModelBinding
 import org.modelix.mps.sync.bindings.ModuleBinding
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.modelixToMps.transformers.ModelTransformer
 import org.modelix.mps.sync.transformation.modelixToMps.transformers.ModuleTransformer
 import org.modelix.mps.sync.transformation.modelixToMps.transformers.NodeTransformer
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.isModel
 import org.modelix.mps.sync.util.isModule
 import org.modelix.mps.sync.util.nodeIdAsLong
@@ -59,7 +60,7 @@ class ITreeToSTreeTransformer(
         val bindings = mutableListOf<IBinding>()
 
         try {
-            syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MODELIX_READ)) {
+            syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
                 val nodeId = entryPoint.nodeIdAsLong()
                 val root = branch.getNode(nodeId)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/initial/ITreeToSTreeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/initial/ITreeToSTreeTransformer.kt
@@ -85,7 +85,9 @@ class ITreeToSTreeTransformer(
                 }
 
                 logger.info("--- Resolving references ---")
-                nodeTransformer.resolveReferences()
+                syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
+                    nodeTransformer.resolveReferences()
+                }
 
                 logger.info("--- Registering module and model bindings ---")
                 nodeMap.modules.forEach {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -28,9 +28,10 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
 import org.modelix.mps.sync.mps.util.createModel
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.getModel
 import org.modelix.mps.sync.util.getModule
 import org.modelix.mps.sync.util.nodeIdAsLong
@@ -52,7 +53,7 @@ class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQue
         val modelId = PersistenceFacade.getInstance().createModelId(serializedId)
 
         lateinit var sModel: EditableSModel
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ)) {
+        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
             val modelDoesNotExist = module.getModel(modelId) == null
             if (modelDoesNotExist) {
                 sModel = module.createModel(name, modelId) as EditableSModel
@@ -91,7 +92,7 @@ class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQue
             val modelImport = SModelReference(moduleReference, id, targetModel.name)
 
             val sourceModel = it.source
-            syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE)) {
+            syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
                 ModelImports(sourceModel).addModelImport(modelImport)
             }
             nodeMap.put(it.source, modelImport, it.modelReferenceNodeId)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -97,9 +97,8 @@ class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQue
             }
             nodeMap.put(it.source, modelImport, it.modelReferenceNodeId)
         }
+        resolvableModelImports.clear()
     }
-
-    fun clearResolvableModelImports() = resolvableModelImports.clear()
 }
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -16,9 +16,16 @@
 
 package org.modelix.mps.sync.transformation.modelixToMps.transformers
 
+import com.intellij.openapi.diagnostic.logger
+import jetbrains.mps.extapi.model.EditableSModelBase
+import jetbrains.mps.extapi.model.SModelBase
+import jetbrains.mps.extapi.module.SModuleBase
+import jetbrains.mps.model.ModelDeleteHelper
+import jetbrains.mps.project.DevKit
 import jetbrains.mps.project.structure.modules.ModuleReference
 import jetbrains.mps.smodel.ModelImports
 import jetbrains.mps.smodel.SModelReference
+import org.jetbrains.mps.openapi.language.SLanguage
 import org.jetbrains.mps.openapi.model.EditableSModel
 import org.jetbrains.mps.openapi.model.SModel
 import org.jetbrains.mps.openapi.module.SModule
@@ -27,10 +34,15 @@ import org.jetbrains.mps.openapi.persistence.PersistenceFacade
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
+import org.modelix.mps.sync.mps.util.ModelRenameHelper
 import org.modelix.mps.sync.mps.util.createModel
+import org.modelix.mps.sync.mps.util.deleteDevKit
+import org.modelix.mps.sync.mps.util.deleteLanguage
 import org.modelix.mps.sync.tasks.SyncDirection
 import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
+import org.modelix.mps.sync.transformation.cache.ModelWithModelReference
+import org.modelix.mps.sync.transformation.cache.ModelWithModuleReference
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.util.getModel
 import org.modelix.mps.sync.util.getModule
@@ -39,7 +51,10 @@ import org.modelix.mps.sync.util.nodeIdAsLong
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQueue: SyncQueue) {
 
+    private val logger = logger<ModelTransformer>()
+
     private val resolvableModelImports = mutableListOf<ResolvableModelImport>()
+
     fun transformToModel(iNode: INode) {
         val name = iNode.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name)
         check(name != null) { "Model's ($iNode) name is null" }
@@ -53,7 +68,10 @@ class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQue
         val modelId = PersistenceFacade.getInstance().createModelId(serializedId)
 
         lateinit var sModel: EditableSModel
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
+        syncQueue.enqueueBlocking(
+            linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ),
+            SyncDirection.MODELIX_TO_MPS,
+        ) {
             val modelDoesNotExist = module.getModel(modelId) == null
             if (modelDoesNotExist) {
                 sModel = module.createModel(name, modelId) as EditableSModel
@@ -98,6 +116,107 @@ class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQue
             nodeMap.put(it.source, modelImport, it.modelReferenceNodeId)
         }
         resolvableModelImports.clear()
+    }
+
+    fun modelPropertyChanged(sModel: SModel, role: String, newValue: String?, nodeId: Long) {
+        val modelId = sModel.modelId
+
+        if (role == BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name.getSimpleName()) {
+            val oldValue = sModel.name.value
+            if (oldValue != newValue) {
+                if (newValue.isNullOrEmpty()) {
+                    logger.error("Name cannot be null or empty for Model $modelId. Corresponding Modelix Node ID is $nodeId.")
+                    return
+                } else if (sModel !is EditableSModelBase) {
+                    logger.error("SModel ($modelId) is not an EditableSModelBase, therefore it cannot be renamed. Corresponding Modelix Node ID is $nodeId.")
+                    return
+                }
+
+                ModelRenameHelper(sModel).renameModel(newValue)
+            }
+        } else if (role == BuiltinLanguages.MPSRepositoryConcepts.Model.stereotype.getSimpleName()) {
+            val oldValue = sModel.name.stereotype
+            if (oldValue != newValue) {
+                if (sModel !is EditableSModelBase) {
+                    logger.error("SModel ($modelId) is not an EditableSModelBase, therefore it cannot be renamed. Corresponding Modelix Node ID is $nodeId.")
+                    return
+                }
+
+                ModelRenameHelper(sModel).changeStereotype(newValue)
+            }
+        } else {
+            logger.error("Role $role is unknown for concept Model. Therefore the property is not set in MPS from Modelix Node $nodeId")
+        }
+    }
+
+    fun modelMovedToNewParent(newParentId: Long, nodeId: Long, sModel: SModel) {
+        val newParentModule = nodeMap.getModule(newParentId)
+        if (newParentModule == null) {
+            logger.error("Modelix Node ($nodeId) that is a Model, was not moved to a new parent module, because new parent Module (Modelix Node $newParentId) was not mapped to MPS yet.")
+            return
+        }
+
+        val oldParentModule = sModel.module
+        if (oldParentModule == newParentModule) {
+            return
+        }
+
+        // remove from old parent
+        if (oldParentModule !is SModuleBase) {
+            logger.error("Old parent Module ${oldParentModule?.moduleId} of Model ${sModel.modelId} is not an SModuleBase. Therefore parent of Modelix Node $nodeId was not changed in MPS.")
+            return
+        } else if (sModel !is SModelBase) {
+            logger.error("Model ${sModel.modelId} is not an SModelBase")
+            return
+        }
+        oldParentModule.unregisterModel(sModel)
+        sModel.module = null
+
+        // add to new parent
+        if (newParentModule !is SModuleBase) {
+            logger.error("New parent Module ${newParentModule.moduleId} is not an SModuleBase. Therefore parent of Modelix Node $nodeId was not changed in MPS.")
+            return
+        }
+        newParentModule.registerModel(sModel)
+    }
+
+    fun modelDeleted(sModel: SModel, nodeId: Long) {
+        ModelDeleteHelper(sModel).delete()
+        nodeMap.remove(nodeId)
+    }
+
+    fun modeImportDeleted(outgoingModelReference: ModelWithModelReference) {
+        ModelImports(outgoingModelReference.source).removeModelImport(outgoingModelReference.modelReference)
+    }
+
+    fun moduleDependencyOfModelDeleted(modelWithModuleReference: ModelWithModuleReference, nodeId: Long) {
+        val sourceModel = modelWithModuleReference.source
+        val targetModuleReference = modelWithModuleReference.moduleReference
+        when (val targetModule = targetModuleReference.resolve(sourceModel.repository)) {
+            is SLanguage -> {
+                try {
+                    sourceModel.deleteLanguage(targetModule)
+                } catch (ex: Exception) {
+                    val message =
+                        "Language import ($targetModule) cannot be deleted, because ${ex.message} Corresponding Modelix Node ID is $nodeId."
+                    logger.error(message, ex)
+                }
+            }
+
+            is DevKit -> {
+                try {
+                    sourceModel.deleteDevKit(targetModuleReference)
+                } catch (ex: Exception) {
+                    val message =
+                        "DevKit dependency ($targetModule) cannot be deleted, because ${ex.message} Corresponding Modelix Node ID is $nodeId."
+                    logger.error(message, ex)
+                }
+            }
+
+            else -> {
+                logger.error("Target module referred by $targetModuleReference is neither a Language nor DevKit. Therefore the dependency for it cannot be deleted. Corresponding Modelix Node ID is $nodeId.")
+            }
+        }
     }
 }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModelTransformer.kt
@@ -23,9 +23,10 @@ import jetbrains.mps.extapi.module.SModuleBase
 import jetbrains.mps.model.ModelDeleteHelper
 import jetbrains.mps.project.DevKit
 import jetbrains.mps.project.structure.modules.ModuleReference
+import jetbrains.mps.smodel.Language
 import jetbrains.mps.smodel.ModelImports
 import jetbrains.mps.smodel.SModelReference
-import org.jetbrains.mps.openapi.language.SLanguage
+import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory
 import org.jetbrains.mps.openapi.model.EditableSModel
 import org.jetbrains.mps.openapi.model.SModel
 import org.jetbrains.mps.openapi.module.SModule
@@ -193,9 +194,10 @@ class ModelTransformer(private val nodeMap: MpsToModelixMap, private val syncQue
         val sourceModel = modelWithModuleReference.source
         val targetModuleReference = modelWithModuleReference.moduleReference
         when (val targetModule = targetModuleReference.resolve(sourceModel.repository)) {
-            is SLanguage -> {
+            is Language -> {
                 try {
-                    sourceModel.deleteLanguage(targetModule)
+                    val sLanguage = MetaAdapterFactory.getLanguage(targetModuleReference)
+                    sourceModel.deleteLanguage(sLanguage)
                 } catch (ex: Exception) {
                     val message =
                         "Language import ($targetModule) cannot be deleted, because ${ex.message} Corresponding Modelix Node ID is $nodeId."

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
@@ -26,9 +26,10 @@ import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
 import org.modelix.mps.sync.mps.factories.SolutionProducer
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.nodeIdAsLong
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
@@ -52,7 +53,7 @@ class ModuleTransformer(private val nodeMap: MpsToModelixMap, private val syncQu
         check(name != null) { "Module's ($iNode) name is null" }
 
         var sModule: AbstractModule? = null
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE)) {
+        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
             sModule = solutionProducer.createOrGetModule(name, moduleId as ModuleId)
             sModule // ignored
         }
@@ -72,7 +73,7 @@ class ModuleTransformer(private val nodeMap: MpsToModelixMap, private val syncQu
         val moduleName = iNode.getPropertyValue(BuiltinLanguages.MPSRepositoryConcepts.ModuleDependency.name)
         val moduleId = getTargetModuleIdFromModuleDependency(iNode)
         val moduleReference = ModuleReference(moduleName, moduleId)
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE)) {
+        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_WRITE), SyncDirection.MODELIX_TO_MPS) {
             parentModule.addDependency(moduleReference, reexport)
         }
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/ModuleTransformer.kt
@@ -16,21 +16,32 @@
 
 package org.modelix.mps.sync.transformation.modelixToMps.transformers
 
+import com.intellij.openapi.diagnostic.logger
+import jetbrains.mps.model.ModelDeleteHelper
+import jetbrains.mps.module.ModuleDeleteHelper
 import jetbrains.mps.project.AbstractModule
 import jetbrains.mps.project.MPSProject
 import jetbrains.mps.project.ModuleId
+import jetbrains.mps.project.Project
 import jetbrains.mps.project.structure.modules.ModuleReference
+import jetbrains.mps.project.structure.modules.SolutionDescriptor
+import jetbrains.mps.refactoring.Renamer
+import org.jetbrains.mps.openapi.module.SModule
 import org.jetbrains.mps.openapi.module.SModuleId
 import org.jetbrains.mps.openapi.persistence.PersistenceFacade
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
+import org.modelix.mps.sync.mps.ActiveMpsProjectInjector
 import org.modelix.mps.sync.mps.factories.SolutionProducer
 import org.modelix.mps.sync.tasks.SyncDirection
 import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
+import org.modelix.mps.sync.transformation.cache.ModuleWithModuleReference
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
+import org.modelix.mps.sync.util.BooleanUtil
 import org.modelix.mps.sync.util.nodeIdAsLong
+import java.text.ParseException
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModuleTransformer(private val nodeMap: MpsToModelixMap, private val syncQueue: SyncQueue, project: MPSProject) {
@@ -41,6 +52,8 @@ class ModuleTransformer(private val nodeMap: MpsToModelixMap, private val syncQu
             return PersistenceFacade.getInstance().createModuleId(uuid)
         }
     }
+
+    private val logger = logger<ModuleTransformer>()
 
     private val solutionProducer = SolutionProducer(project)
 
@@ -78,5 +91,81 @@ class ModuleTransformer(private val nodeMap: MpsToModelixMap, private val syncQu
         }
 
         nodeMap.put(parentModule, moduleReference, iNode.nodeIdAsLong())
+    }
+
+    fun modulePropertyChanged(role: String, nodeId: Long, sModule: SModule, newValue: String?) {
+        val moduleId = sModule.moduleId
+        if (sModule !is AbstractModule) {
+            logger.error("SModule ($moduleId) is not an AbstractModule, therefore its $role property cannot be changed. Corresponding Modelix Node ID is $nodeId.")
+            return
+        }
+
+        if (role == BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name.getSimpleName()) {
+            val oldValue = sModule.moduleName
+            if (oldValue != newValue) {
+                if (newValue.isNullOrEmpty()) {
+                    logger.error("Name cannot be null or empty for Module $moduleId. Corresponding Modelix Node ID is $nodeId.")
+                    return
+                }
+
+                val activeProject = ActiveMpsProjectInjector.activeMpsProject as Project
+                Renamer(activeProject).renameModule(sModule, newValue)
+            }
+        } else if (role == BuiltinLanguages.MPSRepositoryConcepts.Module.moduleVersion.getSimpleName()) {
+            try {
+                val newVersion = newValue?.toInt() ?: return
+                val oldVersion = sModule.moduleVersion
+                if (oldVersion != newVersion) {
+                    sModule.moduleVersion = newVersion
+                }
+            } catch (ex: NumberFormatException) {
+                logger.error("New module version ($newValue) of SModule ($moduleId) is not an integer, therefore it cannot be set in MPS. Corresponding Modelix Node ID is $nodeId.")
+            }
+        } else if (role == BuiltinLanguages.MPSRepositoryConcepts.Module.compileInMPS.getSimpleName()) {
+            try {
+                val newCompileInMPS = newValue?.let { BooleanUtil.toBooleanStrict(it) } ?: return
+                val moduleDescriptor = sModule.moduleDescriptor ?: return
+                val oldCompileInMPS = moduleDescriptor.compileInMPS
+                if (oldCompileInMPS != newCompileInMPS) {
+                    if (moduleDescriptor !is SolutionDescriptor) {
+                        logger.error("Module ($moduleId)'s descriptor is not a SolutionDescriptor, therefore compileInMPS will not be (un)set in MPS. Corresponding Modelix Node ID is $nodeId.")
+                        return
+                    }
+                    moduleDescriptor.compileInMPS = newCompileInMPS
+                }
+            } catch (ex: ParseException) {
+                logger.error("New compileInMPS ($newValue) property of SModule ($moduleId) is not a strict boolean, therefore it cannot be set in MPS. Corresponding Modelix Node ID is $nodeId.")
+            }
+        } else {
+            logger.error("Role $role is unknown for concept Module. Therefore the property is not set in MPS from Modelix Node $nodeId")
+        }
+    }
+
+    fun moduleDeleted(sModule: SModule, nodeId: Long) {
+        sModule.models.forEach { model ->
+            val modelNodeId = nodeMap[model]
+            ModelDeleteHelper(model).delete()
+            modelNodeId?.let { nodeMap.remove(it) }
+        }
+        val project = ActiveMpsProjectInjector.activeMpsProject!!
+        ModuleDeleteHelper(project).deleteModules(listOf(sModule), false, true)
+        nodeMap.remove(nodeId)
+    }
+
+    fun outgoingModuleReferenceFromModuleDeleted(moduleWithModuleReference: ModuleWithModuleReference, nodeId: Long) {
+        val sourceModule = moduleWithModuleReference.source
+        if (sourceModule !is AbstractModule) {
+            logger.error("Source module ($sourceModule) is not an AbstractModule, therefore outgoing module dependency reference cannot be removed. Corresponding Modelix Node ID is $nodeId.")
+            return
+        }
+
+        val targetModuleReference = moduleWithModuleReference.moduleReference
+        val dependency =
+            sourceModule.moduleDescriptor?.dependencies?.firstOrNull { it.moduleRef == targetModuleReference }
+        if (dependency != null) {
+            sourceModule.removeDependency(dependency)
+        } else {
+            logger.error("Outgoing dependency $targetModuleReference from Module $sourceModule is not found, therefore it cannot be deleted. Corresponding Modelix Node ID is $nodeId.")
+        }
     }
 }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
@@ -131,9 +131,10 @@ class NodeTransformer(
         }
     }
 
-    fun resolveReferences() = nodeFactory.resolveReferences()
-
-    fun clearResolvableReferences() = nodeFactory.clearResolvableReferences()
+    fun resolveReferences() {
+        nodeFactory.resolveReferences()
+        nodeFactory.clearResolvableReferences()
+    }
 
     private fun getDependentModule(iNode: INode): SModule {
         val uuid = iNode.getPropertyValue(BuiltinLanguages.MPSRepositoryConcepts.LanguageDependency.uuid)!!

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/modelixToMps/transformers/NodeTransformer.kt
@@ -30,9 +30,10 @@ import org.modelix.mps.sync.mps.ActiveMpsProjectInjector
 import org.modelix.mps.sync.mps.factories.SNodeFactory
 import org.modelix.mps.sync.mps.util.addDevKit
 import org.modelix.mps.sync.mps.util.addLanguageImport
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.getModel
 import org.modelix.mps.sync.util.isDevKitDependency
 import org.modelix.mps.sync.util.isModel
@@ -75,7 +76,7 @@ class NodeTransformer(
     }
 
     fun transformLanguageDependency(iNode: INode) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ)) {
+        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
             val dependentModule = getDependentModule(iNode)
             val languageModuleReference = (dependentModule as Language).moduleReference
             val sLanguage = MetaAdapterFactory.getLanguage(languageModuleReference)
@@ -105,7 +106,7 @@ class NodeTransformer(
     }
 
     fun transformDevKitDependency(iNode: INode) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ)) {
+        syncQueue.enqueue(linkedSetOf(SyncLock.MPS_WRITE, SyncLock.MODELIX_READ), SyncDirection.MODELIX_TO_MPS) {
             val dependentModule = getDependentModule(iNode)
             val devKitModuleReference = (dependentModule as DevKit).moduleReference
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
@@ -50,23 +50,27 @@ class ModelChangeListener(
     private val modelSynchronizer = ModelSynchronizer(branch, nodeMap, bindingsRegistry, syncQueue)
     private val nodeSynchronizer = NodeSynchronizer(branch, nodeMap, syncQueue)
 
-    override fun importAdded(event: SModelImportEvent) = modelSynchronizer.addModelImport(event.model, event.modelUID)
+    override fun importAdded(event: SModelImportEvent) {
+        modelSynchronizer.addModelImport(event.model, event.modelUID)
+    }
 
     override fun importRemoved(event: SModelImportEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },
         childNodeIdProducer = { it[event.model, event.modelUID]!! },
     )
 
-    override fun languageAdded(event: SModelLanguageEvent) =
+    override fun languageAdded(event: SModelLanguageEvent) {
         modelSynchronizer.addLanguageDependency(event.model, event.eventLanguage)
+    }
 
     override fun languageRemoved(event: SModelLanguageEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },
         childNodeIdProducer = { it[event.model, event.eventLanguage.sourceModuleReference]!! },
     )
 
-    override fun devkitAdded(event: SModelDevKitEvent) =
+    override fun devkitAdded(event: SModelDevKitEvent) {
         modelSynchronizer.addDevKitDependency(event.model, event.devkitNamespace)
+    }
 
     override fun devkitRemoved(event: SModelDevKitEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
@@ -50,7 +50,7 @@ class ModelChangeListener(
     private val modelSynchronizer = ModelSynchronizer(branch, nodeMap, bindingsRegistry, syncQueue)
     private val nodeSynchronizer = NodeSynchronizer(branch, nodeMap, syncQueue)
 
-    override fun importAdded(event: SModelImportEvent) = modelSynchronizer.addModelImport(event.model, event.modelUID)
+    override fun importAdded(event: SModelImportEvent) = modelSynchronizer.addModelImportAsync(event.model, event.modelUID)
 
     override fun importRemoved(event: SModelImportEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },
@@ -58,7 +58,7 @@ class ModelChangeListener(
     )
 
     override fun languageAdded(event: SModelLanguageEvent) =
-        modelSynchronizer.addLanguageDependency(event.model, event.eventLanguage)
+        modelSynchronizer.addLanguageDependencyAsync(event.model, event.eventLanguage)
 
     override fun languageRemoved(event: SModelLanguageEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },
@@ -66,7 +66,7 @@ class ModelChangeListener(
     )
 
     override fun devkitAdded(event: SModelDevKitEvent) =
-        modelSynchronizer.addDevKitDependency(event.model, event.devkitNamespace)
+        modelSynchronizer.addDevKitDependencyAsync(event.model, event.devkitNamespace)
 
     override fun devkitRemoved(event: SModelDevKitEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
@@ -33,10 +33,10 @@ import org.modelix.model.api.IBranch
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.bindings.ModelBinding
 import org.modelix.mps.sync.mps.ApplicationLifecycleTracker
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.ModelSynchronizer
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.NodeSynchronizer
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelChangeListener(

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModelChangeListener.kt
@@ -50,7 +50,7 @@ class ModelChangeListener(
     private val modelSynchronizer = ModelSynchronizer(branch, nodeMap, bindingsRegistry, syncQueue)
     private val nodeSynchronizer = NodeSynchronizer(branch, nodeMap, syncQueue)
 
-    override fun importAdded(event: SModelImportEvent) = modelSynchronizer.addModelImportAsync(event.model, event.modelUID)
+    override fun importAdded(event: SModelImportEvent) = modelSynchronizer.addModelImport(event.model, event.modelUID)
 
     override fun importRemoved(event: SModelImportEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },
@@ -58,7 +58,7 @@ class ModelChangeListener(
     )
 
     override fun languageAdded(event: SModelLanguageEvent) =
-        modelSynchronizer.addLanguageDependencyAsync(event.model, event.eventLanguage)
+        modelSynchronizer.addLanguageDependency(event.model, event.eventLanguage)
 
     override fun languageRemoved(event: SModelLanguageEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },
@@ -66,7 +66,7 @@ class ModelChangeListener(
     )
 
     override fun devkitAdded(event: SModelDevKitEvent) =
-        modelSynchronizer.addDevKitDependencyAsync(event.model, event.devkitNamespace)
+        modelSynchronizer.addDevKitDependency(event.model, event.devkitNamespace)
 
     override fun devkitRemoved(event: SModelDevKitEvent) = nodeSynchronizer.removeNode(
         parentNodeIdProducer = { it[event.model]!! },

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
@@ -29,6 +29,7 @@ import org.modelix.model.api.IBranch
 import org.modelix.model.api.getNode
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.mps.ApplicationLifecycleTracker
+import org.modelix.mps.sync.tasks.InspectionMode
 import org.modelix.mps.sync.tasks.SyncDirection
 import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
@@ -70,7 +71,11 @@ class ModuleChangeListener(
     }
 
     override fun moduleChanged(module: SModule) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX, true) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val iModuleNodeId = nodeMap[module]!!
             val iModule = branch.getNode(iModuleNodeId)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
@@ -79,7 +79,7 @@ class ModuleChangeListener(
             val iName = iModule.getPropertyValue(nameProperty)
             val actualName = module.moduleName!!
             if (actualName != iName) {
-                nodeSynchronizer.runSetPropertyAction(
+                nodeSynchronizer.setProperty(
                     nameProperty,
                     actualName,
                     sourceNodeIdProducer = { iModuleNodeId },
@@ -95,7 +95,7 @@ class ModuleChangeListener(
                     ModuleTransformer.getTargetModuleIdFromModuleDependency(dependencyINode) == sDependency.targetModule.moduleId
                 }
             }
-            addedDependencies.forEach { dependency -> moduleSynchronizer.runAddDependencyAction(module, dependency) }
+            addedDependencies.forEach { dependency -> moduleSynchronizer.addDependency(module, dependency) }
 
             val removedDependencies = lastKnownDependencies.filter { dependencyINode ->
                 val targetModuleIdAccordingToModelix =
@@ -105,7 +105,7 @@ class ModuleChangeListener(
                 }
             }
             removedDependencies.forEach { dependencyINode ->
-                nodeSynchronizer.runRemoveNodeAction(
+                nodeSynchronizer.removeNode(
                     parentNodeIdProducer = { it[module]!! },
                     childNodeIdProducer = { dependencyINode.nodeIdAsLong() },
                 )

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
@@ -95,7 +95,7 @@ class ModuleChangeListener(
                     ModuleTransformer.getTargetModuleIdFromModuleDependency(dependencyINode) == sDependency.targetModule.moduleId
                 }
             }
-            addedDependencies.forEach { dependency -> moduleSynchronizer.addDependency(module, dependency) }
+            addedDependencies.forEach { dependency -> moduleSynchronizer.addDependencyAsync(module, dependency) }
 
             val removedDependencies = lastKnownDependencies.filter { dependencyINode ->
                 val targetModuleIdAccordingToModelix =

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
@@ -29,13 +29,14 @@ import org.modelix.model.api.IBranch
 import org.modelix.model.api.getNode
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.mps.ApplicationLifecycleTracker
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.modelixToMps.transformers.ModuleTransformer
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.ModelSynchronizer
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.ModuleSynchronizer
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.NodeSynchronizer
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.nodeIdAsLong
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
@@ -69,7 +70,7 @@ class ModuleChangeListener(
     }
 
     override fun moduleChanged(module: SModule) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), true) {
+        syncQueue.enqueue(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX, true) {
             val iModuleNodeId = nodeMap[module]!!
             val iModule = branch.getNode(iModuleNodeId)
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/ModuleChangeListener.kt
@@ -100,7 +100,7 @@ class ModuleChangeListener(
                     ModuleTransformer.getTargetModuleIdFromModuleDependency(dependencyINode) == sDependency.targetModule.moduleId
                 }
             }
-            addedDependencies.forEach { dependency -> moduleSynchronizer.addDependencyAsync(module, dependency) }
+            addedDependencies.forEach { dependency -> moduleSynchronizer.addDependency(module, dependency) }
 
             val removedDependencies = lastKnownDependencies.filter { dependencyINode ->
                 val targetModuleIdAccordingToModelix =

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
@@ -37,7 +37,7 @@ class NodeChangeListener(
 
     private val synchronizer = NodeSynchronizer(branch, nodeMap, syncQueue)
 
-    override fun nodeAdded(event: SNodeAddEvent) = synchronizer.addNodeAsync(event.child)
+    override fun nodeAdded(event: SNodeAddEvent) = synchronizer.addNode(event.child)
 
     override fun nodeRemoved(event: SNodeRemoveEvent) = synchronizer.removeNode(
         parentNodeIdProducer = {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
@@ -23,6 +23,7 @@ import org.jetbrains.mps.openapi.event.SReferenceChangeEvent
 import org.jetbrains.mps.openapi.model.SNodeChangeListener
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.IBranch
+import org.modelix.model.mpsadapters.MPSProperty
 import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.NodeSynchronizer
@@ -36,7 +37,7 @@ class NodeChangeListener(
 
     private val synchronizer = NodeSynchronizer(branch, nodeMap, syncQueue)
 
-    override fun nodeAdded(event: SNodeAddEvent) = synchronizer.addNode(event.child)
+    override fun nodeAdded(event: SNodeAddEvent) = synchronizer.addNodeAsync(event.child)
 
     override fun nodeRemoved(event: SNodeRemoveEvent) = synchronizer.removeNode(
         parentNodeIdProducer = {
@@ -50,7 +51,7 @@ class NodeChangeListener(
     )
 
     override fun propertyChanged(event: SPropertyChangeEvent) =
-        synchronizer.setProperty(event.property, event.newValue) { it[event.node]!! }
+        synchronizer.setProperty(MPSProperty(event.property), event.newValue) { it[event.node]!! }
 
     override fun referenceChanged(event: SReferenceChangeEvent) {
         // TODO fix me: it does not work correctly, if event.newValue.targetNode points to a node that is in a different model, that has not been synced yet to model server...

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
@@ -37,7 +37,9 @@ class NodeChangeListener(
 
     private val synchronizer = NodeSynchronizer(branch, nodeMap, syncQueue)
 
-    override fun nodeAdded(event: SNodeAddEvent) = synchronizer.addNode(event.child)
+    override fun nodeAdded(event: SNodeAddEvent) {
+        synchronizer.addNode(event.child)
+    }
 
     override fun nodeRemoved(event: SNodeRemoveEvent) = synchronizer.removeNode(
         parentNodeIdProducer = {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/incremental/NodeChangeListener.kt
@@ -23,9 +23,9 @@ import org.jetbrains.mps.openapi.event.SReferenceChangeEvent
 import org.jetbrains.mps.openapi.model.SNodeChangeListener
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.model.api.IBranch
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.NodeSynchronizer
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class NodeChangeListener(

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -30,6 +30,7 @@ import org.modelix.mps.sync.IBinding
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.bindings.ModelBinding
 import org.modelix.mps.sync.tasks.ContinuableSyncTask
+import org.modelix.mps.sync.tasks.InspectionMode
 import org.modelix.mps.sync.tasks.SyncDirection
 import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
@@ -65,7 +66,11 @@ class ModelSynchronizer(
     }
 
     private fun addModelAsync(model: SModelBase): ContinuableSyncTask =
-        syncQueue.enqueue(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.NONE),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             addModelSync(model).getResult()
         }
 
@@ -73,7 +78,7 @@ class ModelSynchronizer(
         syncQueue.enqueueBlocking(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
-            true,
+            InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             val moduleModelixId = nodeMap[model.module]!!
             val models = BuiltinLanguages.MPSRepositoryConcepts.Module.models
@@ -115,13 +120,21 @@ class ModelSynchronizer(
     }
 
     fun addModelImportAsync(model: SModel, importedModelReference: SModelReference) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.NONE),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             addModelImportSync(model, importedModelReference)
         }
     }
 
     private fun addModelImportSync(model: SModel, importedModelReference: SModelReference) {
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX, true) {
+        syncQueue.enqueueBlocking(
+            linkedSetOf(SyncLock.MPS_READ),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             val targetModel = importedModelReference.resolve(model.repository)
             if (resolvableModelImports != null) {
                 resolvableModelImports.add(CloudResolvableModelImport(model, targetModel))
@@ -152,7 +165,11 @@ class ModelSynchronizer(
     }
 
     fun addLanguageDependencyAsync(model: SModel, language: SLanguage) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.NONE),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             addLanguageDependencySync(model, language)
         }
     }
@@ -161,7 +178,7 @@ class ModelSynchronizer(
         syncQueue.enqueueBlocking(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
-            true,
+            InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             val modelixId = nodeMap[model]!!
 
@@ -197,7 +214,11 @@ class ModelSynchronizer(
     }
 
     fun addDevKitDependencyAsync(model: SModel, devKit: SModuleReference) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.NONE),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             addDevKitDependencySync(model, devKit)
         }
     }
@@ -206,7 +227,7 @@ class ModelSynchronizer(
         syncQueue.enqueueBlocking(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
-            true,
+            InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             val modelixId = nodeMap[model]!!
 

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -36,7 +36,7 @@ import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.util.nodeIdAsLong
-import org.modelix.mps.sync.util.waitForCompletionOnEach
+import org.modelix.mps.sync.util.waitForCompletionOfEachTask
 import java.util.concurrent.CopyOnWriteArrayList
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
@@ -84,28 +84,28 @@ class ModelSynchronizer(
             synchronizeModelProperties(cloudModel, model)
 
             // synchronize root nodes
-            model.rootNodes.waitForCompletionOnEach { nodeSynchronizer.addNode(it) }
+            model.rootNodes.waitForCompletionOfEachTask { nodeSynchronizer.addNode(it) }
         }.continueWith(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             // synchronize model imports
-            model.modelImports.waitForCompletionOnEach { addModelImport(model, it) }
+            model.modelImports.waitForCompletionOfEachTask { addModelImport(model, it) }
         }.continueWith(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             // synchronize language dependencies
-            model.importedLanguageIds().waitForCompletionOnEach { addLanguageDependency(model, it) }
+            model.importedLanguageIds().waitForCompletionOfEachTask { addLanguageDependency(model, it) }
         }.continueWith(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             // synchronize devKits
-            model.importedDevkits().waitForCompletionOnEach { addDevKitDependency(model, it) }
+            model.importedDevkits().waitForCompletionOfEachTask { addDevKitDependency(model, it) }
         }.continueWith(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -59,7 +59,7 @@ class ModelSynchronizer(
 
     fun addModelAndActivate(model: SModelBase) {
         addModel(model)
-            .continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+            .continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.NONE) {
                 (it as IBinding).activate()
             }
     }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -36,6 +36,7 @@ import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.util.nodeIdAsLong
+import java.util.concurrent.CopyOnWriteArrayList
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelSynchronizer(
@@ -47,13 +48,13 @@ class ModelSynchronizer(
 ) {
 
     private val nodeSynchronizer = if (postponeReferenceResolution) {
-        NodeSynchronizer(branch, nodeMap, syncQueue, mutableListOf())
+        NodeSynchronizer(branch, nodeMap, syncQueue, CopyOnWriteArrayList<CloudResolvableReference>())
     } else {
         NodeSynchronizer(branch, nodeMap, syncQueue)
     }
 
     private val resolvableModelImports = if (postponeReferenceResolution) {
-        mutableListOf<CloudResolvableModelImport>()
+        CopyOnWriteArrayList<CloudResolvableModelImport>()
     } else {
         null
     }

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModelSynchronizer.kt
@@ -82,32 +82,36 @@ class ModelSynchronizer(
             nodeMap.put(model, cloudModel.nodeIdAsLong())
 
             synchronizeModelProperties(cloudModel, model)
-
+        }.continueWith(
+            linkedSetOf(SyncLock.MPS_READ),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             // synchronize root nodes
             model.rootNodes.waitForCompletionOfEachTask { nodeSynchronizer.addNode(it) }
         }.continueWith(
-            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
+            linkedSetOf(SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             // synchronize model imports
             model.modelImports.waitForCompletionOfEachTask { addModelImport(model, it) }
         }.continueWith(
-            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
+            linkedSetOf(SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             // synchronize language dependencies
             model.importedLanguageIds().waitForCompletionOfEachTask { addLanguageDependency(model, it) }
         }.continueWith(
-            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
+            linkedSetOf(SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             // synchronize devKits
             model.importedDevkits().waitForCompletionOfEachTask { addDevKitDependency(model, it) }
         }.continueWith(
-            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
+            linkedSetOf(SyncLock.NONE),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -38,7 +38,7 @@ import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.util.nodeIdAsLong
-import org.modelix.mps.sync.util.waitForCompletionOnEach
+import org.modelix.mps.sync.util.waitForCompletionOfEachTask
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModuleSynchronizer(
@@ -62,10 +62,10 @@ class ModuleSynchronizer(
 
             synchronizeModuleProperties(cloudModule, module)
             // synchronize dependencies
-            module.declaredDependencies.waitForCompletionOnEach { addDependency(module, it) }
+            module.declaredDependencies.waitForCompletionOfEachTask { addDependency(module, it) }
         }.continueWith(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             // synchronize models
-            module.models.waitForCompletionOnEach { modelSynchronizer.addModel(it as SModelBase) }
+            module.models.waitForCompletionOfEachTask { modelSynchronizer.addModel(it as SModelBase) }
         }.continueWith(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             // resolve cross-model references
             modelSynchronizer.resolveCrossModelReferences()

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -32,9 +32,10 @@ import org.modelix.model.api.getNode
 import org.modelix.model.api.getRootNode
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.bindings.ModuleBinding
+import org.modelix.mps.sync.tasks.SyncDirection
+import org.modelix.mps.sync.tasks.SyncLock
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
-import org.modelix.mps.sync.util.SyncLock
-import org.modelix.mps.sync.util.SyncQueue
 import org.modelix.mps.sync.util.nodeIdAsLong
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
@@ -49,7 +50,7 @@ class ModuleSynchronizer(
         ModelSynchronizer(branch, nodeMap, bindingsRegistry, syncQueue, postponeReferenceResolution = true)
 
     fun addModule(module: AbstractModule) {
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ)) {
+        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             val rootNode = branch.getRootNode()
             val cloudModule = rootNode.addNewChild(
                 ChildLinkFromName("modules"),

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -61,15 +61,16 @@ class ModuleSynchronizer(
             nodeMap.put(module, cloudModule.nodeIdAsLong())
 
             synchronizeModuleProperties(cloudModule, module)
+        }.continueWith(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             // synchronize dependencies
             module.declaredDependencies.waitForCompletionOfEachTask { addDependency(module, it) }
-        }.continueWith(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
+        }.continueWith(linkedSetOf(SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             // synchronize models
             module.models.waitForCompletionOfEachTask { modelSynchronizer.addModel(it as SModelBase) }
         }.continueWith(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
             // resolve cross-model references
             modelSynchronizer.resolveCrossModelReferences()
-        }.continueWith(linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ), SyncDirection.MPS_TO_MODELIX) {
+        }.continueWith(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
             // register binding
             val binding = ModuleBinding(module, branch, nodeMap, bindingsRegistry, syncQueue)
             bindingsRegistry.addModuleBinding(binding)

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -32,6 +32,7 @@ import org.modelix.model.api.getNode
 import org.modelix.model.api.getRootNode
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.bindings.ModuleBinding
+import org.modelix.mps.sync.tasks.InspectionMode
 import org.modelix.mps.sync.tasks.SyncDirection
 import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
@@ -74,7 +75,11 @@ class ModuleSynchronizer(
     }
 
     fun addDependencyAsync(module: SModule, dependency: SDependency) {
-        syncQueue.enqueue(linkedSetOf(SyncLock.NONE), SyncDirection.MPS_TO_MODELIX) {
+        syncQueue.enqueue(
+            linkedSetOf(SyncLock.NONE),
+            SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
+        ) {
             addDependencySync(module, dependency)
         }
     }
@@ -83,6 +88,7 @@ class ModuleSynchronizer(
         syncQueue.enqueueBlocking(
             linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
+            InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
             val moduleModelixId = nodeMap[module]!!
             val dependencies = BuiltinLanguages.MPSRepositoryConcepts.Module.dependencies

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/ModuleSynchronizer.kt
@@ -143,7 +143,7 @@ class ModuleSynchronizer(
         )
         cloudModule.setPropertyValue(
             BuiltinLanguages.MPSRepositoryConcepts.Module.moduleVersion,
-            ((module as? AbstractModule)?.moduleDescriptor?.moduleVersion ?: 0).toString(),
+            ((module as? AbstractModule)?.moduleVersion).toString(),
         )
 
         val compileInMPS =

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
@@ -37,13 +37,14 @@ import org.modelix.mps.sync.tasks.SyncLock
 import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.util.nodeIdAsLong
+import java.util.concurrent.CopyOnWriteArrayList
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class NodeSynchronizer(
     private val branch: IBranch,
     private val nodeMap: MpsToModelixMap,
     private val syncQueue: SyncQueue,
-    private val resolvableReferences: MutableList<CloudResolvableReference>? = null,
+    private val resolvableReferences: CopyOnWriteArrayList<CloudResolvableReference>? = null,
 ) {
 
     fun addNodeAsync(node: SNode) {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
@@ -49,7 +49,7 @@ class NodeSynchronizer(
 
     fun addNode(node: SNode) =
         syncQueue.enqueue(
-            linkedSetOf(SyncLock.NONE),
+            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
@@ -174,13 +174,10 @@ class NodeSynchronizer(
         }
     }
 
-    fun resolveReferencesSync() {
-        syncQueue.enqueueBlocking(linkedSetOf(SyncLock.MODELIX_WRITE), SyncDirection.MPS_TO_MODELIX) {
-            resolvableReferences?.forEach { setReferenceInTheCloud(it.sourceNode, it.referenceLink, it.mpsTargetNode) }
-        }
+    fun resolveReferences() {
+        resolvableReferences?.forEach { setReferenceInTheCloud(it.sourceNode, it.referenceLink, it.mpsTargetNode) }
+        resolvableReferences?.clear()
     }
-
-    fun clearResolvableReferences() = resolvableReferences?.clear()
 }
 
 @UnstableModelixFeature(

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/transformation/mpsToModelix/initial/NodeSynchronizer.kt
@@ -47,17 +47,9 @@ class NodeSynchronizer(
     private val resolvableReferences: CopyOnWriteArrayList<CloudResolvableReference>? = null,
 ) {
 
-    fun addNodeAsync(node: SNode) {
+    fun addNode(node: SNode) =
         syncQueue.enqueue(
             linkedSetOf(SyncLock.NONE),
-            SyncDirection.MPS_TO_MODELIX,
-            InspectionMode.CHECK_EXECUTION_THREAD,
-        ) { addNodeSync(node) }
-    }
-
-    fun addNodeSync(node: SNode) {
-        syncQueue.enqueueBlocking(
-            linkedSetOf(SyncLock.MODELIX_WRITE, SyncLock.MPS_READ),
             SyncDirection.MPS_TO_MODELIX,
             InspectionMode.CHECK_EXECUTION_THREAD,
         ) {
@@ -83,7 +75,6 @@ class NodeSynchronizer(
 
             synchronizeNodeToCloud(mpsConcept, node, cloudChildNode)
         }
-    }
 
     private fun synchronizeNodeToCloud(
         mpsConcept: SConcept,

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/BooleanUtil.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/BooleanUtil.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.mps.sync.util
+
+import java.text.ParseException
+
+object BooleanUtil {
+
+    /**
+     * Drop-in replacement, because String.toStringBoolean() does not compile
+     */
+    @Throws(ParseException::class)
+    fun toBooleanStrict(value: String) =
+        when (value) {
+            "true" -> {
+                true
+            }
+
+            "false" -> {
+                false
+            }
+
+            else -> {
+                throw ParseException("Not a boolean", 0)
+            }
+        }
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/SynchronizedCollections.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/SynchronizedCollections.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.mps.sync.util
+
+import org.modelix.kotlin.utils.UnstableModelixFeature
+import java.util.Collections
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+fun <K, V> synchronizedMap(): MutableMap<K, V> = Collections.synchronizedMap(mutableMapOf<K, V>())
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+fun <K> synchronizedLinkedHashSet(): MutableSet<K> = Collections.synchronizedSet(LinkedHashSet<K>())

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/WaitForSubtaskCompletionUtil.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/WaitForSubtaskCompletionUtil.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.mps.sync.util
+
+import org.modelix.kotlin.utils.UnstableModelixFeature
+import org.modelix.mps.sync.tasks.ContinuableSyncTask
+import java.util.concurrent.CompletableFuture
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+fun <T> Collection<T>.waitForCompletion(continuableSyncTaskProducer: (T) -> ContinuableSyncTask) =
+    this.asIterable().waitForCompletion(continuableSyncTaskProducer)
+
+@UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
+fun <T> Iterable<T>.waitForCompletion(continuableSyncTaskProducer: (T) -> ContinuableSyncTask) {
+    val futures = mutableSetOf<CompletableFuture<*>>()
+    this.forEach {
+        val future = continuableSyncTaskProducer.invoke(it).getResult()
+        futures.add(future)
+    }
+    futures.forEach { it.join() }
+}

--- a/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/WaitForSubtaskCompletionUtil.kt
+++ b/mps-sync-plugin-lib/src/main/kotlin/org/modelix/mps/sync/util/WaitForSubtaskCompletionUtil.kt
@@ -21,11 +21,11 @@ import org.modelix.mps.sync.tasks.ContinuableSyncTask
 import java.util.concurrent.CompletableFuture
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
-fun <T> Collection<T>.waitForCompletion(continuableSyncTaskProducer: (T) -> ContinuableSyncTask) =
-    this.asIterable().waitForCompletion(continuableSyncTaskProducer)
+fun <T> Collection<T>.waitForCompletionOnEach(continuableSyncTaskProducer: (T) -> ContinuableSyncTask) =
+    this.asIterable().waitForCompletionOnEach(continuableSyncTaskProducer)
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
-fun <T> Iterable<T>.waitForCompletion(continuableSyncTaskProducer: (T) -> ContinuableSyncTask) {
+fun <T> Iterable<T>.waitForCompletionOnEach(continuableSyncTaskProducer: (T) -> ContinuableSyncTask) {
     val futures = mutableSetOf<CompletableFuture<*>>()
     this.forEach {
         val future = continuableSyncTaskProducer.invoke(it).getResult()

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModelSyncAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModelSyncAction.kt
@@ -25,9 +25,9 @@ import org.jetbrains.mps.openapi.model.SModel
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.modelix.ReplicatedModelRegistry
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.ModelSynchronizer
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModelSyncAction : AnAction {

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModuleSyncAction.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/action/ModuleSyncAction.kt
@@ -25,9 +25,9 @@ import org.jetbrains.mps.openapi.module.SModule
 import org.modelix.kotlin.utils.UnstableModelixFeature
 import org.modelix.mps.sync.bindings.BindingsRegistry
 import org.modelix.mps.sync.modelix.ReplicatedModelRegistry
+import org.modelix.mps.sync.tasks.SyncQueue
 import org.modelix.mps.sync.transformation.cache.MpsToModelixMap
 import org.modelix.mps.sync.transformation.mpsToModelix.initial.ModuleSynchronizer
-import org.modelix.mps.sync.util.SyncQueue
 
 @UnstableModelixFeature(reason = "The new modelix MPS plugin is under construction", intendedFinalization = "2024.1")
 class ModuleSyncAction : AnAction {

--- a/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/gui/ModelSyncGuiFactory.kt
+++ b/mps-sync-plugin/src/main/kotlin/org/modelix/mps/sync/plugin/gui/ModelSyncGuiFactory.kt
@@ -248,7 +248,6 @@ class ModelSyncGuiFactory : ToolWindowFactory, Disposable {
             unbindButton.addActionListener {
                 existingBindingCB.selectedItem?.let {
                     (it as IBinding).deactivate(removeFromServer = false)
-                    existingBindingCB.removeItem(it)
                 }
             }
             bindingsPanel.add(unbindButton)


### PR DESCRIPTION
### Changes in this pull request

- extensive (manual) testing the SyncQueue in various scenarios:
  -  SyncTasks starting new SyncTasks
  - using the async execution semantics extensively by the tasks waiting for each other
  - consecutive tasks are cancelled if a predecessor throws an exception
  - simplifying lock acquisiton (MPS read/write, modelix read/write) in some cases. However, there might be some corner-cases still wherer MPS might get frozen. This is can be also due to some missing dependencies between the SyncTasks. But we'll debug and improve it further as we go on with the plugin.
  - Model/ModuleBinding.deactivate is more thread-safe due to explicit synchronizations
  - Collections that might be accessed from different threads are synchronized. E.g., inside the BindingsRegistry, MpsToModelixMap
  - ModelixTreeChangeVisitor is refactored: 
      - the event-handlers are moved to the Node/Model/ModuleTransformers where they semantically belong (depending on the type of change and the target of the change)
      - errors are logged explicitly, especially if we missed a case that should have been handled. E.g. a Modelix Node is neither an MPS Node/Model/Module.
  - new changes are handled in ModelixTreeChangeVisitor:
      - property change in Models/Module, 
      - deletion of ModelImports, Language/DevKit Dependencies, ModuleDependencies
      - model/module rename. However, module rename still does not work due to [MODELIX-726](https://issues.modelix.org/issue/MODELIX-726).
  - some other refactorings, bugfixes and TODO comments I forgot to mention