### PR TITLE
MODELIX-789 bulk-model-sync from model-server to MPS results in many renamed files without content changes

### DIFF
--- a/bulk-model-sync-gradle-test/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/build.gradle.kts
@@ -87,7 +87,7 @@ modelSync {
     direction("testPush") {
         includeModulesByPrefix("GraphSolution")
         fromLocal {
-            mpsHeapSize = "2g"
+            mpsHeapSize = "4g"
             repositoryDir = repoDir
         }
         toModelServer {
@@ -107,6 +107,7 @@ modelSync {
         }
         toLocal {
             repositoryDir = repoDir
+            mpsHeapSize = "4g"
         }
     }
 }

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -285,6 +285,7 @@ class ModelImporter(
         nodeData.references.forEach {
             val expectedTargetId = it.value
             val actualTargetId = node.getReferenceTarget(it.key)?.originalId()
+                ?: node.getReferenceTargetRef(it.key)?.serialize()
             if (actualTargetId != expectedTargetId) {
                 val expectedTarget = originalIdToExisting[expectedTargetId]
                 if (expectedTarget == null) {
@@ -296,8 +297,7 @@ class ModelImporter(
         }
         val toBeRemoved = node.getReferenceRoles().toSet() - nodeData.references.keys
         toBeRemoved.forEach {
-            val nullReference: INodeReference? = null
-            node.setReferenceTarget(it, nullReference)
+            node.setReferenceTarget(it, null as INodeReference?)
         }
     }
 }

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -265,7 +265,7 @@ class ModelImporter(
     }
 
     private fun syncProperties(node: INode, nodeData: NodeData) {
-        if (node.getPropertyValue(NodeData.idPropertyKey) == null) {
+        if (node.originalId() == null) {
             node.setPropertyValue(NodeData.idPropertyKey, nodeData.originalId())
         }
 
@@ -303,11 +303,11 @@ class ModelImporter(
 }
 
 internal fun INode.originalId(): String? {
-    return this.getPropertyValue(NodeData.idPropertyKey)
+    return this.getOriginalReference()
 }
 
 internal fun NodeData.originalId(): String? {
-    return properties[NodeData.idPropertyKey] ?: id
+    return properties[NodeData.ID_PROPERTY_KEY] ?: id
 }
 
 data class ExistingAndExpectedNode(

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -211,6 +211,7 @@ interface INode {
      * @return the original reference of this node
      */
     fun getOriginalReference(): String? = getPropertyValue(IProperty.fromName(NodeData.ID_PROPERTY_KEY))
+        ?: getPropertyValue(IProperty.fromName("#mpsNodeID#")) // for backwards compatibility
 
     // <editor-fold desc="non-string based API">
     fun usesRoleIds(): Boolean = false

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
 import org.modelix.model.area.IArea
+import org.modelix.model.data.NodeData
 
 /**
  * Representation of a model element.
@@ -205,6 +206,11 @@ interface INode {
      */
     @Deprecated("use getReferenceLinks()")
     fun getReferenceRoles(): List<String>
+
+    /**
+     * @return the original reference of this node
+     */
+    fun getOriginalReference(): String? = getPropertyValue(IProperty.fromName(NodeData.ID_PROPERTY_KEY))
 
     // <editor-fold desc="non-string based API">
     fun usesRoleIds(): Boolean = false

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -208,7 +208,7 @@ interface INode {
     fun getReferenceRoles(): List<String>
 
     /**
-     * @return the original reference of this node
+     * @return the serialized reference of the source node, if this one was created during an import
      */
     fun getOriginalReference(): String? = getPropertyValue(IProperty.fromName(NodeData.ID_PROPERTY_KEY))
         ?: getPropertyValue(IProperty.fromName("#mpsNodeID#")) // for backwards compatibility

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleProperty.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleProperty.kt
@@ -15,7 +15,7 @@ package org.modelix.model.api
 
 import kotlin.jvm.JvmOverloads
 
-class SimpleProperty
+data class SimpleProperty
 @JvmOverloads constructor(
     private val simpleName: String,
     override val isOptional: Boolean = true,

--- a/model-api/src/commonMain/kotlin/org/modelix/model/data/ModelData.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/data/ModelData.kt
@@ -86,7 +86,11 @@ data class NodeData(
     val references: Map<String, String> = emptyMap(),
 ) {
     companion object {
-        const val ID_PROPERTY_KEY = "#mpsNodeId#"
+
+        /**
+         * Users should not use this directly. Use [INode.getOriginalReference].
+         */
+        const val ID_PROPERTY_KEY = "#originalRef#"
 
         @Deprecated("Use ID_PROPERTY_KEY", replaceWith = ReplaceWith("ID_PROPERTY_KEY"))
         const val idPropertyKey = ID_PROPERTY_KEY

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IDefaultNodeAdapter.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IDefaultNodeAdapter.kt
@@ -38,6 +38,10 @@ interface IDefaultNodeAdapter : IDeprecatedNodeDefaults {
         return concept?.getReference()
     }
 
+    override fun getOriginalReference(): String? {
+        return reference.serialize()
+    }
+
     override fun getPropertyLinks(): List<IProperty> {
         return concept?.getAllProperties() ?: emptyList()
     }

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSDevKitDependencyAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSDevKitDependencyAsNode.kt
@@ -67,9 +67,7 @@ data class MPSDevKitDependencyAsNode(
     }
 
     override fun getPropertyValue(property: IProperty): String? {
-        return if (property.isIdProperty()) {
-            reference.serialize()
-        } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.LanguageDependency.name)) {
+        return if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.LanguageDependency.name)) {
             moduleReference.moduleName
         } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.LanguageDependency.uuid)) {
             moduleReference.moduleId.toString()

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode.kt
@@ -48,9 +48,7 @@ data class MPSJavaModuleFacetAsNode(val facet: JavaModuleFacet) : IDefaultNodeAd
     }
 
     override fun getPropertyValue(property: IProperty): String? {
-        return if (property.isIdProperty()) {
-            reference.serialize()
-        } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.JavaModuleFacet.generated)) {
+        return if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.JavaModuleFacet.generated)) {
             // Should always be true
             // https://github.com/JetBrains/MPS/blob/2820965ff7b8836ed1d14adaf1bde29744c88147/core/project/source/jetbrains/mps/project/facets/JavaModuleFacetImpl.java
             true.toString()

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelAsNode.kt
@@ -111,8 +111,6 @@ data class MPSModelAsNode(val model: SModel) : IDefaultNodeAdapter {
             model.name.value
         } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.Model.id)) {
             model.modelId.toString()
-        } else if (property.isIdProperty()) {
-            reference.serialize()
         } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.Model.stereotype)) {
             model.name.stereotype
         } else {

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelImportAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelImportAsNode.kt
@@ -62,9 +62,6 @@ class MPSModelImportAsNode(val importedModel: SModel, val importingModel: SModel
     }
 
     override fun getPropertyValue(property: IProperty): String? {
-        if (!property.isIdProperty()) {
-            return super.getPropertyValue(property)
-        }
         return reference.serialize()
     }
 

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
@@ -141,8 +141,6 @@ data class MPSModuleAsNode(val module: SModule) : IDefaultNodeAdapter {
             version.toString()
         } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.Module.compileInMPS)) {
             getCompileInMPS().toString()
-        } else if (property.isIdProperty()) {
-            reference.serialize()
         } else {
             null
         }

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleDependencyAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleDependencyAsNode.kt
@@ -58,9 +58,7 @@ data class MPSModuleDependencyAsNode(
     override fun getPropertyValue(property: IProperty): String? {
         val moduleDependency = BuiltinLanguages.MPSRepositoryConcepts.ModuleDependency
 
-        return if (property.isIdProperty()) {
-            reference.serialize()
-        } else if (property.conformsTo(moduleDependency.explicit)) {
+        return if (property.conformsTo(moduleDependency.explicit)) {
             explicit.toString()
         } else if (property.conformsTo(moduleDependency.name)) {
             moduleReference.moduleName

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
@@ -29,7 +29,6 @@ import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.IChildLink
 import org.modelix.model.api.IConcept
 import org.modelix.model.api.IConceptReference
-import org.modelix.model.api.IDeprecatedNodeDefaults
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
 import org.modelix.model.api.IProperty
@@ -37,7 +36,7 @@ import org.modelix.model.api.IReferenceLink
 import org.modelix.model.api.resolveIn
 import org.modelix.model.area.IArea
 
-data class MPSNode(val node: SNode) : IDeprecatedNodeDefaults {
+data class MPSNode(val node: SNode) : IDefaultNodeAdapter {
     override fun getArea(): IArea {
         return MPSArea(node.model?.repository ?: MPSModuleRepository.getInstance())
     }
@@ -159,9 +158,6 @@ data class MPSNode(val node: SNode) : IDeprecatedNodeDefaults {
     }
 
     override fun getPropertyValue(property: IProperty): String? {
-        if (property.isIdProperty()) {
-            return node.nodeId.toString()
-        }
         val mpsProperty = node.properties.firstOrNull { MPSProperty(it).getUID() == property.getUID() } ?: return null
         return node.getProperty(mpsProperty)
     }

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectAsNode.kt
@@ -49,9 +49,7 @@ data class MPSProjectAsNode(val project: ProjectBase) : IDefaultNodeAdapter {
     }
 
     override fun getPropertyValue(property: IProperty): String? {
-        return if (property.isIdProperty()) {
-            reference.serialize()
-        } else if (property.conformsTo(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name)) {
+        return if (property.conformsTo(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name)) {
             project.name
         } else {
             null

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectModuleAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectModuleAsNode.kt
@@ -54,9 +54,7 @@ data class MPSProjectModuleAsNode(val project: ProjectBase, val module: SModule)
     }
 
     override fun getPropertyValue(property: IProperty): String? {
-        return if (property.isIdProperty()) {
-            reference.serialize()
-        } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.ProjectModule.virtualFolder)) {
+        return if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.ProjectModule.virtualFolder)) {
             project.getPath(module)?.virtualFolder
         } else {
             null

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode.kt
@@ -35,9 +35,7 @@ data class MPSSingleLanguageDependencyAsNode(
 ) : IDefaultNodeAdapter {
 
     override fun getPropertyValue(property: IProperty): String? {
-        return if (property.isIdProperty()) {
-            reference.serialize()
-        } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.SingleLanguageDependency.version)) {
+        return if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.SingleLanguageDependency.version)) {
             languageVersion.toString()
         } else if (property.conformsTo(BuiltinLanguages.MPSRepositoryConcepts.LanguageDependency.name)) {
             moduleReference.moduleName

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/Util.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/Util.kt
@@ -20,9 +20,6 @@ import org.modelix.model.api.IChildLink
 import org.modelix.model.api.IProperty
 import org.modelix.model.api.IReferenceLink
 import org.modelix.model.api.IRole
-import org.modelix.model.data.NodeData
-
-internal fun IProperty.isIdProperty() = getSimpleName() == NodeData.ID_PROPERTY_KEY
 
 // statically ensures that receiver and parameter are of the same type
 internal fun IChildLink.conformsTo(other: IChildLink) = conformsToRole(other)


### PR DESCRIPTION
The renamings happen because the project used FilePerRootPersistence and MPS could not resolve the concept, as it was not loaded. As a fallback the filename would default to the id of the root node of a changed model.

However changes were made where none should have been. This PR fixes those cases.