### PR TITLE
feat(model-client): Add convenience method overload for pollHash

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -70,6 +70,8 @@ interface IModelClientV2 {
      */
     suspend fun poll(branch: BranchReference, lastKnownVersion: IVersion?): IVersion
 
+    suspend fun pollHash(branch: BranchReference, lastKnownHash: String?): String
+
     suspend fun pollHash(branch: BranchReference, lastKnownVersion: IVersion?): String
 
     suspend fun <R> query(branch: BranchReference, body: (IMonoStep<INode>) -> IMonoStep<R>): R

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -288,12 +288,16 @@ class ModelClientV2(
     }
 
     override suspend fun pollHash(branch: BranchReference, lastKnownVersion: IVersion?): String {
+        return pollHash(branch, lastKnownVersion?.getContentHash())
+    }
+
+    override suspend fun pollHash(branch: BranchReference, lastKnownHash: String?): String {
         val response = httpClient.get {
             url {
                 takeFrom(baseUrl)
                 appendPathSegmentsEncodingSlash("repositories", branch.repositoryId.id, "branches", branch.branchName, "pollHash")
-                if (lastKnownVersion != null) {
-                    parameters["lastKnown"] = lastKnownVersion.getContentHash()
+                if (lastKnownHash != null) {
+                    parameters["lastKnown"] = lastKnownHash
                 }
             }
         }


### PR DESCRIPTION
This enhancement provides a more convenient and efficient way to use the pollHash method by eliminating the requirement to separately load and pass a version. Users can now directly specify the hash they want to use.