### PR TITLE
fix(bulk-model-sync-gradle): allow meta properties to overwrite existing values

### DIFF
--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -99,10 +99,7 @@ abstract class ImportIntoModelServer @Inject constructor(of: ObjectFactory) : De
 
                     logger.info("Setting meta properties...")
                     for ((key, value) in metaProperties.get()) {
-                        val property = IProperty.fromName(key)
-                        if (rootNode.getPropertyValue(property) == null) {
-                            rootNode.setPropertyValue(property, value)
-                        }
+                        rootNode.setPropertyValue(IProperty.fromName(key), value)
                     }
                 }
                 logger.info("Sending diff to server...")


### PR DESCRIPTION
The check was an additional safety measure to ensure, that a user does not overwrite existing data. However, it also prevented them from overwriting existing meta property values.