### PR TITLE
fix(model-server): do not import models into memory inside the request coroutine

### DIFF
--- a/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
+++ b/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
@@ -80,7 +80,7 @@ class ModelQLServer private constructor(val rootNodeProvider: () -> INode?, val 
             handleCall(call, { rootNode to area }, {})
         }
 
-        suspend fun handleCall(call: ApplicationCall, input: (write: Boolean) -> Pair<INode, IArea>, afterQueryExecution: () -> Unit = {}) {
+        suspend fun handleCall(call: ApplicationCall, input: suspend (write: Boolean) -> Pair<INode, IArea>, afterQueryExecution: () -> Unit = {}) {
             try {
                 val serializedQuery = call.receiveText()
                 val json = UntypedModelQL.json


### PR DESCRIPTION
Loading data on the request coroutine resulted in making the server unresponsive.
For example, health checks were not answered in the meantime and timed out.
Now the loading is done on Dispatchers.Default instead.