### PR TITLE
perf(bulk-model-sync): use ModelQL to load model data from server

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -328,10 +328,10 @@ class ModelClientV2(
         return ModelQLClient.builder().httpClient(httpClient).url(url.buildString()).build().query(body)
     }
 
-    override suspend fun <R> query(repository: RepositoryId, versionHash: String, body: (IMonoStep<INode>) -> IMonoStep<R>): R {
+    override suspend fun <R> query(repositoryId: RepositoryId, versionHash: String, body: (IMonoStep<INode>) -> IMonoStep<R>): R {
         val url = URLBuilder().apply {
             takeFrom(baseUrl)
-            appendPathSegmentsEncodingSlash("repositories", repository.id, "versions", versionHash, "query")
+            appendPathSegmentsEncodingSlash("repositories", repositoryId.id, "versions", versionHash, "query")
         }
         return ModelQLClient.builder().httpClient(httpClient).url(url.buildString()).build().query(body)
     }


### PR DESCRIPTION
ModelQL does not load data for a previous version.
Reads for ModelQL are optimized with an InMemoryModel. --> Still ModelQL has probably much overhead when serializing. Test it with big model and optimize serialization of INode.
Performance probably degrades when reading specific version, because we do not use bulk queries.