### PR TITLE
ci: dependabot wasn't updating maven dependencies anymore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
+registries:
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2/
+  maven-itemis:
+    type: maven-repository
+    url: https://artifacts.itemis.cloud/repository/maven-mps/
 updates:
   - package-ecosystem: "gradle"
     open-pull-requests-limit: 20
+    registries:
+      - maven-central
+      - maven-itemis
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
The error log at
https://github.com/modelix/modelix.core/network/updates showed that it couldn't connect to
https://maven.pkg.github.com/modelix/modelix

Looks like dependabot also checks publishing repositories, which is unnecessary.