### PR TITLE
fix(model-server): RepositoriesManager.computeDelta should wait for channel to have capacity

### DIFF
--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -196,7 +196,10 @@ class ModelClientV2Test {
         val repositoryId = RepositoryId("repo1")
         val branchId = repositoryId.getBranchReference("my-branch")
         modelClientForArrange.runWrite(branchId) { root ->
-            root.addNewChild("aChild", -1, null as IConceptReference?)
+            // Creating many children makes the flow emitting many values at once.
+            repeat(100) {
+                root.addNewChild("aChild", -1, null as IConceptReference?)
+            }
         }
 
         // Act


### PR DESCRIPTION
Previously, sending objects failed quietly when the underlying channel was full. Now, the execution of the bulk query is blocked when the underlying channel is full.