### PR TITLE
fix(model-server): some objects were missing when pulling a version

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import org.apache.commons.collections4.map.LRUMap
 import org.modelix.model.IKeyValueStore
@@ -30,7 +31,6 @@ import org.modelix.model.api.IdGeneratorDummy
 import org.modelix.model.api.PBranch
 import org.modelix.model.api.runSynchronized
 import org.modelix.model.lazy.BranchReference
-import org.modelix.model.lazy.BulkQuery
 import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.IDeserializingKeyValueStore
@@ -246,19 +246,18 @@ class RepositoriesManager(val client: LocalModelClient) {
                 // we have to do this to not emit objects more than once.
                 val seenHashes = mutableSetOf<String>()
                 fun emitObjects(entry: KVEntryReference<*>) {
+                    if (seenHashes.contains(entry.getHash())) return
+                    seenHashes.add(entry.getHash())
                     bulkQuery.get(entry).onSuccess {
-                        channel.trySend(entry.getHash() to it!!.serialize())
-                        for (referencedEntry in it.getReferencedEntries()) {
-                            val wasSeenBefore = !seenHashes.add(referencedEntry.getHash())
-                            // Do not emit the object if we already emitted it.
-                            if (!wasSeenBefore) {
-                                emitObjects(referencedEntry)
-                            }
+                        val value = checkNotNull(it) { "No value received for ${entry.getHash()}" }
+                        runBlocking { channel.send(entry.getHash() to value.serialize()) }
+                        for (referencedEntry in value.getReferencedEntries()) {
+                            emitObjects(referencedEntry)
                         }
                     }
                 }
                 emitObjects(KVEntryReference(versionHash, CPVersion.DESERIALIZER))
-                (bulkQuery as? BulkQuery)?.process()
+                bulkQuery.process()
             }
         }
 


### PR DESCRIPTION
Channel.trySend fails when the buffer is full, but that failure was ignored. Using runBlocking together with Channel.send to wait for space in the buffer.

This was detected by https://github.com/modelix/modelix.mps-plugins/pull/38. The tests in modelix.mps-plugins succeed with this change.

It was broken since version 4.8.1 which includes PR https://github.com/modelix/modelix.core/pull/451. There was already a comment about it https://github.com/modelix/modelix.core/pull/451#issuecomment-1933696866.