### PR TITLE
fix(model-server): handle empty MODELIX_SERVER_MODELQL_WARMUP_BRANCH

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
@@ -96,7 +96,9 @@ class KeyValueLikeModelServer(val repositoriesManager: RepositoriesManager) {
             get<Paths.getHealth> {
                 // eagerly load model into memory to speed up ModelQL queries
                 val branchRef = System.getenv("MODELIX_SERVER_MODELQL_WARMUP_REPOSITORY")?.let { RepositoryId(it) }
-                    ?.getBranchReference(System.getenv("MODELIX_SERVER_MODELQL_WARMUP_BRANCH"))
+                    ?.let { repoId ->
+                        System.getenv("MODELIX_SERVER_MODELQL_WARMUP_BRANCH")?.let { repoId.getBranchReference(it) }
+                    }
                 if (branchRef != null) {
                     val version = repositoriesManager.getVersion(branchRef)
                     if (!repositoriesManager.inMemoryModels.loadModelAsync(version!!.getTree())) {


### PR DESCRIPTION
Don't fail the health check in case the user did not define the new env var MODELIX_SERVER_MODELQL_WARMUP_BRANCH. Before this fix, the health checked returned 500 due to a NullPointerException.