### PR TITLE
MODELIX-775 model-server cannot be launched if warmup is requested for a to be created repository

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
@@ -99,12 +99,16 @@ class KeyValueLikeModelServer(val repositoriesManager: RepositoriesManager) {
                     ?.getBranchReference(System.getenv("MODELIX_SERVER_MODELQL_WARMUP_BRANCH"))
                 if (branchRef != null) {
                     val version = repositoriesManager.getVersion(branchRef)
-                    if (repositoriesManager.inMemoryModels.getModel(version!!.getTree()).isActive) {
-                        call.respondText(
-                            status = HttpStatusCode.ServiceUnavailable,
-                            text = "Waiting for version $version to be loaded into memory",
-                        )
-                        return@get
+                    // The repository may not exist yet. This is not an error. There just isn't anything to do until
+                    // it's created.
+                    if (version != null) {
+                        if (repositoriesManager.inMemoryModels.getModel(version.getTree()).isActive) {
+                            call.respondText(
+                                status = HttpStatusCode.ServiceUnavailable,
+                                text = "Waiting for version $version to be loaded into memory",
+                            )
+                            return@get
+                        }
                     }
                 }
 


### PR DESCRIPTION
The /health endpoint was unhealthy if the specified repository for the eager loading of the ModelQL in-memory model doesn't exist. But if it never gets healthy then there is no way to create that repository. Therefore, it must be legal to specify a non-existing repository.