### PR TITLE
build: check binary compatibility of Kotlin JVM APIs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: ^.*/api/.*\.api$
       - id: check-toml
       - id: check-yaml
       - id: check-added-large-files

--- a/authorization/api/authorization.api
+++ b/authorization/api/authorization.api
@@ -1,0 +1,135 @@
+public final class org/modelix/authorization/AccessTokenPrincipal : io/ktor/server/auth/Principal {
+	public fun <init> (Lcom/auth0/jwt/interfaces/DecodedJWT;)V
+	public final fun getJwt ()Lcom/auth0/jwt/interfaces/DecodedJWT;
+	public final fun getUserName ()Ljava/lang/String;
+}
+
+public final class org/modelix/authorization/EPermissionType : java/lang/Enum {
+	public static final field READ Lorg/modelix/authorization/EPermissionType;
+	public static final field WRITE Lorg/modelix/authorization/EPermissionType;
+	public final fun getIncludedTypes ()[Lorg/modelix/authorization/EPermissionType;
+	public final fun includes (Lorg/modelix/authorization/EPermissionType;)Z
+	public static fun valueOf (Ljava/lang/String;)Lorg/modelix/authorization/EPermissionType;
+	public static fun values ()[Lorg/modelix/authorization/EPermissionType;
+}
+
+public final class org/modelix/authorization/KeycloakResource {
+	public fun <init> (Ljava/lang/String;Lorg/modelix/authorization/KeycloakResourceType;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/modelix/authorization/KeycloakResourceType;
+	public final fun copy (Ljava/lang/String;Lorg/modelix/authorization/KeycloakResourceType;)Lorg/modelix/authorization/KeycloakResource;
+	public static synthetic fun copy$default (Lorg/modelix/authorization/KeycloakResource;Ljava/lang/String;Lorg/modelix/authorization/KeycloakResourceType;ILjava/lang/Object;)Lorg/modelix/authorization/KeycloakResource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lorg/modelix/authorization/KeycloakResourceType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/authorization/KeycloakResourceType {
+	public static final field Companion Lorg/modelix/authorization/KeycloakResourceType$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/Set;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/Set;Z)Lorg/modelix/authorization/KeycloakResourceType;
+	public static synthetic fun copy$default (Lorg/modelix/authorization/KeycloakResourceType;Ljava/lang/String;Ljava/util/Set;ZILjava/lang/Object;)Lorg/modelix/authorization/KeycloakResourceType;
+	public final fun createInstance (Ljava/lang/String;)Lorg/modelix/authorization/KeycloakResource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreateByUser ()Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getScopes ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/authorization/KeycloakResourceType$Companion {
+	public final fun getDEFAULT_TYPE ()Lorg/modelix/authorization/KeycloakResourceType;
+	public final fun getMODEL_SERVER_ENTRY ()Lorg/modelix/authorization/KeycloakResourceType;
+	public final fun getREPOSITORY ()Lorg/modelix/authorization/KeycloakResourceType;
+}
+
+public final class org/modelix/authorization/KeycloakScope {
+	public static final field Companion Lorg/modelix/authorization/KeycloakScope$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/authorization/KeycloakScope;
+	public static synthetic fun copy$default (Lorg/modelix/authorization/KeycloakScope;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/authorization/KeycloakScope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun plus (Lorg/modelix/authorization/KeycloakScope;)Ljava/util/Set;
+	public final fun toSet ()Ljava/util/Set;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/authorization/KeycloakScope$Companion {
+	public final fun getADD ()Lorg/modelix/authorization/KeycloakScope;
+	public final fun getALL_SCOPES ()Ljava/util/Set;
+	public final fun getDELETE ()Lorg/modelix/authorization/KeycloakScope;
+	public final fun getLIST ()Lorg/modelix/authorization/KeycloakScope;
+	public final fun getREAD ()Lorg/modelix/authorization/KeycloakScope;
+	public final fun getREAD_LIST ()Ljava/util/Set;
+	public final fun getREAD_ONLY ()Ljava/util/Set;
+	public final fun getREAD_WRITE ()Ljava/util/Set;
+	public final fun getREAD_WRITE_DELETE ()Ljava/util/Set;
+	public final fun getREAD_WRITE_DELETE_LIST ()Ljava/util/Set;
+	public final fun getREAD_WRITE_LIST ()Ljava/util/Set;
+	public final fun getWRITE ()Lorg/modelix/authorization/KeycloakScope;
+}
+
+public final class org/modelix/authorization/KeycloakUtils {
+	public static final field INSTANCE Lorg/modelix/authorization/KeycloakUtils;
+	public final fun createToken (Ljava/util/List;)Lcom/auth0/jwt/interfaces/DecodedJWT;
+	public final fun ensureResourcesExists (Lorg/modelix/authorization/KeycloakResource;Lcom/auth0/jwt/interfaces/DecodedJWT;)Lorg/keycloak/representations/idm/authorization/ResourceRepresentation;
+	public static synthetic fun ensureResourcesExists$default (Lorg/modelix/authorization/KeycloakUtils;Lorg/modelix/authorization/KeycloakResource;Lcom/auth0/jwt/interfaces/DecodedJWT;ILjava/lang/Object;)Lorg/keycloak/representations/idm/authorization/ResourceRepresentation;
+	public final fun getAuthzClient ()Lorg/keycloak/authorization/client/AuthzClient;
+	public final fun getBASE_URL ()Ljava/lang/String;
+	public final fun getCLIENT_ID ()Ljava/lang/String;
+	public final fun getCLIENT_SECRET ()Ljava/lang/String;
+	public final fun getJwkProvider ()Lcom/auth0/jwk/JwkProvider;
+	public final fun getREALM ()Ljava/lang/String;
+	public final fun getServiceAccountToken ()Lcom/auth0/jwt/interfaces/DecodedJWT;
+	public final fun hasPermission (Lcom/auth0/jwt/interfaces/DecodedJWT;Lorg/modelix/authorization/KeycloakResource;Lorg/modelix/authorization/KeycloakScope;)Z
+	public final fun isEnabled ()Z
+}
+
+public final class org/modelix/authorization/KeycloakUtilsKt {
+	public static final fun asResource (Ljava/lang/String;)Lorg/modelix/authorization/KeycloakResource;
+	public static final fun toKeycloakScope (Lorg/modelix/authorization/EPermissionType;)Lorg/modelix/authorization/KeycloakScope;
+}
+
+public final class org/modelix/authorization/KtorAuthUtilsKt {
+	public static final fun checkPermission (Lio/ktor/server/application/ApplicationCall;Lorg/modelix/authorization/KeycloakResource;Lorg/modelix/authorization/KeycloakScope;)V
+	public static final fun getBearerToken (Lio/ktor/server/application/ApplicationCall;)Ljava/lang/String;
+	public static final fun getServiceAccountTokenProvider ()Lkotlin/jvm/functions/Function0;
+	public static final fun getUserName (Lio/ktor/server/application/ApplicationCall;)Ljava/lang/String;
+	public static final fun getUserName (Lio/ktor/util/pipeline/PipelineContext;)Ljava/lang/String;
+	public static final fun installAuthentication (Lio/ktor/server/application/Application;Z)V
+	public static synthetic fun installAuthentication$default (Lio/ktor/server/application/Application;ZILjava/lang/Object;)V
+	public static final fun jwt (Lio/ktor/server/application/ApplicationCall;)Lcom/auth0/jwt/interfaces/DecodedJWT;
+	public static final fun jwtFromHeaders (Lio/ktor/server/application/ApplicationCall;)Lcom/auth0/jwt/interfaces/DecodedJWT;
+	public static final fun nullIfInvalid (Lcom/auth0/jwt/interfaces/DecodedJWT;)Lcom/auth0/jwt/interfaces/DecodedJWT;
+	public static final fun requiresDelete (Lio/ktor/server/routing/Route;Lorg/modelix/authorization/KeycloakResource;Lkotlin/jvm/functions/Function1;)V
+	public static final fun requiresLogin (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;)V
+	public static final fun requiresPermission (Lio/ktor/server/routing/Route;Lorg/modelix/authorization/KeycloakResource;Lorg/modelix/authorization/EPermissionType;Lkotlin/jvm/functions/Function1;)V
+	public static final fun requiresPermission (Lio/ktor/server/routing/Route;Lorg/modelix/authorization/KeycloakResource;Lorg/modelix/authorization/KeycloakScope;Lkotlin/jvm/functions/Function1;)V
+	public static final fun requiresRead (Lio/ktor/server/routing/Route;Lorg/modelix/authorization/KeycloakResource;Lkotlin/jvm/functions/Function1;)V
+	public static final fun requiresWrite (Lio/ktor/server/routing/Route;Lorg/modelix/authorization/KeycloakResource;Lkotlin/jvm/functions/Function1;)V
+	public static final fun verifyTokenSignature (Lcom/auth0/jwt/interfaces/DecodedJWT;)V
+}
+
+public final class org/modelix/authorization/NoPermissionException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Lorg/modelix/authorization/AccessTokenPrincipal;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lorg/modelix/authorization/AccessTokenPrincipal;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getResourceId ()Ljava/lang/String;
+	public final fun getScope ()Ljava/lang/String;
+	public final fun getUser ()Lorg/modelix/authorization/AccessTokenPrincipal;
+}
+
+public final class org/modelix/authorization/NotLoggedInException : java/lang/RuntimeException {
+	public fun <init> ()V
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.node) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.kotlin.binary.compatibility)
 }
 
 group = "org.modelix"
@@ -408,4 +409,40 @@ publishing {
             setMetadata()
         }
     }
+}
+
+apiValidation {
+    /**
+     * Packages that are excluded from public API dumps even if they
+     * contain public API.
+     */
+//    ignoredPackages.add("kotlinx.coroutines.internal")
+
+    /**
+     * Sub-projects that are excluded from API validation
+     */
+//    ignoredProjects.addAll(listOf("benchmarks", "examples"))
+
+    /**
+     * Classes (fully qualified) that are excluded from public API dumps even if they
+     * contain public API.
+     */
+//    ignoredClasses.add("com.company.BuildConfig")
+
+    /**
+     * Set of annotations that exclude API from being public.
+     * Typically, it is all kinds of `@InternalApi` annotations that mark
+     * effectively private API that cannot be actually private for technical reasons.
+     */
+//    nonPublicMarkers.add("my.package.MyInternalApiAnnotation")
+
+    /**
+     * Flag to programmatically disable compatibility validator
+     */
+//    validationDisabled = false
+
+    /**
+     * A path to a subdirectory inside the project root directory where dumps should be stored.
+     */
+//    apiDumpDirectory = "aux/validation"
 }

--- a/bulk-model-sync-gradle/api/bulk-model-sync-gradle.api
+++ b/bulk-model-sync-gradle/api/bulk-model-sync-gradle.api
@@ -1,0 +1,201 @@
+public final class org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public abstract interface class org/modelix/model/sync/bulk/gradle/config/LocalEndpoint : org/modelix/model/sync/bulk/gradle/config/SyncEndpoint {
+	public abstract fun getMpsDebugPort ()Ljava/lang/Integer;
+	public abstract fun getMpsHeapSize ()Ljava/lang/String;
+	public abstract fun getMpsHome ()Ljava/io/File;
+	public abstract fun getRepositoryDir ()Ljava/io/File;
+	public fun getValidationErrors ()Ljava/util/List;
+	public abstract fun mpsLibrary (Ljava/io/File;)V
+	public abstract fun setMpsDebugPort (Ljava/lang/Integer;)V
+	public abstract fun setMpsHeapSize (Ljava/lang/String;)V
+	public abstract fun setMpsHome (Ljava/io/File;)V
+	public abstract fun setRepositoryDir (Ljava/io/File;)V
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/LocalEndpoint$DefaultImpls {
+	public static fun getValidationErrors (Lorg/modelix/model/sync/bulk/gradle/config/LocalEndpoint;)Ljava/util/List;
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/LocalSource : org/modelix/model/sync/bulk/gradle/config/LocalEndpoint {
+	public fun <init> ()V
+	public fun <init> (Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/io/File;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;)Lorg/modelix/model/sync/bulk/gradle/config/LocalSource;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/gradle/config/LocalSource;Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/modelix/model/sync/bulk/gradle/config/LocalSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMpsDebugPort ()Ljava/lang/Integer;
+	public fun getMpsHeapSize ()Ljava/lang/String;
+	public fun getMpsHome ()Ljava/io/File;
+	public fun getRepositoryDir ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun mpsLibrary (Ljava/io/File;)V
+	public fun setMpsDebugPort (Ljava/lang/Integer;)V
+	public fun setMpsHeapSize (Ljava/lang/String;)V
+	public fun setMpsHome (Ljava/io/File;)V
+	public fun setRepositoryDir (Ljava/io/File;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/LocalTarget : org/modelix/model/sync/bulk/gradle/config/LocalEndpoint {
+	public fun <init> ()V
+	public fun <init> (Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/io/File;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;)Lorg/modelix/model/sync/bulk/gradle/config/LocalTarget;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/gradle/config/LocalTarget;Ljava/io/File;Ljava/util/Set;Ljava/lang/String;Ljava/io/File;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/modelix/model/sync/bulk/gradle/config/LocalTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMpsDebugPort ()Ljava/lang/Integer;
+	public fun getMpsHeapSize ()Ljava/lang/String;
+	public fun getMpsHome ()Ljava/io/File;
+	public fun getRepositoryDir ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun mpsLibrary (Ljava/io/File;)V
+	public fun setMpsDebugPort (Ljava/lang/Integer;)V
+	public fun setMpsHeapSize (Ljava/lang/String;)V
+	public fun setMpsHome (Ljava/io/File;)V
+	public fun setRepositoryDir (Ljava/io/File;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public class org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings {
+	public fun <init> ()V
+	public final fun dependsOn (Ljava/lang/Object;)V
+	public final fun direction (Ljava/lang/String;Lorg/gradle/api/Action;)V
+}
+
+public abstract interface class org/modelix/model/sync/bulk/gradle/config/ServerEndpoint : org/modelix/model/sync/bulk/gradle/config/SyncEndpoint {
+	public abstract fun getBranchName ()Ljava/lang/String;
+	public abstract fun getRepositoryId ()Ljava/lang/String;
+	public abstract fun getRequestTimeoutSeconds ()I
+	public abstract fun getUrl ()Ljava/lang/String;
+	public fun getValidationErrors ()Ljava/util/List;
+	public abstract fun setBranchName (Ljava/lang/String;)V
+	public abstract fun setRepositoryId (Ljava/lang/String;)V
+	public abstract fun setRequestTimeoutSeconds (I)V
+	public abstract fun setUrl (Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/ServerEndpoint$DefaultImpls {
+	public static fun getValidationErrors (Lorg/modelix/model/sync/bulk/gradle/config/ServerEndpoint;)Ljava/util/List;
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/ServerSource : org/modelix/model/sync/bulk/gradle/config/ServerEndpoint {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)Lorg/modelix/model/sync/bulk/gradle/config/ServerSource;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/gradle/config/ServerSource;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/sync/bulk/gradle/config/ServerSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBranchName ()Ljava/lang/String;
+	public fun getRepositoryId ()Ljava/lang/String;
+	public fun getRequestTimeoutSeconds ()I
+	public final fun getRevision ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun getValidationErrors ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun setBranchName (Ljava/lang/String;)V
+	public fun setRepositoryId (Ljava/lang/String;)V
+	public fun setRequestTimeoutSeconds (I)V
+	public final fun setRevision (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/ServerTarget : org/modelix/model/sync/bulk/gradle/config/ServerEndpoint {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;)Lorg/modelix/model/sync/bulk/gradle/config/ServerTarget;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/gradle/config/ServerTarget;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;ILjava/lang/Object;)Lorg/modelix/model/sync/bulk/gradle/config/ServerTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBranchName ()Ljava/lang/String;
+	public final fun getMetaProperties ()Ljava/util/Map;
+	public fun getRepositoryId ()Ljava/lang/String;
+	public fun getRequestTimeoutSeconds ()I
+	public fun getUrl ()Ljava/lang/String;
+	public fun getValidationErrors ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun setBranchName (Ljava/lang/String;)V
+	public fun setRepositoryId (Ljava/lang/String;)V
+	public fun setRequestTimeoutSeconds (I)V
+	public fun setUrl (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/sync/bulk/gradle/config/SyncDirection {
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Ljava/util/Set;Ljava/util/Set;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Ljava/util/Set;Ljava/util/Set;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Ljava/util/Set;Ljava/util/Set;Z)Lorg/modelix/model/sync/bulk/gradle/config/SyncDirection;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/gradle/config/SyncDirection;Ljava/lang/String;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Lorg/modelix/model/sync/bulk/gradle/config/SyncEndpoint;Ljava/util/Set;Ljava/util/Set;ZILjava/lang/Object;)Lorg/modelix/model/sync/bulk/gradle/config/SyncDirection;
+	public final fun enableContinueOnError (Z)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun fromLocal (Lorg/gradle/api/Action;)V
+	public final fun fromModelServer (Lorg/gradle/api/Action;)V
+	public fun hashCode ()I
+	public final fun includeModule (Ljava/lang/String;)V
+	public final fun includeModulesByPrefix (Ljava/lang/String;)V
+	public final fun registerLanguage (Lorg/modelix/model/api/ILanguage;)V
+	public final fun toLocal (Lorg/gradle/api/Action;)V
+	public final fun toModelServer (Lorg/gradle/api/Action;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/sync/bulk/gradle/config/SyncEndpoint {
+	public abstract fun getValidationErrors ()Ljava/util/List;
+}
+
+public abstract class org/modelix/model/sync/bulk/gradle/tasks/ExportFromModelServer : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun export ()V
+	public final fun getBranchName ()Lorg/gradle/api/provider/Property;
+	public final fun getIncludedModulePrefixes ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getIncludedModules ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getRepositoryId ()Lorg/gradle/api/provider/Property;
+	public final fun getRequestTimeoutSeconds ()Lorg/gradle/api/provider/Property;
+	public final fun getRevision ()Lorg/gradle/api/provider/Property;
+	public final fun getUrl ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract class org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getBranchName ()Lorg/gradle/api/provider/Property;
+	public final fun getContinueOnError ()Lorg/gradle/api/provider/Property;
+	public final fun getIncludedModulePrefixes ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getIncludedModules ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getInputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getMetaProperties ()Lorg/gradle/api/provider/MapProperty;
+	public final fun getRepositoryId ()Lorg/gradle/api/provider/Property;
+	public final fun getRequestTimeoutSeconds ()Lorg/gradle/api/provider/Property;
+	public final fun getUrl ()Lorg/gradle/api/provider/Property;
+	public final fun import ()V
+}
+
+public abstract class org/modelix/model/sync/bulk/gradle/tasks/ValidateSyncSettings : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getSettings ()Lorg/gradle/api/provider/Property;
+	public final fun validate ()V
+}
+

--- a/bulk-model-sync-lib/api/bulk-model-sync-lib.api
+++ b/bulk-model-sync-lib/api/bulk-model-sync-lib.api
@@ -1,0 +1,67 @@
+public final class org/modelix/model/sync/bulk/ExistingAndExpectedNode {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/data/ModelData;)V
+	public final fun component1 ()Lorg/modelix/model/api/INode;
+	public final fun component2 ()Lorg/modelix/model/data/ModelData;
+	public final fun copy (Lorg/modelix/model/api/INode;Lorg/modelix/model/data/ModelData;)Lorg/modelix/model/sync/bulk/ExistingAndExpectedNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/ExistingAndExpectedNode;Lorg/modelix/model/api/INode;Lorg/modelix/model/data/ModelData;ILjava/lang/Object;)Lorg/modelix/model/sync/bulk/ExistingAndExpectedNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExistingNode ()Lorg/modelix/model/api/INode;
+	public final fun getExpectedNodeData ()Lorg/modelix/model/data/ModelData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/sync/bulk/ModelExporter {
+	public fun <init> (Lorg/modelix/model/api/INode;)V
+	public final fun export (Ljava/io/File;)V
+}
+
+public final class org/modelix/model/sync/bulk/ModelExporterKt {
+	public static final fun asExported (Lorg/modelix/model/api/INode;)Lorg/modelix/model/data/NodeData;
+}
+
+public final class org/modelix/model/sync/bulk/ModelImporter {
+	public fun <init> (Lorg/modelix/model/api/INode;)V
+	public fun <init> (Lorg/modelix/model/api/INode;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/modelix/model/api/INode;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun importData (Lorg/modelix/model/data/ModelData;)V
+	public final fun importIntoNodes (Lkotlin/sequences/Sequence;)V
+}
+
+public final class org/modelix/model/sync/bulk/ModelImporter$PostponedReference {
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/api/INode;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/modelix/model/api/INode;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/sync/bulk/ModelImporter$PostponedReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/sync/bulk/ModelImporter$PostponedReference;Ljava/lang/String;Lorg/modelix/model/api/INode;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/sync/bulk/ModelImporter$PostponedReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpectedTargetId ()Ljava/lang/String;
+	public final fun getMpsNode ()Lorg/modelix/model/api/INode;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/sync/bulk/PlatformSpecificKt {
+	public static final fun importFile (Lorg/modelix/model/sync/bulk/ModelImporter;Ljava/io/File;)V
+	public static final fun importFilesAsRootChildren (Lorg/modelix/model/sync/bulk/ModelImporter;Ljava/util/Collection;)V
+	public static final fun importFilesAsRootChildren (Lorg/modelix/model/sync/bulk/ModelImporter;[Ljava/io/File;)V
+}
+
+public final class org/modelix/model/sync/bulk/ProgressReporter {
+	public synthetic fun <init> (JLmu/KLogger;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLmu/KLogger;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun step-VKZWuLQ (J)V
+}
+
+public final class org/modelix/model/sync/bulk/UtilKt {
+	public static final fun isModuleIncluded (Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;)Z
+	public static final fun mergeModelData (Ljava/util/Collection;)Lorg/modelix/model/data/ModelData;
+	public static final fun mergeModelData ([Lorg/modelix/model/data/ModelData;)Lorg/modelix/model/data/ModelData;
+}
+
+public final class org/modelix/model/sync/bulk/UtilsKt {
+	public static final fun isTty ()Z
+}
+

--- a/bulk-model-sync-mps/api/bulk-model-sync-mps.api
+++ b/bulk-model-sync-mps/api/bulk-model-sync-mps.api
@@ -1,0 +1,6 @@
+public final class org/modelix/mps/model/sync/bulk/MPSBulkSynchronizer {
+	public static final field INSTANCE Lorg/modelix/mps/model/sync/bulk/MPSBulkSynchronizer;
+	public static final fun exportRepository ()V
+	public static final fun importRepository ()V
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ test-logger = { id = "com.adarshr.test-logger", version = "4.0.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 intellij = { id = "org.jetbrains.intellij", version = "1.17.2" }
 openapi-generator = {id = "org.openapi.generator", version.ref = "openapi"}
+kotlin-binary-compatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 
 [versions]
 kotlin = "1.9.23"

--- a/kotlin-utils/api/kotlin-utils.api
+++ b/kotlin-utils/api/kotlin-utils.api
@@ -1,0 +1,33 @@
+public final class org/modelix/kotlin/utils/ContextValue {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Ljava/util/List;)V
+	public final fun computeWith (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getAllValues ()Ljava/util/List;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun getValueOrNull ()Ljava/lang/Object;
+	public final fun runInCoroutine (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/kotlin/utils/ContextValueKt {
+	public static final fun offer (Lorg/modelix/kotlin/utils/ContextValue;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/kotlin/utils/DataStructures_jvmKt {
+	public static final fun createMemoryEfficientMap ()Ljava/util/Map;
+}
+
+public abstract interface annotation class org/modelix/kotlin/utils/DeprecationInfo : java/lang/annotation/Annotation {
+	public abstract fun removalHint ()Ljava/lang/String;
+	public abstract fun since ()Ljava/lang/String;
+}
+
+public final class org/modelix/kotlin/utils/RunSynchronized_jvmKt {
+	public static final fun runSynchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface annotation class org/modelix/kotlin/utils/UnstableModelixFeature : java/lang/annotation/Annotation {
+	public abstract fun intendedFinalization ()Ljava/lang/String;
+	public abstract fun reason ()Ljava/lang/String;
+}
+

--- a/light-model-client/api/light-model-client.api
+++ b/light-model-client/api/light-model-client.api
@@ -1,0 +1,168 @@
+public final class org/modelix/client/light/LightClientNodeReference : org/modelix/model/api/INodeReference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getNodeId ()Ljava/lang/String;
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/client/light/LightClientReferenceSerializer : org/modelix/model/api/INodeReferenceSerializerEx {
+	public static final field INSTANCE Lorg/modelix/client/light/LightClientReferenceSerializer;
+	public fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getPrefix ()Ljava/lang/String;
+	public fun getSupportedReferenceClasses ()Ljava/util/Set;
+	public final fun register ()V
+	public fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+	public final fun unregister ()V
+}
+
+public final class org/modelix/client/light/LightModelClient {
+	public static final field Companion Lorg/modelix/client/light/LightModelClient$Companion;
+	public static final fun builder ()Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun changeQuery (Lorg/modelix/model/server/api/ModelQuery;)V
+	public final fun checkException ()V
+	public final fun dispose ()V
+	public final fun getAutoFilterNonLoadedNodes ()Z
+	public final fun getConnection ()Lorg/modelix/client/light/LightModelClient$IConnection;
+	public final fun getDebugName ()Ljava/lang/String;
+	public final fun getModelQLClient ()Lorg/modelix/modelql/client/ModelQLClient;
+	public final fun getNode (Ljava/lang/String;)Lorg/modelix/client/light/LightModelClient$NodeAdapter;
+	public final fun getNodeIfLoaded (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getRootNode ()Lorg/modelix/model/api/INode;
+	public final fun isInSync ()Z
+	public final fun isInitialized ()Z
+	public final fun runRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun runWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun tryGetParentId (Ljava/lang/String;)Ljava/lang/String;
+	public final fun waitForRootNode-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun waitForRootNode-VtjQ1oo$default (Lorg/modelix/client/light/LightModelClient;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/client/light/LightModelClient$Area : org/modelix/model/area/IArea {
+	public fun <init> (Lorg/modelix/client/light/LightModelClient;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getClient ()Lorg/modelix/client/light/LightModelClient;
+	public fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/client/light/LightModelClient$AreaReference : org/modelix/model/area/IAreaReference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/client/light/LightModelClient$AreaReference;
+	public static synthetic fun copy$default (Lorg/modelix/client/light/LightModelClient$AreaReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/client/light/LightModelClient$AreaReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranchId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/client/light/LightModelClient$Companion {
+	public final fun builder ()Lorg/modelix/client/light/LightModelClientBuilder;
+}
+
+public abstract interface class org/modelix/client/light/LightModelClient$IConnection {
+	public abstract fun connect (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun disconnect ()V
+	public abstract fun sendMessage (Lorg/modelix/model/server/api/MessageFromClient;)V
+}
+
+public final class org/modelix/client/light/LightModelClient$NodeAdapter : org/modelix/model/api/INodeEx, org/modelix/modelql/untyped/ISupportsModelQL {
+	public fun <init> (Lorg/modelix/client/light/LightModelClient;Ljava/lang/String;)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public final fun checkContainmentConsistency ()V
+	public fun createQueryExecutor ()Lorg/modelix/modelql/core/IQueryExecutor;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getAllChildren ()Ljava/util/List;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public synthetic fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getChildren (Ljava/lang/String;)Ljava/util/List;
+	public final fun getClient ()Lorg/modelix/client/light/LightModelClient;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public final fun getData ()Lorg/modelix/model/server/api/NodeData;
+	public final fun getNodeId ()Ljava/lang/String;
+	public fun getParent ()Lorg/modelix/client/light/LightModelClient$NodeAdapter;
+	public synthetic fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/client/light/LightModelClient$NodeAdapter;
+	public synthetic fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/client/light/LightClientNodeReference;
+	public synthetic fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public final fun setNodeId (Ljava/lang/String;)V
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun toString ()Ljava/lang/String;
+	public fun usesRoleIds ()Z
+}
+
+public abstract class org/modelix/client/light/LightModelClientBuilder {
+	public fun <init> ()V
+	public final fun autoFilterNonLoadedNodes (Z)Lorg/modelix/client/light/LightModelClientBuilder;
+	public static synthetic fun autoFilterNonLoadedNodes$default (Lorg/modelix/client/light/LightModelClientBuilder;ZILjava/lang/Object;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun autoTransactions ()Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun build ()Lorg/modelix/client/light/LightModelClient;
+	public final fun connection (Lorg/modelix/client/light/LightModelClient$IConnection;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun debugName (Ljava/lang/String;)Lorg/modelix/client/light/LightModelClientBuilder;
+	protected abstract fun getDefaultEngineFactory ()Lio/ktor/client/engine/HttpClientEngineFactory;
+	public final fun host (Ljava/lang/String;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun httpClient (Lio/ktor/client/HttpClient;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun httpEngine (Lio/ktor/client/engine/HttpClientEngine;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun httpEngine (Lio/ktor/client/engine/HttpClientEngineFactory;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun modelQLClient (Lorg/modelix/modelql/client/ModelQLClient;)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun port (I)Lorg/modelix/client/light/LightModelClientBuilder;
+	public final fun url (Ljava/lang/String;)Lorg/modelix/client/light/LightModelClientBuilder;
+}
+
+public final class org/modelix/client/light/LightModelClientJVM {
+	public static final field INSTANCE Lorg/modelix/client/light/LightModelClientJVM;
+	public static final fun builder ()Lorg/modelix/client/light/LightModelClientBuilder;
+}
+
+public final class org/modelix/client/light/LightModelClientKt {
+	public static final fun asUpdateData (Lorg/modelix/model/server/api/NodeData;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public static final fun filterLoaded (Ljava/lang/Iterable;)Ljava/util/List;
+	public static final fun filterLoaded (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+	public static final fun isLoaded (Lorg/modelix/model/api/INode;)Z
+}
+
+public final class org/modelix/client/light/PlatformSpecificLightModelClientBuilder : org/modelix/client/light/LightModelClientBuilder {
+	public fun <init> ()V
+}
+
+public final class org/modelix/client/light/ServerSideException : java/lang/Exception {
+	public fun <init> (Lorg/modelix/model/server/api/ExceptionData;)V
+}
+
+public final class org/modelix/client/light/WebsocketConnection : org/modelix/client/light/LightModelClient$IConnection {
+	public fun <init> (Lio/ktor/client/HttpClient;Ljava/lang/String;)V
+	public fun connect (Lkotlin/jvm/functions/Function1;)V
+	public fun disconnect ()V
+	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+	public final fun getHttpClient ()Lio/ktor/client/HttpClient;
+	public final fun getOutgoingMessagesChannel ()Lkotlinx/coroutines/channels/Channel;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun sendMessage (Lorg/modelix/model/server/api/MessageFromClient;)V
+}
+

--- a/model-api-gen-gradle/api/model-api-gen-gradle.api
+++ b/model-api-gen-gradle/api/model-api-gen-gradle.api
@@ -1,0 +1,71 @@
+public abstract class org/modelix/metamodel/gradle/GenerateAntScriptForMpsMetaModelExport : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun generate ()V
+	public final fun getAntScriptFile ()Lorg/gradle/api/file/RegularFileProperty;
+	public final fun getExportModulesFilter ()Lorg/gradle/api/provider/Property;
+	public final fun getExporterDir ()Lorg/gradle/api/provider/Property;
+	public final fun getHeapSize ()Lorg/gradle/api/provider/Property;
+	public final fun getModuleFolders ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getMpsHome ()Lorg/gradle/api/provider/Property;
+}
+
+public abstract class org/modelix/metamodel/gradle/GenerateMetaModelSources : org/gradle/api/DefaultTask {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun generate ()V
+	public final fun getConceptPropertiesInterfaceName ()Lorg/gradle/api/provider/Property;
+	public final fun getExportedLanguagesDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getIncludedConcepts ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getIncludedLanguages ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getIncludedNamespaces ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getKotlinOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getModelqlKotlinOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getNameConfig ()Lorg/gradle/api/provider/Property;
+	public final fun getRegistrationHelperName ()Lorg/gradle/api/provider/Property;
+	public final fun getTypescriptOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+}
+
+public final class org/modelix/metamodel/gradle/MetaModelGradlePlugin : org/gradle/api/Plugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public class org/modelix/metamodel/gradle/MetaModelGradleSettings {
+	public fun <init> ()V
+	public final fun dependsOn ([Ljava/lang/Object;)V
+	public final fun exportModules (Ljava/lang/String;)V
+	public final fun getConceptPropertiesInterfaceName ()Ljava/lang/String;
+	public final fun getIncludedConcepts ()Ljava/util/Set;
+	public final fun getIncludedLanguageNamespaces ()Ljava/util/Set;
+	public final fun getIncludedLanguages ()Ljava/util/Set;
+	public final fun getIncludedModules ()Ljava/util/Set;
+	public final fun getJavaExecutable ()Ljava/io/File;
+	public final fun getJsonDir ()Ljava/io/File;
+	public final fun getKotlinDir ()Ljava/io/File;
+	public final fun getKotlinProject ()Lorg/gradle/api/Project;
+	public final fun getModelqlKotlinDir ()Ljava/io/File;
+	public final fun getModuleFolders ()Ljava/util/ArrayList;
+	public final fun getMpsHeapSize ()Ljava/lang/String;
+	public final fun getMpsHome ()Ljava/io/File;
+	public final fun getRegistrationHelperName ()Ljava/lang/String;
+	public final fun getTaskDependencies ()Ljava/util/List;
+	public final fun getTypescriptDir ()Ljava/io/File;
+	public final fun includeConcept (Ljava/lang/String;)V
+	public final fun includeLanguage (Ljava/lang/String;)V
+	public final fun includeNamespace (Ljava/lang/String;)V
+	public final fun javaExecutable (Ljava/io/File;)V
+	public final fun javaExecutable (Lkotlin/jvm/functions/Function0;)V
+	public final fun modulesFrom (Ljava/io/File;)V
+	public final fun names (Lorg/gradle/api/Action;)V
+	public final fun setConceptPropertiesInterfaceName (Ljava/lang/String;)V
+	public final fun setJavaExecutable (Ljava/io/File;)V
+	public final fun setJsonDir (Ljava/io/File;)V
+	public final fun setKotlinDir (Ljava/io/File;)V
+	public final fun setKotlinProject (Lorg/gradle/api/Project;)V
+	public final fun setModelqlKotlinDir (Ljava/io/File;)V
+	public final fun setMpsHeapSize (Ljava/lang/String;)V
+	public final fun setMpsHome (Ljava/io/File;)V
+	public final fun setRegistrationHelperName (Ljava/lang/String;)V
+	public final fun setTypescriptDir (Ljava/io/File;)V
+}
+

--- a/model-api-gen-runtime/api/model-api-gen-runtime.api
+++ b/model-api-gen-runtime/api/model-api-gen-runtime.api
@@ -1,0 +1,593 @@
+public final class org/modelix/metamodel/BooleanPropertyAccessor : org/modelix/metamodel/PropertyAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)V
+	public fun convertRead (Ljava/lang/String;)Ljava/lang/Boolean;
+	public synthetic fun convertRead (Ljava/lang/String;)Ljava/lang/Object;
+	public synthetic fun convertWrite (Ljava/lang/Object;)Ljava/lang/String;
+	public fun convertWrite (Z)Ljava/lang/String;
+}
+
+public abstract class org/modelix/metamodel/ChildAccessor : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;Lorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+	public final fun addNew (I)Lorg/modelix/metamodel/ITypedNode;
+	public final fun addNew (ILorg/modelix/metamodel/INonAbstractConcept;)Lorg/modelix/metamodel/ITypedNode;
+	public final fun addNew (Lorg/modelix/metamodel/INonAbstractConcept;)Lorg/modelix/metamodel/ITypedNode;
+	public static synthetic fun addNew$default (Lorg/modelix/metamodel/ChildAccessor;IILjava/lang/Object;)Lorg/modelix/metamodel/ITypedNode;
+	public static synthetic fun addNew$default (Lorg/modelix/metamodel/ChildAccessor;ILorg/modelix/metamodel/INonAbstractConcept;ILjava/lang/Object;)Lorg/modelix/metamodel/ITypedNode;
+	protected final fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getChildType ()Lkotlin/reflect/KClass;
+	protected final fun getParent ()Lorg/modelix/model/api/INode;
+	protected final fun getRole ()Lorg/modelix/model/api/IChildLink;
+	public final fun getSize ()I
+	public final fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public final fun remove (Lorg/modelix/metamodel/TypedNodeImpl;)V
+	public final fun removeUnwrapped (Lorg/modelix/model/api/INode;)V
+	public final fun untypedNodes ()Ljava/lang/Iterable;
+}
+
+public final class org/modelix/metamodel/ChildAccessorKt {
+	public static final fun filterLoaded (Lorg/modelix/metamodel/ChildAccessor;)Ljava/util/List;
+}
+
+public final class org/modelix/metamodel/ChildListAccessor : org/modelix/metamodel/ChildAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;Lorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+}
+
+public final class org/modelix/metamodel/ChildNotSetException : java/lang/Exception {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedMandatorySingleChildLink;)V
+	public final fun getLink ()Lorg/modelix/metamodel/ITypedMandatorySingleChildLink;
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+}
+
+public abstract class org/modelix/metamodel/EmptyConcept : org/modelix/model/api/IConcept {
+	public fun <init> ()V
+	public fun getAllChildLinks ()Ljava/util/List;
+	public fun getAllProperties ()Ljava/util/List;
+	public fun getAllReferenceLinks ()Ljava/util/List;
+	public fun getChildLink (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public fun getDirectSuperConcepts ()Ljava/util/List;
+	public fun getOwnChildLinks ()Ljava/util/List;
+	public fun getOwnProperties ()Ljava/util/List;
+	public fun getOwnReferenceLinks ()Ljava/util/List;
+	public fun getProperty (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public fun getReferenceLink (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public fun isAbstract ()Z
+	public fun isExactly (Lorg/modelix/model/api/IConcept;)Z
+	public fun isSubConceptOf (Lorg/modelix/model/api/IConcept;)Z
+}
+
+public abstract class org/modelix/metamodel/EnumSerializer {
+	public fun <init> ()V
+	protected final fun deserializeEnumMemberId (Ljava/lang/String;)Ljava/lang/String;
+	protected final fun serializeEnumMember (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/FallbackTypedConcept : org/modelix/metamodel/ITypedConcept {
+	public fun <init> (Lorg/modelix/model/api/IConcept;)V
+	public fun untyped ()Lorg/modelix/model/api/IConcept;
+}
+
+public abstract class org/modelix/metamodel/GeneratedChildLink : org/modelix/metamodel/ITypedChildLink, org/modelix/model/api/IChildLink {
+	public fun <init> (Lorg/modelix/model/api/IConcept;Ljava/lang/String;Ljava/lang/String;ZZLorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+	public fun castChild (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+	public fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getTypedChildConcept ()Lorg/modelix/metamodel/IConceptOfTypedNode;
+	public fun getUID ()Ljava/lang/String;
+	public fun isMultiple ()Z
+	public fun isOptional ()Z
+	public fun untyped ()Lorg/modelix/model/api/IChildLink;
+}
+
+public final class org/modelix/metamodel/GeneratedChildListLink : org/modelix/metamodel/GeneratedChildLink, org/modelix/metamodel/ITypedChildListLink {
+	public fun <init> (Lorg/modelix/model/api/IConcept;Ljava/lang/String;Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+}
+
+public abstract class org/modelix/metamodel/GeneratedConcept : org/modelix/model/api/IConcept {
+	public static final field Companion Lorg/modelix/metamodel/GeneratedConcept$Companion;
+	public static final field UID_PREFIX Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Z)V
+	public fun getAllChildLinks ()Ljava/util/List;
+	public fun getAllProperties ()Ljava/util/List;
+	public fun getAllReferenceLinks ()Ljava/util/List;
+	public fun getChildLink (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public abstract fun getInstanceClass ()Lkotlin/reflect/KClass;
+	public fun getLongName ()Ljava/lang/String;
+	public fun getOwnChildLinks ()Ljava/util/List;
+	public fun getOwnProperties ()Ljava/util/List;
+	public fun getOwnReferenceLinks ()Ljava/util/List;
+	public fun getProperty (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getReferenceLink (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public fun getShortName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public final fun get_typed ()Lorg/modelix/metamodel/ITypedConcept;
+	public fun isAbstract ()Z
+	public fun isExactly (Lorg/modelix/model/api/IConcept;)Z
+	public fun isSubConceptOf (Lorg/modelix/model/api/IConcept;)Z
+	public final fun newChildListLink (Ljava/lang/String;Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)Lorg/modelix/metamodel/GeneratedChildListLink;
+	public final fun newMandatorySingleChildLink (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)Lorg/modelix/metamodel/GeneratedMandatorySingleChildLink;
+	public final fun newOptionalSingleChildLink (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)Lorg/modelix/metamodel/GeneratedSingleChildLink;
+	public final fun newProperty (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/metamodel/IPropertyValueSerializer;Z)Lorg/modelix/metamodel/GeneratedProperty;
+	public final fun newReferenceLink (Ljava/lang/String;Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)Lorg/modelix/metamodel/GeneratedReferenceLink;
+	public abstract fun typed ()Lorg/modelix/metamodel/ITypedConcept;
+	public abstract fun wrap (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+}
+
+public final class org/modelix/metamodel/GeneratedConcept$Companion {
+}
+
+public final class org/modelix/metamodel/GeneratedConceptKt {
+	public static final fun typed (Lorg/modelix/model/api/IChildLink;)Lorg/modelix/metamodel/ITypedChildLink;
+	public static final fun typed (Lorg/modelix/model/api/IProperty;)Lorg/modelix/metamodel/ITypedProperty;
+	public static final fun typed (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/metamodel/ITypedReferenceLink;
+}
+
+public abstract class org/modelix/metamodel/GeneratedLanguage : org/modelix/model/api/ILanguage {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun assertRegistered ()V
+	public fun getName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public final fun isRegistered ()Z
+	public final fun register ()V
+	public final fun unregister ()V
+}
+
+public final class org/modelix/metamodel/GeneratedMandatorySingleChildLink : org/modelix/metamodel/GeneratedSingleChildLink, org/modelix/metamodel/ITypedMandatorySingleChildLink {
+	public fun <init> (Lorg/modelix/model/api/IConcept;Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+}
+
+public final class org/modelix/metamodel/GeneratedProperty : org/modelix/metamodel/ITypedProperty, org/modelix/model/api/IProperty {
+	public fun <init> (Lorg/modelix/model/api/IConcept;Ljava/lang/String;Ljava/lang/String;ZLorg/modelix/metamodel/IPropertyValueSerializer;)V
+	public fun deserializeValue (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun isOptional ()Z
+	public fun serializeValue (Ljava/lang/Object;)Ljava/lang/String;
+	public fun untyped ()Lorg/modelix/model/api/IProperty;
+}
+
+public final class org/modelix/metamodel/GeneratedReferenceLink : org/modelix/metamodel/ITypedReferenceLink, org/modelix/model/api/IReferenceLink {
+	public fun <init> (Lorg/modelix/model/api/IConcept;Ljava/lang/String;Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+	public fun castTarget (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getTypedTargetConcept ()Lorg/modelix/metamodel/IConceptOfTypedNode;
+	public fun getUID ()Ljava/lang/String;
+	public fun isOptional ()Z
+	public fun untyped ()Lorg/modelix/model/api/IReferenceLink;
+}
+
+public class org/modelix/metamodel/GeneratedSingleChildLink : org/modelix/metamodel/GeneratedChildLink, org/modelix/metamodel/ITypedSingleChildLink {
+	public fun <init> (Lorg/modelix/model/api/IConcept;Ljava/lang/String;Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+}
+
+public abstract interface class org/modelix/metamodel/IConceptOfTypedNode : org/modelix/metamodel/ITypedConcept {
+	public abstract fun getInstanceInterface ()Lkotlin/reflect/KClass;
+}
+
+public abstract interface class org/modelix/metamodel/INonAbstractConcept : org/modelix/metamodel/IConceptOfTypedNode {
+}
+
+public abstract interface class org/modelix/metamodel/IPropertyValueEnum {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getPresentation ()Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/metamodel/IPropertyValueSerializer {
+	public abstract fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/metamodel/ITypedChildLink : org/modelix/metamodel/ITypedConceptFeature {
+	public abstract fun castChild (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+	public abstract fun getTypedChildConcept ()Lorg/modelix/metamodel/IConceptOfTypedNode;
+	public abstract fun untyped ()Lorg/modelix/model/api/IChildLink;
+}
+
+public final class org/modelix/metamodel/ITypedChildLinkKt {
+	public static final fun addNewChild (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedChildLink;ILorg/modelix/metamodel/INonAbstractConcept;)Lorg/modelix/metamodel/ITypedNode;
+	public static synthetic fun addNewChild$default (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedChildLink;ILorg/modelix/metamodel/INonAbstractConcept;ILjava/lang/Object;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun getChild (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedMandatorySingleChildLink;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun getChild (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedSingleChildLink;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun getChildren (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedChildLink;)Ljava/util/List;
+	public static final fun setNewChild (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedSingleChildLink;Lorg/modelix/metamodel/INonAbstractConcept;)Lorg/modelix/metamodel/ITypedNode;
+	public static synthetic fun setNewChild$default (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedSingleChildLink;Lorg/modelix/metamodel/INonAbstractConcept;ILjava/lang/Object;)Lorg/modelix/metamodel/ITypedNode;
+}
+
+public abstract interface class org/modelix/metamodel/ITypedChildListLink : org/modelix/metamodel/ITypedChildLink {
+}
+
+public abstract interface class org/modelix/metamodel/ITypedConcept {
+	public abstract fun untyped ()Lorg/modelix/model/api/IConcept;
+}
+
+public abstract interface class org/modelix/metamodel/ITypedConceptFeature {
+}
+
+public final class org/modelix/metamodel/ITypedConceptKt {
+	public static final fun getInstanceClass (Lorg/modelix/metamodel/IConceptOfTypedNode;)Lkotlin/reflect/KClass;
+	public static final fun get_concept (Lorg/modelix/metamodel/ITypedConcept;)Lorg/modelix/model/api/IConcept;
+	public static final fun typed (Lorg/modelix/model/api/IConcept;)Lorg/modelix/metamodel/ITypedConcept;
+}
+
+public abstract interface class org/modelix/metamodel/ITypedMandatorySingleChildLink : org/modelix/metamodel/ITypedSingleChildLink {
+}
+
+public abstract interface class org/modelix/metamodel/ITypedNode {
+	public abstract fun get_concept ()Lorg/modelix/metamodel/ITypedConcept;
+	public abstract fun unwrap ()Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/metamodel/ITypedNodeKt {
+	public static final fun getPropertyValue (Lorg/modelix/metamodel/ITypedNode;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static final fun instanceOf (Lorg/modelix/metamodel/ITypedNode;Lorg/modelix/metamodel/ITypedConcept;)Z
+	public static final fun instanceOf (Lorg/modelix/metamodel/ITypedNode;Lorg/modelix/model/api/IConcept;)Z
+	public static final fun typedConcept (Lorg/modelix/metamodel/ITypedNode;)Lorg/modelix/metamodel/ITypedConcept;
+	public static final fun untyped (Lorg/modelix/metamodel/ITypedNode;)Lorg/modelix/model/api/INode;
+	public static final fun untypedConcept (Lorg/modelix/metamodel/ITypedNode;)Lorg/modelix/model/api/IConcept;
+	public static final fun untypedReference (Lorg/modelix/metamodel/ITypedNode;)Lorg/modelix/model/api/INodeReference;
+}
+
+public abstract interface class org/modelix/metamodel/ITypedProperty : org/modelix/metamodel/ITypedConceptFeature {
+	public abstract fun deserializeValue (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun serializeValue (Ljava/lang/Object;)Ljava/lang/String;
+	public abstract fun untyped ()Lorg/modelix/model/api/IProperty;
+}
+
+public final class org/modelix/metamodel/ITypedPropertyKt {
+	public static final fun getTypedPropertyValue (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedProperty;)Ljava/lang/Object;
+	public static final fun setTypedPropertyValue (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedProperty;Ljava/lang/Object;)V
+}
+
+public abstract interface class org/modelix/metamodel/ITypedReferenceLink : org/modelix/metamodel/ITypedConceptFeature {
+	public abstract fun castTarget (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+	public abstract fun getTypedTargetConcept ()Lorg/modelix/metamodel/IConceptOfTypedNode;
+	public abstract fun untyped ()Lorg/modelix/model/api/IReferenceLink;
+}
+
+public final class org/modelix/metamodel/ITypedReferenceLinkKt {
+	public static final fun getReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedReferenceLink;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun getReferenceTargetOrNull (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedReferenceLink;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun setReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedReferenceLink;Lorg/modelix/metamodel/ITypedNode;)V
+}
+
+public abstract interface class org/modelix/metamodel/ITypedSingleChildLink : org/modelix/metamodel/ITypedChildLink {
+}
+
+public final class org/modelix/metamodel/IntPropertyAccessor : org/modelix/metamodel/PropertyAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)V
+	public fun convertRead (Ljava/lang/String;)Ljava/lang/Integer;
+	public synthetic fun convertRead (Ljava/lang/String;)Ljava/lang/Object;
+	public fun convertWrite (I)Ljava/lang/String;
+	public synthetic fun convertWrite (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/MandatoryBooleanPropertySerializer : org/modelix/metamodel/IPropertyValueSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/MandatoryBooleanPropertySerializer;
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/Boolean;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+	public fun serialize (Z)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/MandatoryEnumSerializer : org/modelix/metamodel/EnumSerializer, org/modelix/metamodel/IPropertyValueSerializer {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/Enum;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serialize (Ljava/lang/Enum;)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/MandatoryIntPropertySerializer : org/modelix/metamodel/IPropertyValueSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/MandatoryIntPropertySerializer;
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/Integer;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serialize (I)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/MandatoryReferenceAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;Lkotlin/reflect/KClass;)V
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public final fun getRole ()Lorg/modelix/model/api/IReferenceLink;
+	public final fun getTargetType ()Lkotlin/reflect/KClass;
+	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/modelix/metamodel/ITypedNode;
+	public final fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Lorg/modelix/metamodel/ITypedNode;)V
+}
+
+public final class org/modelix/metamodel/MandatoryStringPropertySerializer : org/modelix/metamodel/IPropertyValueSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/MandatoryStringPropertySerializer;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+	public fun serialize (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/ModelData {
+	public static final field Companion Lorg/modelix/metamodel/ModelData$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/metamodel/NodeData;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/modelix/metamodel/NodeData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/modelix/metamodel/NodeData;
+	public final fun copy (Ljava/lang/String;Lorg/modelix/metamodel/NodeData;)Lorg/modelix/metamodel/ModelData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/ModelData;Ljava/lang/String;Lorg/modelix/metamodel/NodeData;ILjava/lang/Object;)Lorg/modelix/metamodel/ModelData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRoot ()Lorg/modelix/metamodel/NodeData;
+	public fun hashCode ()I
+	public final fun load (Lorg/modelix/model/api/IBranch;)V
+	public final fun toCompactJson ()Ljava/lang/String;
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/ModelData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/ModelData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/ModelData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/ModelData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/ModelData$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lorg/modelix/metamodel/ModelData;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/ModelDataKt {
+	public static final fun nodeUID (Lorg/modelix/metamodel/ModelData;Lorg/modelix/metamodel/NodeData;)Ljava/lang/String;
+	public static final fun uid (Lorg/modelix/metamodel/NodeData;Lorg/modelix/metamodel/ModelData;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/ModelDataUtilsKt {
+	public static final fun modelDataFromFile (Ljava/io/File;)Lorg/modelix/model/data/ModelData;
+	public static final fun modelDataFromJson (Ljava/lang/String;)Lorg/modelix/model/data/ModelData;
+	public static final fun modelDataFromYaml (Ljava/lang/String;)Lorg/modelix/model/data/ModelData;
+	public static final fun toYaml (Lorg/modelix/model/data/ModelData;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/NodeData {
+	public static final field Companion Lorg/modelix/metamodel/NodeData$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)Lorg/modelix/metamodel/NodeData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/NodeData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lorg/modelix/metamodel/NodeData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getConcept ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getReferences ()Ljava/util/Map;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/NodeData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/NodeData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/NodeData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/NodeData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/NodeData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/NullConcept : org/modelix/metamodel/EmptyConcept, org/modelix/model/api/IConceptReference {
+	public static final field INSTANCE Lorg/modelix/metamodel/NullConcept;
+	public fun getLanguage ()Lorg/modelix/model/api/ILanguage;
+	public fun getLongName ()Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getShortName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun resolve (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/IConcept;
+	public fun serialize ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/OptionalBooleanPropertySerializer : org/modelix/metamodel/IPropertyValueSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/OptionalBooleanPropertySerializer;
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/Boolean;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serialize (Ljava/lang/Boolean;)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/OptionalEnumSerializer : org/modelix/metamodel/EnumSerializer, org/modelix/metamodel/IPropertyValueSerializer {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/Enum;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serialize (Ljava/lang/Enum;)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/OptionalIntPropertySerializer : org/modelix/metamodel/IPropertyValueSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/OptionalIntPropertySerializer;
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/Integer;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun serialize (Ljava/lang/Integer;)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/OptionalReferenceAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;Lkotlin/reflect/KClass;)V
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public final fun getRole ()Lorg/modelix/model/api/IReferenceLink;
+	public final fun getTargetType ()Lkotlin/reflect/KClass;
+	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/modelix/metamodel/ITypedNode;
+	public final fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Lorg/modelix/metamodel/ITypedNode;)V
+}
+
+public final class org/modelix/metamodel/OptionalStringPropertySerializer : org/modelix/metamodel/IPropertyValueSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/OptionalStringPropertySerializer;
+	public synthetic fun deserialize (Ljava/lang/String;)Ljava/lang/Object;
+	public fun deserialize (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun serialize (Ljava/lang/Object;)Ljava/lang/String;
+	public fun serialize (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract class org/modelix/metamodel/PropertyAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)V
+	public abstract fun convertRead (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun convertWrite (Ljava/lang/Object;)Ljava/lang/String;
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public final fun getRole ()Lorg/modelix/model/api/IProperty;
+	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
+}
+
+public final class org/modelix/metamodel/RawPropertyAccessor : org/modelix/metamodel/PropertyAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)V
+	public synthetic fun convertRead (Ljava/lang/String;)Ljava/lang/Object;
+	public fun convertRead (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun convertWrite (Ljava/lang/Object;)Ljava/lang/String;
+	public fun convertWrite (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/RawReferenceAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)V
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public final fun getRole ()Lorg/modelix/model/api/IReferenceLink;
+	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/modelix/model/api/INode;
+	public final fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Lorg/modelix/model/api/INode;)V
+}
+
+public final class org/modelix/metamodel/ReferenceNotSetException : java/lang/Exception {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedReferenceLink;)V
+	public final fun getLink ()Lorg/modelix/metamodel/ITypedReferenceLink;
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/metamodel/SingleChildAccessor : org/modelix/metamodel/ChildAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;Lorg/modelix/model/api/IConcept;Lkotlin/reflect/KClass;)V
+	public final fun get ()Lorg/modelix/metamodel/ITypedNode;
+	public final fun isSet ()Z
+	public final fun read (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun setNew ()Lorg/modelix/metamodel/ITypedNode;
+	public final fun setNew (Lorg/modelix/metamodel/INonAbstractConcept;)Lorg/modelix/metamodel/ITypedNode;
+}
+
+public final class org/modelix/metamodel/SingleChildAccessorKt {
+	public static final fun setNew (Lorg/modelix/metamodel/SingleChildAccessor;Lkotlin/jvm/functions/Function1;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun setNew (Lorg/modelix/metamodel/SingleChildAccessor;Lorg/modelix/metamodel/INonAbstractConcept;Lkotlin/jvm/functions/Function1;)Lorg/modelix/metamodel/ITypedNode;
+}
+
+public final class org/modelix/metamodel/StringPropertyAccessor : org/modelix/metamodel/PropertyAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)V
+	public synthetic fun convertRead (Ljava/lang/String;)Ljava/lang/Object;
+	public fun convertRead (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun convertWrite (Ljava/lang/Object;)Ljava/lang/String;
+	public fun convertWrite (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/TypedLanguagesRegistry : org/modelix/model/api/ILanguageRepository {
+	public static final field INSTANCE Lorg/modelix/metamodel/TypedLanguagesRegistry;
+	public final fun dispose ()V
+	public fun getAllConcepts ()Ljava/util/List;
+	public fun getPriority ()I
+	public final fun isRegistered (Lorg/modelix/metamodel/GeneratedLanguage;)Z
+	public final fun register (Lorg/modelix/metamodel/GeneratedLanguage;)V
+	public fun resolveConcept (Ljava/lang/String;)Lorg/modelix/metamodel/GeneratedConcept;
+	public synthetic fun resolveConcept (Ljava/lang/String;)Lorg/modelix/model/api/IConcept;
+	public final fun unregister (Lorg/modelix/metamodel/GeneratedLanguage;)V
+	public final fun wrapNode (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+}
+
+public final class org/modelix/metamodel/TypedLanguagesRegistryKt {
+	public static final fun asTypedNode (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun typed (Lorg/modelix/model/api/INode;Lkotlin/reflect/KClass;)Lorg/modelix/metamodel/ITypedNode;
+	public static final fun typedUnsafe (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/ITypedNode;
+}
+
+public abstract class org/modelix/metamodel/TypedNodeImpl : org/modelix/metamodel/ITypedNode {
+	public fun <init> (Lorg/modelix/model/api/INode;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWrappedNode ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun unwrap ()Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/metamodel/TypedNodeReference {
+	public fun <init> (Lorg/modelix/model/api/INodeReference;Lkotlin/reflect/KClass;)V
+	public final fun component1 ()Lorg/modelix/model/api/INodeReference;
+	public final fun component2 ()Lkotlin/reflect/KClass;
+	public final fun copy (Lorg/modelix/model/api/INodeReference;Lkotlin/reflect/KClass;)Lorg/modelix/metamodel/TypedNodeReference;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/TypedNodeReference;Lorg/modelix/model/api/INodeReference;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lorg/modelix/metamodel/TypedNodeReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeClass ()Lkotlin/reflect/KClass;
+	public final fun getRef ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public final fun resolve (Lorg/modelix/model/area/IArea;)Lorg/modelix/metamodel/ITypedNode;
+	public fun toString ()Ljava/lang/String;
+	public final fun untyped ()Lorg/modelix/model/api/INodeReference;
+}
+
+public final class org/modelix/metamodel/TypedNodeTraversalKt {
+	public static final fun descendants (Lorg/modelix/metamodel/ITypedNode;Z)Lkotlin/sequences/Sequence;
+	public static synthetic fun descendants$default (Lorg/modelix/metamodel/ITypedNode;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
+}
+
+public final class org/modelix/metamodel/TypedPropertyAccessor {
+	public fun <init> (Lorg/modelix/model/api/INode;Lorg/modelix/metamodel/ITypedProperty;)V
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public final fun getRole ()Lorg/modelix/metamodel/ITypedProperty;
+	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
+}
+
+public final class org/modelix/metamodel/UnknownConcept : org/modelix/metamodel/EmptyConcept {
+	public fun <init> (Lorg/modelix/model/api/IConceptReference;)V
+	public final fun copy (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/metamodel/UnknownConcept;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/UnknownConcept;Lorg/modelix/model/api/IConceptReference;ILjava/lang/Object;)Lorg/modelix/metamodel/UnknownConcept;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLanguage ()Lorg/modelix/model/api/ILanguage;
+	public fun getLongName ()Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getShortName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/UnknownConceptInstance : org/modelix/metamodel/ITypedNode {
+	public fun <init> (Lorg/modelix/model/api/INode;)V
+	public final fun component1 ()Lorg/modelix/model/api/INode;
+	public final fun copy (Lorg/modelix/model/api/INode;)Lorg/modelix/metamodel/UnknownConceptInstance;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/UnknownConceptInstance;Lorg/modelix/model/api/INode;ILjava/lang/Object;)Lorg/modelix/metamodel/UnknownConceptInstance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public fun get_concept ()Lorg/modelix/metamodel/ITypedConcept;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun unwrap ()Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/metamodel/UnknownTypedConcept : org/modelix/metamodel/ITypedConcept {
+	public fun <init> (Lorg/modelix/model/api/IConceptReference;)V
+	public final fun copy (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/metamodel/UnknownTypedConcept;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/UnknownTypedConcept;Lorg/modelix/model/api/IConceptReference;ILjava/lang/Object;)Lorg/modelix/metamodel/UnknownTypedConcept;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun untyped ()Lorg/modelix/model/api/IConcept;
+}
+

--- a/model-api-gen/api/model-api-gen.api
+++ b/model-api-gen/api/model-api-gen.api
@@ -1,0 +1,349 @@
+public final class org/modelix/metamodel/generator/ChildLinkData : org/modelix/metamodel/generator/IConceptFeatureData {
+	public static final field Companion Lorg/modelix/metamodel/generator/ChildLinkData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZ)Lorg/modelix/metamodel/generator/ChildLinkData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/generator/ChildLinkData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Lorg/modelix/metamodel/generator/ChildLinkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMultiple ()Z
+	public fun getName ()Ljava/lang/String;
+	public final fun getOptional ()Z
+	public final fun getType ()Ljava/lang/String;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/ChildLinkData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/generator/ChildLinkData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/generator/ChildLinkData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/generator/ChildLinkData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/ChildLinkData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/ConceptBuilder {
+	public fun <init> (Ljava/lang/String;Lorg/modelix/metamodel/generator/LanguageBuilder;)V
+	public final fun abstract (Z)V
+	public static synthetic fun abstract$default (Lorg/modelix/metamodel/generator/ConceptBuilder;ZILjava/lang/Object;)V
+	public final fun build ()Lorg/modelix/model/data/ConceptData;
+	public final fun child (Ljava/lang/String;Ljava/lang/String;ZZ)V
+	public final fun child0 (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun child0n (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun child1 (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun child1n (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun concept (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun concept$default (Lorg/modelix/metamodel/generator/ConceptBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun extends (Ljava/lang/String;)V
+	public final fun getConceptName ()Ljava/lang/String;
+	public final fun getLanguageBuilder ()Lorg/modelix/metamodel/generator/LanguageBuilder;
+	public final fun optionalReference (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun property (Ljava/lang/String;)V
+	public final fun reference (Ljava/lang/String;Ljava/lang/String;Z)V
+	public static synthetic fun reference$default (Lorg/modelix/metamodel/generator/ConceptBuilder;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)V
+}
+
+public final class org/modelix/metamodel/generator/ConceptData {
+	public static final field Companion Lorg/modelix/metamodel/generator/ConceptData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/modelix/metamodel/generator/ConceptData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/generator/ConceptData;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/metamodel/generator/ConceptData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbstract ()Z
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getExtends ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/List;
+	public final fun getReferences ()Ljava/util/List;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/ConceptData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/generator/ConceptData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/generator/ConceptData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/generator/ConceptData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/ConceptData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/ConceptInLanguageKt {
+	public static final fun parseConceptRef (Ljava/lang/String;Lorg/modelix/model/data/LanguageData;)Lorg/modelix/metamodel/generator/ConceptRef;
+}
+
+public final class org/modelix/metamodel/generator/ConceptRef {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getConceptName ()Ljava/lang/String;
+	public final fun getLanguageName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/ConceptsFilter {
+	public fun <init> (Lorg/modelix/metamodel/generator/LanguageSet;)V
+	public final fun apply ()Lorg/modelix/metamodel/generator/LanguageSet;
+	public final fun getLanguageSet ()Lorg/modelix/metamodel/generator/LanguageSet;
+	public final fun includeConcept (Ljava/lang/String;)V
+	public final fun isConceptIncluded (Ljava/lang/String;)Z
+	public final fun isLanguageIncluded (Ljava/lang/String;)Z
+}
+
+public final class org/modelix/metamodel/generator/ConfigurableName : java/io/Serializable {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBaseNameConversion ()Lkotlin/jvm/functions/Function1;
+	public final fun getPrefix ()Ljava/lang/String;
+	public final fun getSuffix ()Ljava/lang/String;
+	public final fun invoke (Ljava/lang/String;)Ljava/lang/String;
+	public final fun setBaseNameConversion (Lkotlin/jvm/functions/Function1;)V
+	public final fun setPrefix (Ljava/lang/String;)V
+	public final fun setSuffix (Ljava/lang/String;)V
+}
+
+public final class org/modelix/metamodel/generator/FeatureInConcept {
+	public fun <init> (Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;Lorg/modelix/model/data/IConceptFeatureData;)V
+	public final fun component1 ()Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;
+	public final fun component2 ()Lorg/modelix/model/data/IConceptFeatureData;
+	public final fun copy (Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;Lorg/modelix/model/data/IConceptFeatureData;)Lorg/modelix/metamodel/generator/FeatureInConcept;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/generator/FeatureInConcept;Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;Lorg/modelix/model/data/IConceptFeatureData;ILjava/lang/Object;)Lorg/modelix/metamodel/generator/FeatureInConcept;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConcept ()Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;
+	public final fun getData ()Lorg/modelix/model/data/IConceptFeatureData;
+	public final fun getOriginalName ()Ljava/lang/String;
+	public final fun getValidName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/GeneratorInputKt {
+	public static final fun getReservedPropertyNames ()Ljava/util/Set;
+	public static final fun process (Lorg/modelix/metamodel/generator/LanguageSet;)Lorg/modelix/metamodel/generator/IProcessedLanguageSet;
+}
+
+public abstract interface class org/modelix/metamodel/generator/IConceptFeatureData {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getUid ()Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/metamodel/generator/IProcessedLanguageSet {
+}
+
+public final class org/modelix/metamodel/generator/LanguageBuilder {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun build ()Lorg/modelix/model/data/LanguageData;
+	public final fun concept (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun concept$default (Lorg/modelix/metamodel/generator/LanguageBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/LanguageData {
+	public static final field Companion Lorg/modelix/metamodel/generator/LanguageData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lorg/modelix/metamodel/generator/LanguageData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/generator/LanguageData;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/metamodel/generator/LanguageData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConcepts ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toCompactJson ()Ljava/lang/String;
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public final fun toYaml ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/LanguageData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/generator/LanguageData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/generator/LanguageData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/generator/LanguageData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/LanguageData$Companion {
+	public final fun fromFile (Ljava/io/File;)Lorg/modelix/metamodel/generator/LanguageData;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/LanguageSet {
+	public fun <init> (Ljava/util/List;)V
+	public final fun filter (Lkotlin/jvm/functions/Function1;)Lorg/modelix/metamodel/generator/LanguageSet;
+	public final fun getLanguages ()Ljava/util/List;
+	public final fun resolveConcept (Ljava/lang/String;)Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;
+}
+
+public final class org/modelix/metamodel/generator/LanguageSet$ConceptInLanguage {
+	public fun <init> (Lorg/modelix/metamodel/generator/LanguageSet;Lorg/modelix/model/data/ConceptData;Lorg/modelix/model/data/LanguageData;)V
+	public final fun allFeatures ()Ljava/util/List;
+	public final fun allSuperConcepts ()Ljava/util/List;
+	public final fun allSuperConceptsAndSelf ()Ljava/util/List;
+	public final fun directFeatures ()Ljava/util/List;
+	public final fun directFeaturesAndConflicts ()Ljava/util/List;
+	public final fun directSuperConcepts ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun extended ()Ljava/util/List;
+	public final fun extends ()Ljava/util/List;
+	public final fun getConcept ()Lorg/modelix/model/data/ConceptData;
+	public final fun getConceptFqName ()Ljava/lang/String;
+	public final fun getFqName ()Ljava/lang/String;
+	public final fun getLanguage ()Lorg/modelix/model/data/LanguageData;
+	public final fun getSimpleName ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun loadInheritance (Lorg/modelix/metamodel/generator/LanguageSet$ConceptInLanguage;Ljava/util/Map;)V
+	public final fun ref ()Lorg/modelix/metamodel/generator/ConceptRef;
+	public final fun resolveMultipleInheritanceConflicts ()Ljava/util/Map;
+}
+
+public final class org/modelix/metamodel/generator/LanguageSet$LanguageInSet {
+	public fun <init> (Lorg/modelix/metamodel/generator/LanguageSet;Lorg/modelix/model/data/LanguageData;)V
+	public final fun getConceptsInLanguage ()Ljava/util/List;
+	public final fun getLanguage ()Lorg/modelix/model/data/LanguageData;
+	public final fun getLanguageSet ()Lorg/modelix/metamodel/generator/LanguageSet;
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/MetaModelDSLKt {
+	public static final fun newLanguage (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/data/LanguageData;
+}
+
+public final class org/modelix/metamodel/generator/MetaModelGenerator {
+	public static final field Companion Lorg/modelix/metamodel/generator/MetaModelGenerator$Companion;
+	public static final field HEADER_COMMENT Ljava/lang/String;
+	public fun <init> (Ljava/nio/file/Path;Lorg/modelix/metamodel/generator/NameConfig;Ljava/nio/file/Path;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Lorg/modelix/metamodel/generator/NameConfig;Ljava/nio/file/Path;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun generate (Lorg/modelix/metamodel/generator/IProcessedLanguageSet;)V
+	public final fun generateRegistrationHelper (Ljava/lang/String;Lorg/modelix/metamodel/generator/IProcessedLanguageSet;)V
+}
+
+public final class org/modelix/metamodel/generator/MetaModelGenerator$Companion {
+}
+
+public final class org/modelix/metamodel/generator/NameConfig : java/io/Serializable {
+	public fun <init> ()V
+	public final fun getConceptTypeAlias ()Lorg/modelix/metamodel/generator/ConfigurableName;
+	public final fun getLanguageClass ()Lorg/modelix/metamodel/generator/ConfigurableName;
+	public final fun getTypedConcept ()Lorg/modelix/metamodel/generator/ConfigurableName;
+	public final fun getTypedConceptImpl ()Lorg/modelix/metamodel/generator/ConfigurableName;
+	public final fun getTypedNode ()Lorg/modelix/metamodel/generator/ConfigurableName;
+	public final fun getTypedNodeImpl ()Lorg/modelix/metamodel/generator/ConfigurableName;
+	public final fun getUntypedConcept ()Lorg/modelix/metamodel/generator/ConfigurableName;
+}
+
+public final class org/modelix/metamodel/generator/PropertyData : org/modelix/metamodel/generator/IConceptFeatureData {
+	public static final field Companion Lorg/modelix/metamodel/generator/PropertyData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/metamodel/generator/PropertyType;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/metamodel/generator/PropertyType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/modelix/metamodel/generator/PropertyType;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/metamodel/generator/PropertyType;)Lorg/modelix/metamodel/generator/PropertyData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/generator/PropertyData;Ljava/lang/String;Ljava/lang/String;Lorg/modelix/metamodel/generator/PropertyType;ILjava/lang/Object;)Lorg/modelix/metamodel/generator/PropertyData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public final fun getType ()Lorg/modelix/metamodel/generator/PropertyType;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/PropertyData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/generator/PropertyData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/generator/PropertyData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/generator/PropertyData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/PropertyData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/PropertyType : java/lang/Enum {
+	public static final field BOOLEAN Lorg/modelix/metamodel/generator/PropertyType;
+	public static final field INT Lorg/modelix/metamodel/generator/PropertyType;
+	public static final field STRING Lorg/modelix/metamodel/generator/PropertyType;
+	public static fun valueOf (Ljava/lang/String;)Lorg/modelix/metamodel/generator/PropertyType;
+	public static fun values ()[Lorg/modelix/metamodel/generator/PropertyType;
+}
+
+public final class org/modelix/metamodel/generator/ReferenceLinkData : org/modelix/metamodel/generator/IConceptFeatureData {
+	public static final field Companion Lorg/modelix/metamodel/generator/ReferenceLinkData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lorg/modelix/metamodel/generator/ReferenceLinkData;
+	public static synthetic fun copy$default (Lorg/modelix/metamodel/generator/ReferenceLinkData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/modelix/metamodel/generator/ReferenceLinkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public final fun getOptional ()Z
+	public final fun getType ()Ljava/lang/String;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/metamodel/generator/ReferenceLinkData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/metamodel/generator/ReferenceLinkData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/generator/ReferenceLinkData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/generator/ReferenceLinkData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/ReferenceLinkData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/metamodel/generator/TypescriptMMGenerator {
+	public fun <init> (Ljava/nio/file/Path;Lorg/modelix/metamodel/generator/NameConfig;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Lorg/modelix/metamodel/generator/NameConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun generate (Lorg/modelix/metamodel/generator/IProcessedLanguageSet;)V
+	public final fun getNameConfig ()Lorg/modelix/metamodel/generator/NameConfig;
+	public final fun getOutputDir ()Ljava/nio/file/Path;
+}
+

--- a/model-api/api/model-api.api
+++ b/model-api/api/model-api.api
@@ -1,0 +1,2055 @@
+public final class org/modelix/model/api/BuiltinLanguages {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages;
+	public final fun getAllLanguages ()Ljava/util/List;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts : org/modelix/model/api/SimpleLanguage {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$DevKit : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$DevKit;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$DevkitDependency : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$DevkitDependency;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$JavaModuleFacet : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$JavaModuleFacet;
+	public final fun getGenerated ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getPath ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Language : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Language;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$LanguageDependency : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$LanguageDependency;
+	public final fun getName ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getUuid ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Model : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Model;
+	public final fun getId ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getModelImports ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getRootNodes ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getStereotype ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getUsedLanguages ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModelReference : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModelReference;
+	public final fun getModel ()Lorg/modelix/model/api/SimpleReferenceLink;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Module : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Module;
+	public final fun getCompileInMPS ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getDependencies ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getFacets ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getId ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getLanguageDependencies ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getModels ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getModuleVersion ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModuleDependency : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModuleDependency;
+	public final fun getExplicit ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getName ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getReexport ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getScope ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getUuid ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getVersion ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModuleFacet : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModuleFacet;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModuleReference : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ModuleReference;
+	public final fun getModule ()Lorg/modelix/model/api/SimpleReferenceLink;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Project : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Project;
+	public final fun getModules ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getProjectModules ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ProjectModule : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$ProjectModule;
+	public final fun getVirtualFolder ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Repository : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Repository;
+	public final fun getModules ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getProjects ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getTempModules ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$SingleLanguageDependency : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$SingleLanguageDependency;
+	public final fun getVersion ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Solution : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$MPSRepositoryConcepts$Solution;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$ModelixRuntimelang : org/modelix/model/api/SimpleLanguage {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$ModelixRuntimelang;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$ModelixRuntimelang$BranchInfo : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$ModelixRuntimelang$BranchInfo;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$ModelixRuntimelang$ModelServerInfo : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$ModelixRuntimelang$ModelServerInfo;
+	public final fun getRepositories ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$ModelixRuntimelang$RepositoryInfo : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$ModelixRuntimelang$RepositoryInfo;
+	public final fun getBranches ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getId ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core : org/modelix/model/api/SimpleLanguage {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$Attribute : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$Attribute;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$BaseConcept : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$BaseConcept;
+	public final fun getSmodelAttribute ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getVirtualPackage ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$INamedConcept : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$INamedConcept;
+	public final fun getName ()Lorg/modelix/model/api/SimpleProperty;
+}
+
+public final class org/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$NodeAttribute : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/api/BuiltinLanguages$jetbrains_mps_lang_core$NodeAttribute;
+}
+
+public final class org/modelix/model/api/ChildLinkFromName : org/modelix/model/api/LinkFromName, org/modelix/model/api/IChildLink {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/api/ChildLinkFromName;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/ChildLinkFromName;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/ChildLinkFromName;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isMultiple ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/CompositeNodeResolutionScope : org/modelix/model/api/INodeResolutionScope {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getScopes ()Ljava/util/List;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/api/ConceptReference : org/modelix/model/api/IConceptReference {
+	public static final field Companion Lorg/modelix/model/api/ConceptReference$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/api/ConceptReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/ConceptReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/ConceptReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getUID ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun resolve (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/IConcept;
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/ConceptReference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/api/ConceptReferenceKSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/api/ConceptReference;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/api/ConceptReference;)V
+}
+
+public final class org/modelix/model/api/ConceptUtilKt {
+	public static final fun getAllConcepts (Lorg/modelix/model/api/IConcept;)Ljava/util/List;
+}
+
+public final class org/modelix/model/api/ContextValue {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun computeWith (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getAllValues ()Ljava/lang/Iterable;
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public final class org/modelix/model/api/DefaultLanguageRepository : org/modelix/model/api/ILanguageRepository {
+	public static final field INSTANCE Lorg/modelix/model/api/DefaultLanguageRepository;
+	public fun getAllConcepts ()Ljava/util/List;
+	public fun getPriority ()I
+	public final fun registerConcept (Lorg/modelix/model/api/IConcept;)V
+	public final fun registerLanguage (Lorg/modelix/model/api/ILanguage;)V
+	public fun resolveConcept (Ljava/lang/String;)Lorg/modelix/model/api/IConcept;
+	public final fun unregisterLanguage (Lorg/modelix/model/api/ILanguage;)V
+}
+
+public abstract interface class org/modelix/model/api/IBranch {
+	public abstract fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public abstract fun canRead ()Z
+	public abstract fun canWrite ()Z
+	public abstract fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeReadT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWriteT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public abstract fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public abstract fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public abstract fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public abstract fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runReadT (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun runWrite (Lkotlin/jvm/functions/Function0;)V
+	public fun runWriteT (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/api/IBranch$DefaultImpls {
+	public static fun computeReadT (Lorg/modelix/model/api/IBranch;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static fun computeWriteT (Lorg/modelix/model/api/IBranch;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static fun runReadT (Lorg/modelix/model/api/IBranch;Lkotlin/jvm/functions/Function1;)V
+	public static fun runWriteT (Lorg/modelix/model/api/IBranch;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/api/IBranchKt {
+	public static final fun deepUnwrap (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/api/IBranch;
+}
+
+public abstract interface class org/modelix/model/api/IBranchListener {
+	public abstract fun treeChanged (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITree;)V
+}
+
+public abstract interface class org/modelix/model/api/IBranchWrapper : org/modelix/model/api/IBranch {
+	public abstract fun unwrapBranch ()Lorg/modelix/model/api/IBranch;
+}
+
+public final class org/modelix/model/api/IBranchWrapper$DefaultImpls {
+	public static fun computeReadT (Lorg/modelix/model/api/IBranchWrapper;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static fun computeWriteT (Lorg/modelix/model/api/IBranchWrapper;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static fun runReadT (Lorg/modelix/model/api/IBranchWrapper;Lkotlin/jvm/functions/Function1;)V
+	public static fun runWriteT (Lorg/modelix/model/api/IBranchWrapper;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class org/modelix/model/api/IChildLink : org/modelix/model/api/ILink {
+	public static final field Companion Lorg/modelix/model/api/IChildLink$Companion;
+	public abstract fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public abstract fun isMultiple ()Z
+	public fun isOrdered ()Z
+}
+
+public final class org/modelix/model/api/IChildLink$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+}
+
+public final class org/modelix/model/api/IChildLink$DefaultImpls {
+	public static fun getName (Lorg/modelix/model/api/IChildLink;)Ljava/lang/String;
+	public static fun isOrdered (Lorg/modelix/model/api/IChildLink;)Z
+}
+
+public abstract interface class org/modelix/model/api/IConcept {
+	public abstract fun getAllChildLinks ()Ljava/util/List;
+	public abstract fun getAllProperties ()Ljava/util/List;
+	public abstract fun getAllReferenceLinks ()Ljava/util/List;
+	public abstract fun getChildLink (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public abstract fun getDirectSuperConcepts ()Ljava/util/List;
+	public abstract fun getLanguage ()Lorg/modelix/model/api/ILanguage;
+	public abstract fun getLongName ()Ljava/lang/String;
+	public abstract fun getOwnChildLinks ()Ljava/util/List;
+	public abstract fun getOwnProperties ()Ljava/util/List;
+	public abstract fun getOwnReferenceLinks ()Ljava/util/List;
+	public abstract fun getProperty (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public abstract fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public abstract fun getReferenceLink (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public abstract fun getShortName ()Ljava/lang/String;
+	public abstract fun getUID ()Ljava/lang/String;
+	public abstract fun isAbstract ()Z
+	public abstract fun isExactly (Lorg/modelix/model/api/IConcept;)Z
+	public abstract fun isSubConceptOf (Lorg/modelix/model/api/IConcept;)Z
+}
+
+public final class org/modelix/model/api/IConceptKt {
+	public static final fun isSubConceptOf (Lorg/modelix/model/api/IConcept;Lorg/modelix/model/api/IConcept;)Z
+}
+
+public abstract interface class org/modelix/model/api/IConceptReference {
+	public static final field Companion Lorg/modelix/model/api/IConceptReference$Companion;
+	public abstract fun getUID ()Ljava/lang/String;
+	public abstract fun resolve (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/IConcept;
+	public abstract fun serialize ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/IConceptReference$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/ConceptReference;
+	public final fun registerDeserializer (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public final fun unregisterSerializer (Ljava/lang/Object;)V
+}
+
+public final class org/modelix/model/api/IConceptReferenceKt {
+	public static final fun resolve (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public static final fun tryResolve (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+}
+
+public abstract interface class org/modelix/model/api/IDeprecatedNodeDefaults : org/modelix/model/api/INode {
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public abstract fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public abstract fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public abstract fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public abstract fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public abstract fun getPropertyLinks ()Ljava/util/List;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public abstract fun getReferenceLinks ()Ljava/util/List;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public abstract fun getReferenceTarget (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public abstract fun getReferenceTargetRef (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public abstract fun moveChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public abstract fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public abstract fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public fun usesRoleIds ()Z
+}
+
+public final class org/modelix/model/api/IDeprecatedNodeDefaults$DefaultImpls {
+	public static fun addNewChild (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChildren (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllProperties (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefs (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefsAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargets (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/util/List;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildren (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;)Ljava/lang/Iterable;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Z)Lkotlinx/coroutines/flow/Flow;
+	public static fun getOriginalReference (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/lang/String;
+	public static fun getParentAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyRoles (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/util/List;
+	public static fun getPropertyValue (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;)Ljava/lang/String;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceRoles (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/util/List;
+	public static fun getReferenceTarget (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRefAsFlow (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getRoleInParent (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Ljava/lang/String;
+	public static fun moveChild (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public static fun removeReference (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Lorg/modelix/model/api/IReferenceLink;)V
+	public static fun setPropertyValue (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;Ljava/lang/String;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/IDeprecatedNodeDefaults;Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public static fun tryGetConcept (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Lorg/modelix/model/api/IConcept;
+	public static fun usesRoleIds (Lorg/modelix/model/api/IDeprecatedNodeDefaults;)Z
+}
+
+public abstract interface class org/modelix/model/api/IIdGenerator {
+	public abstract fun generate ()J
+}
+
+public abstract interface class org/modelix/model/api/ILanguage {
+	public abstract fun getConcepts ()Ljava/util/List;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getUID ()Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/ILanguageRepository {
+	public static final field Companion Lorg/modelix/model/api/ILanguageRepository$Companion;
+	public abstract fun getAllConcepts ()Ljava/util/List;
+	public fun getPriority ()I
+	public abstract fun resolveConcept (Ljava/lang/String;)Lorg/modelix/model/api/IConcept;
+}
+
+public final class org/modelix/model/api/ILanguageRepository$Companion {
+	public final fun getDefault ()Lorg/modelix/model/api/DefaultLanguageRepository;
+	public final fun getDirectSubConcepts (Lorg/modelix/model/api/IConcept;)Ljava/util/Set;
+	public final fun register (Lorg/modelix/model/api/ILanguageRepository;)V
+	public final fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public final fun tryResolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public final fun unregister (Lorg/modelix/model/api/ILanguageRepository;)V
+}
+
+public final class org/modelix/model/api/ILanguageRepository$DefaultImpls {
+	public static fun getPriority (Lorg/modelix/model/api/ILanguageRepository;)I
+}
+
+public final class org/modelix/model/api/ILanguageRepositoryKt {
+	public static final fun getAllSubConcepts (Lorg/modelix/model/api/IConcept;Z)Ljava/util/Set;
+	public static final fun getDirectSubConcepts (Lorg/modelix/model/api/IConcept;)Ljava/util/Set;
+	public static final fun getInstantiatableSubConcepts (Lorg/modelix/model/api/IConcept;)Ljava/util/List;
+}
+
+public abstract interface class org/modelix/model/api/ILink : org/modelix/model/api/IRole {
+	public abstract fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+}
+
+public final class org/modelix/model/api/ILink$DefaultImpls {
+	public static fun getName (Lorg/modelix/model/api/ILink;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/INode {
+	public abstract fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun addNewChildren (Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public abstract fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getAllChildrenAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getAllProperties ()Ljava/util/List;
+	public fun getAllReferenceTargetRefs ()Ljava/util/List;
+	public fun getAllReferenceTargetRefsAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getAllReferenceTargets ()Ljava/util/List;
+	public fun getAllReferenceTargetsAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getArea ()Lorg/modelix/model/area/IArea;
+	public abstract fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getChildrenAsFlow (Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public abstract fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public fun getDescendantsAsFlow (Z)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getDescendantsAsFlow$default (Lorg/modelix/model/api/INode;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOriginalReference ()Ljava/lang/String;
+	public abstract fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getParentAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getPropertyLinks ()Ljava/util/List;
+	public abstract fun getPropertyRoles ()Ljava/util/List;
+	public abstract fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getPropertyValueAsFlow (Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceLinks ()Ljava/util/List;
+	public abstract fun getReferenceRoles ()Ljava/util/List;
+	public abstract fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTarget (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetAsFlow (Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTargetRef (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTargetRefAsFlow (Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getRoleInParent ()Ljava/lang/String;
+	public abstract fun isValid ()Z
+	public abstract fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun moveChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public abstract fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun removeReference (Lorg/modelix/model/api/IReferenceLink;)V
+	public abstract fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public abstract fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public fun tryGetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun usesRoleIds ()Z
+}
+
+public final class org/modelix/model/api/INode$DefaultImpls {
+	public static fun addNewChild (Lorg/modelix/model/api/INode;Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChildren (Lorg/modelix/model/api/INode;Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/api/INode;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllProperties (Lorg/modelix/model/api/INode;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefs (Lorg/modelix/model/api/INode;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefsAsFlow (Lorg/modelix/model/api/INode;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargets (Lorg/modelix/model/api/INode;)Ljava/util/List;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/api/INode;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildren (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getContainmentLink (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/IChildLink;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/api/INode;Z)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getDescendantsAsFlow$default (Lorg/modelix/model/api/INode;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getOriginalReference (Lorg/modelix/model/api/INode;)Ljava/lang/String;
+	public static fun getParentAsFlow (Lorg/modelix/model/api/INode;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyLinks (Lorg/modelix/model/api/INode;)Ljava/util/List;
+	public static fun getPropertyValue (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceLinks (Lorg/modelix/model/api/INode;)Ljava/util/List;
+	public static fun getReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRefAsFlow (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun moveChild (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public static fun removeReference (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)V
+	public static fun setPropertyValue (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INode;Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public static fun tryGetConcept (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/IConcept;
+	public static fun usesRoleIds (Lorg/modelix/model/api/INode;)Z
+}
+
+public abstract interface class org/modelix/model/api/INodeEx : org/modelix/model/api/INode {
+}
+
+public final class org/modelix/model/api/INodeEx$DefaultImpls {
+	public static fun addNewChild (Lorg/modelix/model/api/INodeEx;Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChildren (Lorg/modelix/model/api/INodeEx;Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/api/INodeEx;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllProperties (Lorg/modelix/model/api/INodeEx;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefs (Lorg/modelix/model/api/INodeEx;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefsAsFlow (Lorg/modelix/model/api/INodeEx;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargets (Lorg/modelix/model/api/INodeEx;)Ljava/util/List;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/api/INodeEx;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildren (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getContainmentLink (Lorg/modelix/model/api/INodeEx;)Lorg/modelix/model/api/IChildLink;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/api/INodeEx;Z)Lkotlinx/coroutines/flow/Flow;
+	public static fun getOriginalReference (Lorg/modelix/model/api/INodeEx;)Ljava/lang/String;
+	public static fun getParentAsFlow (Lorg/modelix/model/api/INodeEx;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyLinks (Lorg/modelix/model/api/INodeEx;)Ljava/util/List;
+	public static fun getPropertyValue (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceLinks (Lorg/modelix/model/api/INodeEx;)Ljava/util/List;
+	public static fun getReferenceTarget (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/INodeEx;Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRefAsFlow (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun moveChild (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public static fun removeReference (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;)V
+	public static fun setPropertyValue (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INodeEx;Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INodeEx;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public static fun tryGetConcept (Lorg/modelix/model/api/INodeEx;)Lorg/modelix/model/api/IConcept;
+	public static fun usesRoleIds (Lorg/modelix/model/api/INodeEx;)Z
+}
+
+public final class org/modelix/model/api/INodeKt {
+	public static final fun addNewChild (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public static final fun addNewChild (Lorg/modelix/model/api/INode;Ljava/lang/String;I)Lorg/modelix/model/api/INode;
+	public static final fun addNewChild (Lorg/modelix/model/api/INode;Ljava/lang/String;Lorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static final fun addNewChild (Lorg/modelix/model/api/INode;Ljava/lang/String;Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static final fun addNewChild (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static final fun filterSecondNotNull (Ljava/util/List;)Ljava/util/List;
+	public static final fun getChildren (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public static final fun getConcept (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/IConcept;
+	public static final fun getContainmentLink (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/IChildLink;
+	public static final fun getPropertyValue (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static final fun getReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public static final fun getReferenceTargetRef (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public static final fun getResolvedConcept (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/IConcept;
+	public static final fun getResolvedReferenceTarget (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public static final fun getRoot (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+	public static final fun index (Lorg/modelix/model/api/INode;)I
+	public static final fun isChildRoleOrdered (Lorg/modelix/model/api/INode;Ljava/lang/String;)Z
+	public static final fun isInstanceOf (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IConcept;)Z
+	public static final fun isInstanceOfSafe (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IConcept;)Z
+	public static final fun key (Lorg/modelix/model/api/IRole;)Ljava/lang/String;
+	public static final fun key (Lorg/modelix/model/api/IRole;Lorg/modelix/model/api/INode;)Ljava/lang/String;
+	public static final fun moveChild (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public static final fun remove (Lorg/modelix/model/api/INode;)V
+	public static final fun resolveChildLink (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public static final fun resolveChildLinkOrFallback (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public static final fun resolveProperty (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public static final fun resolvePropertyOrFallback (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public static final fun resolveReferenceLink (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public static final fun resolveReferenceLinkOrFallback (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public static final fun setPropertyValue (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public static final fun setReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public static final fun setReferenceTarget (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public static final fun tryResolveChildLink (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public static final fun tryResolveProperty (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public static final fun tryResolveReferenceLink (Lorg/modelix/model/api/INode;Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public static final fun usesRoleIds (Lorg/modelix/model/api/INode;)Z
+}
+
+public abstract interface class org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/api/INodeReference$Companion;
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public fun serialize ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/INodeReference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/api/INodeReference$DefaultImpls {
+	public static fun resolveNode (Lorg/modelix/model/api/INodeReference;Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public static fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/INodeReferenceKt {
+	public static final fun resolveIn (Lorg/modelix/model/api/INodeReference;Lorg/modelix/model/api/INodeResolutionScope;)Lorg/modelix/model/api/INode;
+	public static final fun resolveInCurrentContext (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public abstract interface class org/modelix/model/api/INodeReferenceSerializer {
+	public static final field Companion Lorg/modelix/model/api/INodeReferenceSerializer$Companion;
+	public abstract fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public abstract fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/INodeReferenceSerializer$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public final fun register (Lorg/modelix/model/api/INodeReferenceSerializer;)V
+	public final fun register (Lorg/modelix/model/api/INodeReferenceSerializer;Z)V
+	public final fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+	public final fun tryDeserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public final fun unregister (Lorg/modelix/model/api/INodeReferenceSerializer;)V
+}
+
+public abstract interface class org/modelix/model/api/INodeReferenceSerializerEx : org/modelix/model/api/INodeReferenceSerializer {
+	public static final field Companion Lorg/modelix/model/api/INodeReferenceSerializerEx$Companion;
+	public static final field SEPARATOR Ljava/lang/String;
+	public abstract fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public abstract fun getPrefix ()Ljava/lang/String;
+	public abstract fun getSupportedReferenceClasses ()Ljava/util/Set;
+	public abstract fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/INodeReferenceSerializerEx$Companion {
+	public static final field SEPARATOR Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/INodeReferenceSerializerKt {
+	public static final fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/INodeResolutionScope {
+	public static final field Companion Lorg/modelix/model/api/INodeResolutionScope$Companion;
+	public abstract fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun runWith (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun runWithAdditionalScope (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun runWithAdditionalScopeInCoroutine (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun runWithAdditionalScopeInCoroutine$suspendImpl (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun runWithInCoroutine (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun runWithInCoroutine$suspendImpl (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/api/INodeResolutionScope$Companion {
+	public final fun ensureInContext (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getCurrentScope ()Lorg/modelix/model/api/INodeResolutionScope;
+	public final fun getCurrentScopes ()Ljava/util/List;
+	public final fun runWithAdditionalScope (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun runWithAdditionalScopeInCoroutine (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/api/INodeResolutionScope$DefaultImpls {
+	public static fun runWith (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static fun runWithAdditionalScope (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static fun runWithAdditionalScopeInCoroutine (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun runWithInCoroutine (Lorg/modelix/model/api/INodeResolutionScope;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/model/api/INodeWrapper : org/modelix/model/api/INode {
+	public abstract fun getWrappedNode ()Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/api/INodeWrapper$DefaultImpls {
+	public static fun addNewChild (Lorg/modelix/model/api/INodeWrapper;Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChildren (Lorg/modelix/model/api/INodeWrapper;Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/api/INodeWrapper;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllProperties (Lorg/modelix/model/api/INodeWrapper;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefs (Lorg/modelix/model/api/INodeWrapper;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefsAsFlow (Lorg/modelix/model/api/INodeWrapper;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargets (Lorg/modelix/model/api/INodeWrapper;)Ljava/util/List;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/api/INodeWrapper;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildren (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getContainmentLink (Lorg/modelix/model/api/INodeWrapper;)Lorg/modelix/model/api/IChildLink;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/api/INodeWrapper;Z)Lkotlinx/coroutines/flow/Flow;
+	public static fun getOriginalReference (Lorg/modelix/model/api/INodeWrapper;)Ljava/lang/String;
+	public static fun getParentAsFlow (Lorg/modelix/model/api/INodeWrapper;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyLinks (Lorg/modelix/model/api/INodeWrapper;)Ljava/util/List;
+	public static fun getPropertyValue (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceLinks (Lorg/modelix/model/api/INodeWrapper;)Ljava/util/List;
+	public static fun getReferenceTarget (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/INodeWrapper;Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRefAsFlow (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun moveChild (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public static fun removeReference (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;)V
+	public static fun setPropertyValue (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INodeWrapper;Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/api/INodeWrapper;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public static fun tryGetConcept (Lorg/modelix/model/api/INodeWrapper;)Lorg/modelix/model/api/IConcept;
+	public static fun usesRoleIds (Lorg/modelix/model/api/INodeWrapper;)Z
+}
+
+public abstract interface class org/modelix/model/api/IProperty : org/modelix/model/api/IRole {
+	public static final field Companion Lorg/modelix/model/api/IProperty$Companion;
+}
+
+public final class org/modelix/model/api/IProperty$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+}
+
+public final class org/modelix/model/api/IProperty$DefaultImpls {
+	public static fun getName (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/IReadTransaction : org/modelix/model/api/ITransaction {
+}
+
+public abstract interface class org/modelix/model/api/IReferenceLink : org/modelix/model/api/ILink {
+	public static final field Companion Lorg/modelix/model/api/IReferenceLink$Companion;
+}
+
+public final class org/modelix/model/api/IReferenceLink$Companion {
+	public final fun fromName (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+}
+
+public final class org/modelix/model/api/IReferenceLink$DefaultImpls {
+	public static fun getName (Lorg/modelix/model/api/IReferenceLink;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/IRole {
+	public abstract fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getName ()Ljava/lang/String;
+	public abstract fun getSimpleName ()Ljava/lang/String;
+	public abstract fun getUID ()Ljava/lang/String;
+	public abstract fun isOptional ()Z
+}
+
+public final class org/modelix/model/api/IRole$DefaultImpls {
+	public static fun getName (Lorg/modelix/model/api/IRole;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/ITransaction {
+	public abstract fun containsNode (J)Z
+	public abstract fun getAllChildren (J)Ljava/lang/Iterable;
+	public abstract fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public abstract fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public abstract fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public abstract fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public abstract fun getParent (J)J
+	public abstract fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public abstract fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public abstract fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public abstract fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public abstract fun getRole (J)Ljava/lang/String;
+	public abstract fun getTree ()Lorg/modelix/model/api/ITree;
+	public abstract fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public final class org/modelix/model/api/ITransactionKt {
+	public static final fun key (Lorg/modelix/model/api/IRole;Lorg/modelix/model/api/ITransaction;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/ITree {
+	public static final field Companion Lorg/modelix/model/api/ITree$Companion;
+	public static final field DETACHED_NODES_ROLE Ljava/lang/String;
+	public static final field ROOT_ID J
+	public abstract fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public abstract fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public abstract fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public abstract fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public abstract fun containsNode (J)Z
+	public abstract fun deleteNode (J)Lorg/modelix/model/api/ITree;
+	public abstract fun deleteNodes ([J)Lorg/modelix/model/api/ITree;
+	public abstract fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getAllChildrenAsFlow (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getAllReferenceTargetsAsFlow (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getChildRoles (J)Ljava/lang/Iterable;
+	public abstract fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getChildrenAsFlow (JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public abstract fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getDescendantsAsFlow (JZ)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getDescendantsAsFlow$default (Lorg/modelix/model/api/ITree;JZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getParent (J)J
+	public fun getParentAsFlow (J)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public abstract fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getPropertyValueAsFlow (JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public abstract fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTargetAsFlow (JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getRole (J)Ljava/lang/String;
+	public abstract fun moveChild (JLjava/lang/String;IJ)Lorg/modelix/model/api/ITree;
+	public abstract fun setProperty (JLjava/lang/String;Ljava/lang/String;)Lorg/modelix/model/api/ITree;
+	public fun setReferenceTarget (JLjava/lang/String;J)Lorg/modelix/model/api/ITree;
+	public abstract fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/ITree;
+	public abstract fun usesRoleIds ()Z
+	public abstract fun visitChanges (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITreeChangeVisitor;)V
+}
+
+public final class org/modelix/model/api/ITree$Companion {
+	public static final field DETACHED_NODES_ROLE Ljava/lang/String;
+	public static final field ROOT_ID J
+}
+
+public final class org/modelix/model/api/ITree$DefaultImpls {
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/api/ITree;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/api/ITree;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/api/ITree;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/api/ITree;JZ)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun getDescendantsAsFlow$default (Lorg/modelix/model/api/ITree;JZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getParentAsFlow (Lorg/modelix/model/api/ITree;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/api/ITree;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/api/ITree;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun setReferenceTarget (Lorg/modelix/model/api/ITree;JLjava/lang/String;J)Lorg/modelix/model/api/ITree;
+}
+
+public abstract interface class org/modelix/model/api/ITreeChangeVisitor {
+	public abstract fun childrenChanged (JLjava/lang/String;)V
+	public abstract fun containmentChanged (J)V
+	public abstract fun propertyChanged (JLjava/lang/String;)V
+	public abstract fun referenceChanged (JLjava/lang/String;)V
+}
+
+public abstract interface class org/modelix/model/api/ITreeChangeVisitorEx : org/modelix/model/api/ITreeChangeVisitor {
+	public abstract fun nodeAdded (J)V
+	public abstract fun nodeRemoved (J)V
+}
+
+public final class org/modelix/model/api/ITreeKt {
+	public static final fun key (Lorg/modelix/model/api/IRole;Lorg/modelix/model/api/ITree;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/api/IWriteTransaction : org/modelix/model/api/ITransaction {
+	public abstract fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public abstract fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public abstract fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public abstract fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public abstract fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public abstract fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public abstract fun deleteNode (J)V
+	public abstract fun getTree ()Lorg/modelix/model/api/ITree;
+	public abstract fun moveChild (JLjava/lang/String;IJ)V
+	public abstract fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public abstract fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public abstract fun setTree (Lorg/modelix/model/api/ITree;)V
+}
+
+public final class org/modelix/model/api/IdGeneratorDummy : org/modelix/model/api/IIdGenerator {
+	public fun <init> ()V
+	public fun generate ()J
+}
+
+public abstract class org/modelix/model/api/LinkFromName : org/modelix/model/api/RoleFromName, org/modelix/model/api/ILink {
+	public fun <init> ()V
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+}
+
+public final class org/modelix/model/api/LocalPNodeReference : org/modelix/model/api/INodeReference {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lorg/modelix/model/api/LocalPNodeReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/LocalPNodeReference;JILjava/lang/Object;)Lorg/modelix/model/api/LocalPNodeReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public fun hashCode ()I
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public final fun toGlobal (Ljava/lang/String;)Lorg/modelix/model/api/PNodeReference;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/NodeReference : org/modelix/model/api/INodeReference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/api/NodeReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/NodeReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/NodeReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSerialized ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/NodeReferenceById : org/modelix/model/api/INodeReference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/api/NodeReferenceById;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/NodeReferenceById;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/NodeReferenceById;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/NodeReferenceKSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/api/INodeReference;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/api/INodeReference;)V
+}
+
+public final class org/modelix/model/api/NodeUtilKt {
+	public static final fun deepUnwrapNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+	public static final fun getAncestor (Lorg/modelix/model/api/INode;Lorg/modelix/model/api/IConcept;Z)Lorg/modelix/model/api/INode;
+	public static final fun getAncestors (Lorg/modelix/model/api/INode;Z)Lkotlin/sequences/Sequence;
+	public static synthetic fun getAncestors$default (Lorg/modelix/model/api/INode;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
+	public static final fun getDescendants (Lorg/modelix/model/api/INode;Z)Lkotlin/sequences/Sequence;
+}
+
+public final class org/modelix/model/api/NullChildLink : org/modelix/model/api/IChildLink {
+	public static final field INSTANCE Lorg/modelix/model/api/NullChildLink;
+	public fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getUID ()Ljava/lang/String;
+	public fun isMultiple ()Z
+	public fun isOptional ()Z
+}
+
+public final class org/modelix/model/api/NullNodeResolutionScope : org/modelix/model/api/INodeResolutionScope {
+	public static final field INSTANCE Lorg/modelix/model/api/NullNodeResolutionScope;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/api/PBranch : org/modelix/model/api/IBranch {
+	public fun <init> (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/IIdGenerator;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getId ()Ljava/lang/String;
+	public fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runWrite (Lkotlin/jvm/functions/Function0;)V
+}
+
+public class org/modelix/model/api/PNodeAdapter : org/modelix/model/api/INode, org/modelix/model/api/INodeEx {
+	public static final field Companion Lorg/modelix/model/api/PNodeAdapter$Companion;
+	public fun <init> (JLorg/modelix/model/api/IBranch;)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun addNewChildren (Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getAllChildrenAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getAllReferenceTargetRefsAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getAllReferenceTargetsAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public synthetic fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getArea ()Lorg/modelix/model/area/PArea;
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getChildrenAsFlow (Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getDescendantsAsFlow (Z)Lkotlinx/coroutines/flow/Flow;
+	public final fun getNodeId ()J
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getParentAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getPropertyValueAsFlow (Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetAsFlow (Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTargetRefAsFlow (Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	protected final fun notifyAccess ()V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun toString ()Ljava/lang/String;
+	protected final fun unwrap (Lorg/modelix/model/api/INode;)J
+	public fun usesRoleIds ()Z
+}
+
+public final class org/modelix/model/api/PNodeAdapter$Companion {
+	public final fun wrap (JLorg/modelix/model/api/IBranch;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/api/PNodeAdapterKt {
+	public static final fun getNode (Lorg/modelix/model/api/IBranch;J)Lorg/modelix/model/api/INode;
+	public static final fun getRootNode (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/api/PNodeReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/api/PNodeReference$Companion;
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lorg/modelix/model/api/PNodeReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/PNodeReference;JLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/PNodeReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranchId ()Ljava/lang/String;
+	public final fun getId ()J
+	public fun hashCode ()I
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public fun serialize ()Ljava/lang/String;
+	public final fun toLocal ()Lorg/modelix/model/api/LocalPNodeReference;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/PNodeReference$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/PNodeReference;
+	public final fun tryDeserialize (Ljava/lang/String;)Lorg/modelix/model/api/PNodeReference;
+}
+
+public final class org/modelix/model/api/PNodeReferenceSerializer : org/modelix/model/api/INodeReferenceSerializerEx {
+	public static final field INSTANCE Lorg/modelix/model/api/PNodeReferenceSerializer;
+	public fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public final fun ensureRegistered ()V
+	public fun getPrefix ()Ljava/lang/String;
+	public fun getSupportedReferenceClasses ()Ljava/util/Set;
+	public fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/PlatformSpecificKt {
+	public static final fun runSynchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/api/PropertyFromName : org/modelix/model/api/RoleFromName, org/modelix/model/api/IProperty {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/api/PropertyFromName;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/PropertyFromName;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/PropertyFromName;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isOptional ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/ReadTransaction : org/modelix/model/api/Transaction, org/modelix/model/api/IReadTransaction {
+	public fun <init> (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/IBranch;)V
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/api/ReferenceLinkFromName : org/modelix/model/api/LinkFromName, org/modelix/model/api/IReferenceLink {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/api/ReferenceLinkFromName;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/ReferenceLinkFromName;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/ReferenceLinkFromName;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/RoleAccessContext {
+	public static final field INSTANCE Lorg/modelix/model/api/RoleAccessContext;
+	public final fun getKey (Lorg/modelix/model/api/IRole;)Ljava/lang/String;
+	public final fun isUsingRoleIds ()Z
+	public final fun runWith (ZLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract class org/modelix/model/api/RoleFromName : org/modelix/model/api/IRole {
+	public fun <init> ()V
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun isOptional ()Z
+}
+
+public final class org/modelix/model/api/SimpleChildLink : org/modelix/model/api/IChildLink {
+	public fun <init> (Ljava/lang/String;ZZLorg/modelix/model/api/IConcept;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZZLorg/modelix/model/api/IConcept;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getOwner ()Lorg/modelix/model/api/SimpleConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getUID ()Ljava/lang/String;
+	public fun isMultiple ()Z
+	public fun isOptional ()Z
+	public fun isOrdered ()Z
+	public final fun setOwner (Lorg/modelix/model/api/SimpleConcept;)V
+}
+
+public class org/modelix/model/api/SimpleConcept : org/modelix/model/api/IConcept {
+	public fun <init> (Ljava/lang/String;ZLjava/lang/Iterable;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Iterable;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addChildLink (Lorg/modelix/model/api/SimpleChildLink;)Lorg/modelix/model/api/SimpleConcept;
+	public final fun addProperty (Lorg/modelix/model/api/SimpleProperty;)Lorg/modelix/model/api/SimpleConcept;
+	public final fun addReferenceLink (Lorg/modelix/model/api/SimpleReferenceLink;)Lorg/modelix/model/api/SimpleConcept;
+	public fun getAllChildLinks ()Ljava/util/List;
+	public fun getAllProperties ()Ljava/util/List;
+	public fun getAllReferenceLinks ()Ljava/util/List;
+	public fun getChildLink (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public final fun getChildLinks ()Ljava/util/List;
+	public fun getDirectSuperConcepts ()Ljava/util/List;
+	public fun getLanguage ()Lorg/modelix/model/api/ILanguage;
+	public fun getLongName ()Ljava/lang/String;
+	public fun getOwnChildLinks ()Ljava/util/List;
+	public fun getOwnProperties ()Ljava/util/List;
+	public fun getOwnReferenceLinks ()Ljava/util/List;
+	public final fun getProperties ()Ljava/util/List;
+	public fun getProperty (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getReferenceLink (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public final fun getReferenceLinks ()Ljava/util/List;
+	public fun getShortName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun isAbstract ()Z
+	public fun isExactly (Lorg/modelix/model/api/IConcept;)Z
+	public fun isSubConceptOf (Lorg/modelix/model/api/IConcept;)Z
+	public fun setLanguage (Lorg/modelix/model/api/ILanguage;)V
+}
+
+public class org/modelix/model/api/SimpleLanguage : org/modelix/model/api/ILanguage {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addConcept (Lorg/modelix/model/api/SimpleConcept;)V
+	public fun getConcepts ()Ljava/util/List;
+	protected fun getIncludedConcepts ()[Lorg/modelix/model/api/SimpleConcept;
+	public fun getName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public final fun register ()V
+	protected fun setIncludedConcepts ([Lorg/modelix/model/api/SimpleConcept;)V
+	public final fun unregister ()V
+}
+
+public final class org/modelix/model/api/SimpleProperty : org/modelix/model/api/IProperty {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;)Lorg/modelix/model/api/SimpleProperty;
+	public static synthetic fun copy$default (Lorg/modelix/model/api/SimpleProperty;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/api/SimpleProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getOwner ()Lorg/modelix/model/api/SimpleConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isOptional ()Z
+	public final fun setOwner (Lorg/modelix/model/api/SimpleConcept;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/api/SimpleReferenceLink : org/modelix/model/api/IReferenceLink {
+	public fun <init> (Ljava/lang/String;ZLorg/modelix/model/api/IConcept;)V
+	public fun <init> (Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLorg/modelix/model/api/IConcept;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getOwner ()Lorg/modelix/model/api/SimpleConcept;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getUID ()Ljava/lang/String;
+	public fun isOptional ()Z
+	public final fun setOwner (Lorg/modelix/model/api/SimpleConcept;)V
+	public fun setTargetConcept (Lorg/modelix/model/api/IConcept;)V
+}
+
+public abstract class org/modelix/model/api/Transaction : org/modelix/model/api/ITransaction {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun containsNode (J)Z
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public final class org/modelix/model/api/TreePointer : org/modelix/model/api/IBranch, org/modelix/model/api/IReadTransaction, org/modelix/model/api/IWriteTransaction {
+	public fun <init> (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/IIdGenerator;)V
+	public synthetic fun <init> (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/IIdGenerator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun containsNode (J)Z
+	public fun deleteNode (J)V
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getId ()Ljava/lang/String;
+	public final fun getIdGenerator ()Lorg/modelix/model/api/IIdGenerator;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public fun moveChild (JLjava/lang/String;IJ)V
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runWrite (Lkotlin/jvm/functions/Function0;)V
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setTree (Lorg/modelix/model/api/ITree;)V
+}
+
+public final class org/modelix/model/api/WriteTransaction : org/modelix/model/api/Transaction, org/modelix/model/api/IWriteTransaction {
+	public fun <init> (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/IBranch;Lorg/modelix/model/api/IIdGenerator;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public final fun close ()V
+	public fun deleteNode (J)V
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun moveChild (JLjava/lang/String;IJ)V
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setTree (Lorg/modelix/model/api/ITree;)V
+}
+
+public abstract class org/modelix/model/area/AbstractArea : org/modelix/model/area/IArea {
+	public fun <init> ()V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/area/AreaListenerRegistry {
+	public static final field INSTANCE Lorg/modelix/model/area/AreaListenerRegistry;
+	public final fun getListeners (Lorg/modelix/model/area/IArea;)Ljava/util/List;
+	public final fun registerListener (Lorg/modelix/model/area/IArea;Lorg/modelix/model/area/IAreaListener;)V
+	public final fun unregisterArea (Lorg/modelix/model/area/IArea;)V
+	public final fun unregisterListener (Lorg/modelix/model/area/IArea;Lorg/modelix/model/area/IAreaListener;)V
+	public final fun unregisterWrappedListener (Lorg/modelix/model/area/IArea;Lorg/modelix/model/area/IAreaListener;)V
+}
+
+public final class org/modelix/model/area/AreaListenerRegistry$Entry {
+	public fun <init> (Lorg/modelix/model/area/IArea;Lorg/modelix/model/area/IAreaListener;)V
+	public final fun getArea ()Lorg/modelix/model/area/IArea;
+	public final fun getListener ()Lorg/modelix/model/area/IAreaListener;
+}
+
+public abstract class org/modelix/model/area/AreaListenerWrapper : org/modelix/model/area/IAreaListener {
+	public fun <init> (Lorg/modelix/model/area/IAreaListener;)V
+	public final fun getWrappedListener ()Lorg/modelix/model/area/IAreaListener;
+}
+
+public final class org/modelix/model/area/AreaWithMounts : org/modelix/model/area/IArea {
+	public fun <init> (Lorg/modelix/model/area/IArea;Ljava/util/Map;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getHiddenNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+	public final fun getMountedArea (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/IArea;
+	public final fun getMountedAreaRoot (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+	public fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public final fun getRootArea ()Lorg/modelix/model/area/IArea;
+	public fun hashCode ()I
+	public final fun isVisible (Lorg/modelix/model/api/INode;)Z
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public final fun unwrapNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/area/AreaWithMounts$AreaReference : org/modelix/model/area/IAreaReference {
+	public fun <init> (Lorg/modelix/model/area/IAreaReference;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Lorg/modelix/model/area/IAreaReference;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lorg/modelix/model/area/IAreaReference;Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/area/AreaWithMounts$AreaReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/area/AreaWithMounts$AreaReference;Lorg/modelix/model/area/IAreaReference;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/area/AreaWithMounts$AreaReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMountKeys ()Ljava/util/List;
+	public final fun getMountValues ()Ljava/util/List;
+	public final fun getRootArea ()Lorg/modelix/model/area/IAreaReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/AreaWithMounts$NodeWrapper : org/modelix/model/api/INode, org/modelix/model/api/INodeWrapper {
+	public fun <init> (Lorg/modelix/model/area/AreaWithMounts;Lorg/modelix/model/api/INode;)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun getWrappedNode ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+}
+
+public final class org/modelix/model/area/ChildrenChangeEvent : org/modelix/model/area/RoleChangeEvent {
+	public fun <init> (Lorg/modelix/model/api/INode;Ljava/lang/String;)V
+	public fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/ChildrenChangeEvent;
+	public synthetic fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/NodeChangeEvent;
+}
+
+public final class org/modelix/model/area/CompositeArea : org/modelix/model/area/IArea {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lorg/modelix/model/area/IArea;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun flatten ()Ljava/util/List;
+	public final fun getAreas ()Ljava/util/List;
+	public fun getReference ()Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public synthetic fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public final fun unwrapNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+	public final fun unwrapNodeRef (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INodeReference;
+	public final fun wrapNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/CompositeArea$NodeWrapper;
+}
+
+public final class org/modelix/model/area/CompositeArea$AreaReference : org/modelix/model/area/IAreaReference {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/area/CompositeArea$AreaReference;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAreaRefs ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/CompositeArea$ListenerWrapper : org/modelix/model/area/AreaListenerWrapper {
+	public fun <init> (Lorg/modelix/model/area/CompositeArea;Lorg/modelix/model/area/IAreaListener;)V
+	public fun areaChanged (Lorg/modelix/model/area/IAreaChangeList;)V
+	public final fun translateEvent (Lorg/modelix/model/area/IAreaChangeEvent;)Lorg/modelix/model/area/IAreaChangeEvent;
+}
+
+public final class org/modelix/model/area/CompositeArea$NodeWrapper : org/modelix/model/api/INode, org/modelix/model/api/INodeWrapper {
+	public fun <init> (Lorg/modelix/model/area/CompositeArea;Lorg/modelix/model/api/INode;)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/CompositeArea;
+	public synthetic fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun getWrappedNode ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/CompositeArea$NodeWrapperReference : org/modelix/model/api/INodeReference {
+	public fun <init> (Lorg/modelix/model/api/INodeReference;Lorg/modelix/model/area/CompositeArea$AreaReference;)V
+	public final fun component1 ()Lorg/modelix/model/api/INodeReference;
+	public final fun component2 ()Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public final fun copy (Lorg/modelix/model/api/INodeReference;Lorg/modelix/model/area/CompositeArea$AreaReference;)Lorg/modelix/model/area/CompositeArea$NodeWrapperReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/area/CompositeArea$NodeWrapperReference;Lorg/modelix/model/api/INodeReference;Lorg/modelix/model/area/CompositeArea$AreaReference;ILjava/lang/Object;)Lorg/modelix/model/area/CompositeArea$NodeWrapperReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAreaRef ()Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public final fun getNodeRef ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/CompositeArea$Root : org/modelix/model/api/INode {
+	public fun <init> (Lorg/modelix/model/area/CompositeArea;)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/CompositeArea;
+	public synthetic fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+}
+
+public final class org/modelix/model/area/CompositeArea$RootNodeReference : org/modelix/model/api/INodeReference {
+	public fun <init> (Lorg/modelix/model/area/CompositeArea$AreaReference;)V
+	public final fun component1 ()Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public final fun copy (Lorg/modelix/model/area/CompositeArea$AreaReference;)Lorg/modelix/model/area/CompositeArea$RootNodeReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/area/CompositeArea$RootNodeReference;Lorg/modelix/model/area/CompositeArea$AreaReference;ILjava/lang/Object;)Lorg/modelix/model/area/CompositeArea$RootNodeReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAreaRef ()Lorg/modelix/model/area/CompositeArea$AreaReference;
+	public fun hashCode ()I
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/ContextArea {
+	public static final field INSTANCE Lorg/modelix/model/area/ContextArea;
+	public final fun getArea ()Lorg/modelix/model/area/IArea;
+	public final fun offer (Lorg/modelix/model/area/IArea;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun withAdditionalContext (Lorg/modelix/model/area/IArea;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/model/area/IArea : org/modelix/model/api/INodeResolutionScope {
+	public abstract fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public abstract fun canRead ()Z
+	public abstract fun canWrite ()Z
+	public abstract fun collectAreas ()Ljava/util/List;
+	public abstract fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getLockOrderingPriority ()J
+	public abstract fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public abstract fun getRoot ()Lorg/modelix/model/api/INode;
+	public abstract fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public abstract fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public abstract fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public abstract fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public abstract fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public abstract fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/area/IArea$DefaultImpls {
+	public static fun getLockOrderingPriority (Lorg/modelix/model/area/IArea;)J
+	public static fun runWith (Lorg/modelix/model/area/IArea;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static fun runWithAdditionalScope (Lorg/modelix/model/area/IArea;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static fun runWithAdditionalScopeInCoroutine (Lorg/modelix/model/area/IArea;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun runWithInCoroutine (Lorg/modelix/model/area/IArea;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/model/area/IAreaChangeEvent {
+}
+
+public abstract interface class org/modelix/model/area/IAreaChangeList {
+	public abstract fun visitChanges (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class org/modelix/model/area/IAreaListener {
+	public abstract fun areaChanged (Lorg/modelix/model/area/IAreaChangeList;)V
+}
+
+public abstract interface class org/modelix/model/area/IAreaReference {
+}
+
+public abstract class org/modelix/model/area/NodeChangeEvent : org/modelix/model/area/IAreaChangeEvent {
+	public fun <init> (Lorg/modelix/model/api/INode;)V
+	public final fun getNode ()Lorg/modelix/model/api/INode;
+	public abstract fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/NodeChangeEvent;
+}
+
+public final class org/modelix/model/area/PArea : org/modelix/model/area/IArea {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun containsNode (J)Z
+	public final fun copy (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/area/PArea;
+	public static synthetic fun copy$default (Lorg/modelix/model/area/PArea;Lorg/modelix/model/api/IBranch;ILjava/lang/Object;)Lorg/modelix/model/area/PArea;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public fun getReference ()Lorg/modelix/model/area/PArea$AreaReference;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/PArea$AreaReference : org/modelix/model/area/IAreaReference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/area/PArea$AreaReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/area/PArea$AreaReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/area/PArea$AreaReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranchId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/area/PAreaKt {
+	public static final fun getArea (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/area/PArea;
+}
+
+public final class org/modelix/model/area/PropertyChangeEvent : org/modelix/model/area/RoleChangeEvent {
+	public fun <init> (Lorg/modelix/model/api/INode;Ljava/lang/String;)V
+	public synthetic fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/NodeChangeEvent;
+	public fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/PropertyChangeEvent;
+}
+
+public final class org/modelix/model/area/ReferenceChangeEvent : org/modelix/model/area/RoleChangeEvent {
+	public fun <init> (Lorg/modelix/model/api/INode;Ljava/lang/String;)V
+	public synthetic fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/NodeChangeEvent;
+	public fun withNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/area/ReferenceChangeEvent;
+}
+
+public abstract class org/modelix/model/area/RoleChangeEvent : org/modelix/model/area/NodeChangeEvent {
+	public fun <init> (Lorg/modelix/model/api/INode;Ljava/lang/String;)V
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/ChildLinkData : org/modelix/model/data/IConceptFeatureData, org/modelix/model/data/IDeprecatable {
+	public static final field Companion Lorg/modelix/model/data/ChildLinkData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;)Lorg/modelix/model/data/ChildLinkData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/ChildLinkData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/data/ChildLinkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getMultiple ()Z
+	public fun getName ()Ljava/lang/String;
+	public final fun getOptional ()Z
+	public final fun getType ()Ljava/lang/String;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/ChildLinkData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/ChildLinkData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/ChildLinkData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/ChildLinkData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ChildLinkData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ConceptData : org/modelix/model/data/IDeprecatable {
+	public static final field ALIAS_KEY Ljava/lang/String;
+	public static final field Companion Lorg/modelix/model/data/ConceptData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)Lorg/modelix/model/data/ConceptData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/ConceptData;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lorg/modelix/model/data/ConceptData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbstract ()Z
+	public final fun getChildren ()Ljava/util/List;
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getExtends ()Ljava/util/List;
+	public final fun getMetaProperties ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/List;
+	public final fun getReferences ()Ljava/util/List;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/ConceptData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/ConceptData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/ConceptData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/ConceptData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ConceptData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/EnumData : org/modelix/model/data/IDeprecatable {
+	public static final field Companion Lorg/modelix/model/data/EnumData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/String;)Lorg/modelix/model/data/EnumData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/EnumData;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/data/EnumData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultIndex ()I
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/EnumData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/EnumData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/EnumData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/EnumData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/EnumData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/EnumMemberData {
+	public static final field Companion Lorg/modelix/model/data/EnumMemberData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/data/EnumMemberData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/EnumMemberData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/data/EnumMemberData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPresentation ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/EnumMemberData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/EnumMemberData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/EnumMemberData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/EnumMemberData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/EnumMemberData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/EnumPropertyType : org/modelix/model/data/PropertyType {
+	public static final field Companion Lorg/modelix/model/data/EnumPropertyType$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/data/EnumPropertyType;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/EnumPropertyType;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/data/EnumPropertyType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnumName ()Ljava/lang/String;
+	public final fun getPckg ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/EnumPropertyType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/EnumPropertyType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/EnumPropertyType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/EnumPropertyType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/EnumPropertyType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class org/modelix/model/data/IConceptFeatureData {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getUid ()Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/data/IDeprecatable {
+	public abstract fun getDeprecationMessage ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/LanguageData {
+	public static final field Companion Lorg/modelix/model/data/LanguageData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/data/LanguageData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/LanguageData;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/data/LanguageData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConcepts ()Ljava/util/List;
+	public final fun getEnums ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toCompactJson ()Ljava/lang/String;
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/LanguageData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/LanguageData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/LanguageData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/LanguageData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/LanguageData$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lorg/modelix/model/data/LanguageData;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ModelData {
+	public static final field Companion Lorg/modelix/model/data/ModelData$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/data/NodeData;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/modelix/model/data/NodeData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/modelix/model/data/NodeData;
+	public final fun copy (Ljava/lang/String;Lorg/modelix/model/data/NodeData;)Lorg/modelix/model/data/ModelData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/ModelData;Ljava/lang/String;Lorg/modelix/model/data/NodeData;ILjava/lang/Object;)Lorg/modelix/model/data/ModelData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRoot ()Lorg/modelix/model/data/NodeData;
+	public fun hashCode ()I
+	public final fun load (Lorg/modelix/model/api/IBranch;)V
+	public final fun toCompactJson ()Ljava/lang/String;
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/ModelData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/ModelData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/ModelData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/ModelData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ModelData$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lorg/modelix/model/data/ModelData;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ModelDataKt {
+	public static final fun asData (Lorg/modelix/model/api/INode;)Lorg/modelix/model/data/NodeData;
+	public static final fun associateWithNotNull (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/util/Map;
+	public static final fun nodeUID (Lorg/modelix/model/data/ModelData;Lorg/modelix/model/data/NodeData;)Ljava/lang/String;
+	public static final fun uid (Lorg/modelix/model/data/NodeData;Lorg/modelix/model/data/ModelData;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/NodeData {
+	public static final field Companion Lorg/modelix/model/data/NodeData$Companion;
+	public static final field ID_PROPERTY_KEY Ljava/lang/String;
+	public static final field idPropertyKey Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)Lorg/modelix/model/data/NodeData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/NodeData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lorg/modelix/model/data/NodeData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getConcept ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getReferences ()Ljava/util/Map;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/NodeData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/NodeData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/NodeData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/NodeData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/NodeData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/Primitive : java/lang/Enum {
+	public static final field BOOLEAN Lorg/modelix/model/data/Primitive;
+	public static final field INT Lorg/modelix/model/data/Primitive;
+	public static final field STRING Lorg/modelix/model/data/Primitive;
+	public static fun valueOf (Ljava/lang/String;)Lorg/modelix/model/data/Primitive;
+	public static fun values ()[Lorg/modelix/model/data/Primitive;
+}
+
+public final class org/modelix/model/data/PrimitivePropertyType : org/modelix/model/data/PropertyType {
+	public static final field Companion Lorg/modelix/model/data/PrimitivePropertyType$Companion;
+	public fun <init> (Lorg/modelix/model/data/Primitive;)V
+	public final fun component1 ()Lorg/modelix/model/data/Primitive;
+	public final fun copy (Lorg/modelix/model/data/Primitive;)Lorg/modelix/model/data/PrimitivePropertyType;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/PrimitivePropertyType;Lorg/modelix/model/data/Primitive;ILjava/lang/Object;)Lorg/modelix/model/data/PrimitivePropertyType;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrimitive ()Lorg/modelix/model/data/Primitive;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/PrimitivePropertyType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/PrimitivePropertyType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/PrimitivePropertyType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/PrimitivePropertyType;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/PrimitivePropertyType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/PropertyData : org/modelix/model/data/IConceptFeatureData, org/modelix/model/data/IDeprecatable {
+	public static final field Companion Lorg/modelix/model/data/PropertyData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/data/PropertyType;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/data/PropertyType;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/modelix/model/data/PropertyType;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/data/PropertyType;ZLjava/lang/String;)Lorg/modelix/model/data/PropertyData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/PropertyData;Ljava/lang/String;Ljava/lang/String;Lorg/modelix/model/data/PropertyType;ZLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/data/PropertyData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getOptional ()Z
+	public final fun getType ()Lorg/modelix/model/data/PropertyType;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/PropertyData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/PropertyData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/PropertyData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/PropertyData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/PropertyData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class org/modelix/model/data/PropertyType {
+	public static final field Companion Lorg/modelix/model/data/PropertyType$Companion;
+}
+
+public final class org/modelix/model/data/PropertyType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/PropertyTypeSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/PropertyType;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/PropertyType;)V
+}
+
+public final class org/modelix/model/data/ReferenceLinkData : org/modelix/model/data/IConceptFeatureData, org/modelix/model/data/IDeprecatable {
+	public static final field Companion Lorg/modelix/model/data/ReferenceLinkData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lorg/modelix/model/data/ReferenceLinkData;
+	public static synthetic fun copy$default (Lorg/modelix/model/data/ReferenceLinkData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/data/ReferenceLinkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDeprecationMessage ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getOptional ()Z
+	public final fun getType ()Ljava/lang/String;
+	public fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/data/ReferenceLinkData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/data/ReferenceLinkData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/data/ReferenceLinkData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/data/ReferenceLinkData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/data/ReferenceLinkData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/test/RandomModelChangeGenerator {
+	public fun <init> (Lorg/modelix/model/api/INode;Lkotlin/random/Random;)V
+	public final fun addOperationOnly ()Lorg/modelix/model/test/RandomModelChangeGenerator;
+	public final fun applyRandomChange ()V
+	public final fun getAddNewOp ()Lkotlin/jvm/functions/Function0;
+	public final fun getChildRoles ()Ljava/util/List;
+	public final fun getDeleteOp ()Lkotlin/jvm/functions/Function0;
+	public final fun getMoveOp ()Lkotlin/jvm/functions/Function0;
+	public final fun getOperations ()Ljava/util/List;
+	public final fun getPropertyRoles ()Ljava/util/List;
+	public final fun getReferenceRoles ()Ljava/util/List;
+	public final fun getRootNode ()Lorg/modelix/model/api/INode;
+	public final fun getSetPropertyOp ()Lkotlin/jvm/functions/Function0;
+	public final fun getSetReferenceOp ()Lkotlin/jvm/functions/Function0;
+	public final fun growingOperationsOnly ()Lorg/modelix/model/test/RandomModelChangeGenerator;
+	public final fun setOperations (Ljava/util/List;)V
+	public final fun withoutMove ()Lorg/modelix/model/test/RandomModelChangeGenerator;
+}
+

--- a/model-client/api/model-client.api
+++ b/model-client/api/model-client.api
@@ -1,0 +1,1067 @@
+public final class org/modelix/model/AllChildrenDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;J)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun copy (Lorg/modelix/model/api/IBranch;J)Lorg/modelix/model/AllChildrenDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/AllChildrenDependency;Lorg/modelix/model/api/IBranch;JILjava/lang/Object;)Lorg/modelix/model/AllChildrenDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/UnclassifiedNodeDependency;
+	public final fun getNodeId ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/AllPropertiesDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;J)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun copy (Lorg/modelix/model/api/IBranch;J)Lorg/modelix/model/AllPropertiesDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/AllPropertiesDependency;Lorg/modelix/model/api/IBranch;JILjava/lang/Object;)Lorg/modelix/model/AllPropertiesDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/UnclassifiedNodeDependency;
+	public final fun getNodeId ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/AllReferencesDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;J)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun copy (Lorg/modelix/model/api/IBranch;J)Lorg/modelix/model/AllReferencesDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/AllReferencesDependency;Lorg/modelix/model/api/IBranch;JILjava/lang/Object;)Lorg/modelix/model/AllReferencesDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/UnclassifiedNodeDependency;
+	public final fun getNodeId ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/AutoReadTransaction : org/modelix/model/AutoTransaction, org/modelix/model/api/IReadTransaction {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+}
+
+public class org/modelix/model/AutoTransaction : org/modelix/model/api/ITransaction {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun containsNode (J)Z
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public final class org/modelix/model/AutoTransactionsBranch : org/modelix/model/api/IBranch, org/modelix/model/api/IBranchWrapper {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeReadT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWriteT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun getId ()Ljava/lang/String;
+	public fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runReadT (Lkotlin/jvm/functions/Function1;)V
+	public fun runWrite (Lkotlin/jvm/functions/Function0;)V
+	public fun runWriteT (Lkotlin/jvm/functions/Function1;)V
+	public fun unwrapBranch ()Lorg/modelix/model/api/IBranch;
+}
+
+public final class org/modelix/model/AutoTransactionsBranchKt {
+	public static final fun withAutoTransactions (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/AutoTransactionsBranch;
+}
+
+public final class org/modelix/model/AutoWriteTransaction : org/modelix/model/AutoTransaction, org/modelix/model/api/IWriteTransaction {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public fun deleteNode (J)V
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun moveChild (JLjava/lang/String;IJ)V
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setTree (Lorg/modelix/model/api/ITree;)V
+}
+
+public final class org/modelix/model/BranchDependency : org/modelix/incremental/IStateVariableReference {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun copy (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/BranchDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/BranchDependency;Lorg/modelix/model/api/IBranch;ILjava/lang/Object;)Lorg/modelix/model/BranchDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun hashCode ()I
+	public synthetic fun read ()Ljava/lang/Object;
+	public fun read ()Lorg/modelix/model/api/IBranch;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/ChildrenDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;JLjava/lang/String;)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lorg/modelix/model/api/IBranch;JLjava/lang/String;)Lorg/modelix/model/ChildrenDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/ChildrenDependency;Lorg/modelix/model/api/IBranch;JLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/ChildrenDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/AllChildrenDependency;
+	public final fun getNodeId ()J
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/ContainmentDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;J)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun copy (Lorg/modelix/model/api/IBranch;J)Lorg/modelix/model/ContainmentDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/ContainmentDependency;Lorg/modelix/model/api/IBranch;JILjava/lang/Object;)Lorg/modelix/model/ContainmentDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/UnclassifiedNodeDependency;
+	public final fun getNodeId ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class org/modelix/model/DependencyBase : org/modelix/incremental/IStateVariableReference {
+	public fun <init> ()V
+	public synthetic fun read ()Ljava/lang/Object;
+	public fun read ()V
+}
+
+public abstract interface class org/modelix/model/IKeyValueStoreWrapper : org/modelix/model/IKeyValueStore {
+	public static final field Companion Lorg/modelix/model/IKeyValueStoreWrapper$Companion;
+	public abstract fun getWrapped ()Lorg/modelix/model/IKeyValueStore;
+}
+
+public final class org/modelix/model/IKeyValueStoreWrapper$Companion {
+	public final fun getAllStores (Lorg/modelix/model/IKeyValueStore;)Ljava/util/List;
+}
+
+public final class org/modelix/model/IKeyValueStoreWrapper$DefaultImpls {
+	public static fun getA (Lorg/modelix/model/IKeyValueStoreWrapper;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun newBulkQuery (Lorg/modelix/model/IKeyValueStoreWrapper;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+}
+
+public final class org/modelix/model/IncrementalBranch : org/modelix/model/api/IBranch, org/modelix/model/api/IBranchWrapper {
+	public static final field Companion Lorg/modelix/model/IncrementalBranch$Companion;
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public final fun accessed (Lorg/modelix/incremental/IStateVariableReference;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeReadT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWriteT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getId ()Ljava/lang/String;
+	public fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public final fun modified (Lorg/modelix/incremental/IStateVariableReference;)V
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runReadT (Lkotlin/jvm/functions/Function1;)V
+	public fun runWrite (Lkotlin/jvm/functions/Function0;)V
+	public fun runWriteT (Lkotlin/jvm/functions/Function1;)V
+	public fun unwrapBranch ()Lorg/modelix/model/api/IBranch;
+}
+
+public final class org/modelix/model/IncrementalBranch$Companion {
+}
+
+public final class org/modelix/model/IncrementalBranch$IncrementalReadTransaction : org/modelix/model/IncrementalBranch$IncrementalTransaction, org/modelix/model/api/IReadTransaction {
+	public fun <init> (Lorg/modelix/model/IncrementalBranch;Lorg/modelix/model/api/IReadTransaction;)V
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+}
+
+public abstract class org/modelix/model/IncrementalBranch$IncrementalTransaction : org/modelix/model/api/ITransaction {
+	public fun <init> (Lorg/modelix/model/IncrementalBranch;Lorg/modelix/model/api/ITransaction;)V
+	public fun containsNode (J)Z
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public final fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public final class org/modelix/model/IncrementalBranch$IncrementalTree : org/modelix/model/api/ITree {
+	public fun <init> (Lorg/modelix/model/IncrementalBranch;Lorg/modelix/model/api/ITree;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public fun containsNode (J)Z
+	public fun deleteNode (J)Lorg/modelix/model/api/ITree;
+	public fun deleteNodes ([J)Lorg/modelix/model/api/ITree;
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getChildRoles (J)Ljava/lang/Iterable;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getId ()Ljava/lang/String;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public final fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun moveChild (JLjava/lang/String;IJ)Lorg/modelix/model/api/ITree;
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)Lorg/modelix/model/api/ITree;
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/ITree;
+	public fun usesRoleIds ()Z
+	public fun visitChanges (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITreeChangeVisitor;)V
+}
+
+public final class org/modelix/model/IncrementalBranch$IncrementalWriteTransaction : org/modelix/model/IncrementalBranch$IncrementalTransaction, org/modelix/model/api/IWriteTransaction {
+	public fun <init> (Lorg/modelix/model/IncrementalBranch;Lorg/modelix/model/api/IWriteTransaction;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public fun deleteNode (J)V
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun moveChild (JLjava/lang/String;IJ)V
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setTree (Lorg/modelix/model/api/ITree;)V
+}
+
+public final class org/modelix/model/IncrementalBranchKt {
+	public static final fun withIncrementalComputationSupport (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/IncrementalBranch;
+}
+
+public final class org/modelix/model/KeyValueStoreCache : org/modelix/model/IKeyValueStoreWrapper {
+	public static final field Companion Lorg/modelix/model/KeyValueStoreCache$Companion;
+	public fun <init> (Lorg/modelix/model/IKeyValueStore;)V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public fun getPendingSize ()I
+	public fun getWrapped ()Lorg/modelix/model/IKeyValueStore;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public fun putAll (Ljava/util/Map;)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public final class org/modelix/model/KeyValueStoreCache$Companion {
+}
+
+public final class org/modelix/model/ModelFacade {
+	public static final field INSTANCE Lorg/modelix/model/ModelFacade;
+	public final fun createBranchReference (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;)Lorg/modelix/model/lazy/BranchReference;
+	public static synthetic fun createBranchReference$default (Lorg/modelix/model/ModelFacade;Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/lazy/BranchReference;
+	public final fun createRepositoryId (Ljava/lang/String;)Lorg/modelix/model/lazy/RepositoryId;
+	public final fun getBranch (Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/IBranch;
+	public final fun getRootNode (Lorg/modelix/model/api/IBranch;)Lorg/modelix/model/api/INode;
+	public final fun loadCurrentModel (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/BranchReference;)Lorg/modelix/model/api/ITree;
+	public final fun loadCurrentVersion (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/BranchReference;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun mergeUpdate (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/CLVersion;
+	public static synthetic fun mergeUpdate$default (Lorg/modelix/model/ModelFacade;Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun newLocalTree ()Lorg/modelix/model/api/ITree;
+	public final fun readNode (Lorg/modelix/model/api/INode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun toLocalBranch (Lorg/modelix/model/api/ITree;)Lorg/modelix/model/api/IBranch;
+	public final fun toNode (Lorg/modelix/model/api/ITree;)Lorg/modelix/model/api/INode;
+	public final fun writeNode (Lorg/modelix/model/api/INode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/ModelIndex {
+	public static final field Companion Lorg/modelix/model/ModelIndex$Companion;
+	public synthetic fun <init> (Lorg/modelix/model/api/ITree;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun find (Ljava/lang/String;)Ljava/util/Set;
+	public final fun getPropertyRole ()Ljava/lang/String;
+	public final fun getTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/ModelIndex$Companion {
+	public final fun fromTree (Lorg/modelix/model/api/ITree;Ljava/lang/String;)Lorg/modelix/model/ModelIndex;
+	public final fun get (Lorg/modelix/model/api/ITransaction;Ljava/lang/String;)Lorg/modelix/model/ModelIndex;
+	public final fun incremental (Lorg/modelix/model/ModelIndex;Lorg/modelix/model/api/ITree;)Lorg/modelix/model/ModelIndex;
+}
+
+public final class org/modelix/model/ModelMigrations {
+	public static final field INSTANCE Lorg/modelix/model/ModelMigrations;
+	public final fun useCanonicalReferences (Lorg/modelix/model/api/IBranch;)V
+}
+
+public final class org/modelix/model/PropertyDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;JLjava/lang/String;)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lorg/modelix/model/api/IBranch;JLjava/lang/String;)Lorg/modelix/model/PropertyDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/PropertyDependency;Lorg/modelix/model/api/IBranch;JLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/PropertyDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/AllPropertiesDependency;
+	public final fun getNodeId ()J
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/ReferenceDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;JLjava/lang/String;)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lorg/modelix/model/api/IBranch;JLjava/lang/String;)Lorg/modelix/model/ReferenceDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/ReferenceDependency;Lorg/modelix/model/api/IBranch;JLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/ReferenceDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public synthetic fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public fun getGroup ()Lorg/modelix/model/AllReferencesDependency;
+	public final fun getNodeId ()J
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/SubtreeChanges {
+	public static final field Companion Lorg/modelix/model/SubtreeChanges$Companion;
+	public fun <init> (I)V
+	public final fun getAffectedSubtrees (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITree;)Ljava/util/Set;
+	public final fun getCacheSize ()I
+}
+
+public final class org/modelix/model/SubtreeChanges$Companion {
+	public final fun getINSTANCE ()Lorg/modelix/model/SubtreeChanges;
+}
+
+public final class org/modelix/model/UnclassifiedNodeDependency : org/modelix/model/DependencyBase {
+	public fun <init> (Lorg/modelix/model/api/IBranch;J)V
+	public final fun component1 ()Lorg/modelix/model/api/IBranch;
+	public final fun component2 ()J
+	public final fun copy (Lorg/modelix/model/api/IBranch;J)Lorg/modelix/model/UnclassifiedNodeDependency;
+	public static synthetic fun copy$default (Lorg/modelix/model/UnclassifiedNodeDependency;Lorg/modelix/model/api/IBranch;JILjava/lang/Object;)Lorg/modelix/model/UnclassifiedNodeDependency;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getGroup ()Lorg/modelix/incremental/IStateVariableGroup;
+	public final fun getNodeId ()J
+	public fun hashCode ()I
+	public synthetic fun read ()Ljava/lang/Object;
+	public fun read ()V
+	public fun toString ()Ljava/lang/String;
+}
+
+public class org/modelix/model/client/ActiveBranch : org/modelix/model/client/IIndirectBranch {
+	public static final field Companion Lorg/modelix/model/client/ActiveBranch$Companion;
+	public static final field DEFAULT_BRANCH_NAME Ljava/lang/String;
+	public fun <init> (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	protected fun createReplicatedRepository (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lorg/modelix/model/client/ReplicatedRepository;
+	public fun dispose ()V
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public final fun getBranchName ()Ljava/lang/String;
+	public final fun getClient ()Lorg/modelix/model/client/IModelClient;
+	public final fun getRepository ()Lorg/modelix/model/lazy/RepositoryId;
+	public final fun getVersion ()Lorg/modelix/model/lazy/CLVersion;
+	protected final fun notifyListeners (Lorg/modelix/model/api/ITree;)V
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public final fun switchBranch (Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/client/ActiveBranch$Companion {
+}
+
+public final class org/modelix/model/client/AsyncStore : org/modelix/model/IKeyValueStoreWrapper {
+	public static final field Companion Lorg/modelix/model/client/AsyncStore$Companion;
+	public fun <init> (Lorg/modelix/model/IKeyValueStore;)V
+	public final fun dispose ()V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public fun getPendingSize ()I
+	public fun getWrapped ()Lorg/modelix/model/IKeyValueStore;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public fun putAll (Ljava/util/Map;)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public final class org/modelix/model/client/AsyncStore$Companion {
+}
+
+public abstract interface class org/modelix/model/client/ConnectionListener {
+	public abstract fun receivedForbiddenResponse ()V
+	public abstract fun receivedSuccessfulResponse ()V
+}
+
+public final class org/modelix/model/client/GarbageFilteringStore : org/modelix/model/IKeyValueStoreWrapper {
+	public fun <init> (Lorg/modelix/model/IKeyValueStore;)V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public fun getPendingSize ()I
+	public fun getWrapped ()Lorg/modelix/model/IKeyValueStore;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public fun putAll (Ljava/util/Map;)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public abstract interface class org/modelix/model/client/IIndirectBranch {
+	public abstract fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public abstract fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public abstract fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+}
+
+public abstract interface class org/modelix/model/client/IModelClient : org/modelix/model/IKeyValueStore {
+	public abstract fun getAsyncStore ()Lorg/modelix/model/IKeyValueStore;
+	public abstract fun getClientId ()I
+	public abstract fun getIdGenerator ()Lorg/modelix/model/api/IIdGenerator;
+	public abstract fun getStoreCache ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+}
+
+public final class org/modelix/model/client/IModelClient$DefaultImpls {
+	public static fun getA (Lorg/modelix/model/client/IModelClient;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun newBulkQuery (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+}
+
+public class org/modelix/model/client/ReplicatedRepository {
+	public static final field Companion Lorg/modelix/model/client/ReplicatedRepository$Companion;
+	public fun <init> (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/BranchReference;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun checkDisposed ()V
+	protected final fun createAndMergeLocalVersion ()Lorg/modelix/model/lazy/CLVersion;
+	public final fun createVersion (Lorg/modelix/model/lazy/CLTree;[Lorg/modelix/model/operations/IOperation;Lorg/modelix/model/lazy/CLVersion;)Lorg/modelix/model/lazy/CLVersion;
+	protected final fun deleteDetachedNodes ()V
+	public fun dispose ()V
+	public final fun endEdit ()Lorg/modelix/model/lazy/CLVersion;
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public final fun getLocalVersion ()Lorg/modelix/model/lazy/CLVersion;
+	public final fun isDisposed ()Z
+	public final fun startEdit ()V
+	protected final fun writeLocalVersion (Lorg/modelix/model/lazy/CLVersion;)V
+	protected final fun writeRemoteVersion (Lorg/modelix/model/lazy/CLVersion;)V
+}
+
+public final class org/modelix/model/client/ReplicatedRepository$Companion {
+}
+
+public final class org/modelix/model/client/RestWebModelClient : org/modelix/model/client/IModelClient {
+	public static final field Companion Lorg/modelix/model/client/RestWebModelClient$Companion;
+	public static final field MODEL_URI_VAR_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Ljava/util/List;Lio/ktor/client/HttpClient;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Ljava/util/List;Lio/ktor/client/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addForbiddenListener (Lorg/modelix/model/client/ConnectionListener;)V
+	public final fun addStatusListener (Lkotlin/jvm/functions/Function2;)V
+	public final fun dispose ()V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getA (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public final fun getAllA (Ljava/lang/Iterable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAsyncStore ()Lorg/modelix/model/IKeyValueStore;
+	public final fun getBaseUrl ()Ljava/lang/String;
+	public fun getClientId ()I
+	public final fun getConnectionStatus ()Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getEmailA (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getIdGenerator ()Lorg/modelix/model/api/IIdGenerator;
+	public fun getPendingSize ()I
+	public fun getStoreCache ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun putA (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun putAll (Ljava/util/Map;)V
+	public final fun putAllA (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun reconnect ()V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public final fun removeStatusListener (Lkotlin/jvm/functions/Function2;)V
+	public final fun setBaseUrl (Ljava/lang/String;)V
+	public final fun sortEntriesByDependency (Ljava/util/Map;)Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/client/RestWebModelClient$Companion {
+	public final fun getDefaultUrl ()Ljava/lang/String;
+	public final fun getModelUrlFromEnv ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/client/RestWebModelClient$ConnectionStatus : java/lang/Enum {
+	public static final field CONNECTED Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+	public static final field DISCONNECTED Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+	public static final field NEW Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+	public static final field WAITING_FOR_TOKEN Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+	public static fun valueOf (Ljava/lang/String;)Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+	public static fun values ()[Lorg/modelix/model/client/RestWebModelClient$ConnectionStatus;
+}
+
+public final class org/modelix/model/client/RestWebModelClient$PollingListener {
+	public fun <init> (Lorg/modelix/model/client/RestWebModelClient;Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public final fun dispose ()V
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getKeyListener ()Lorg/modelix/model/IKeyListener;
+	public final fun getNextDelay-UwyO8pc ()J
+	public final fun setNextDelay-LRDsOJo (J)V
+	public final fun start ()V
+}
+
+public final class org/modelix/model/client/RestWebModelClientKt {
+	public static final fun getForbidden (Lio/ktor/client/statement/HttpResponse;)Z
+	public static final fun getSuccessful (Lio/ktor/client/statement/HttpResponse;)Z
+	public static final fun getUnsuccessful (Lio/ktor/client/statement/HttpResponse;)Z
+}
+
+public final class org/modelix/model/client/SharedExecutors {
+	public static final field FIXED Ljava/util/concurrent/ExecutorService;
+	public static final field INSTANCE Lorg/modelix/model/client/SharedExecutors;
+	public static final fun fixDelay (JJLjava/lang/Runnable;)Ljava/util/concurrent/ScheduledFuture;
+	public static final fun fixDelay (JLjava/lang/Runnable;)Ljava/util/concurrent/ScheduledFuture;
+	public final fun getSCHEDULED ()Ljava/util/concurrent/ScheduledExecutorService;
+	public final fun shutdownAll ()V
+}
+
+public final class org/modelix/model/client/SimpleIndirectBranch : org/modelix/model/client/IIndirectBranch {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+}
+
+public abstract class org/modelix/model/client/VersionChangeDetector {
+	public static final field Companion Lorg/modelix/model/client/VersionChangeDetector$Companion;
+	public fun <init> (Lorg/modelix/model/IKeyValueStore;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun dispose ()V
+	public final fun getLastVersionHash ()Ljava/lang/String;
+	protected abstract fun processVersionChange (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/client/VersionChangeDetector$Companion {
+}
+
+public abstract interface class org/modelix/model/client2/IModelClientV2 {
+	public abstract fun deleteRepository (Lorg/modelix/model/lazy/RepositoryId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getClientId ()I
+	public abstract fun getIdGenerator ()Lorg/modelix/model/api/IIdGenerator;
+	public abstract fun getUserId ()Ljava/lang/String;
+	public abstract fun initRepository (Lorg/modelix/model/lazy/RepositoryId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listBranches (Lorg/modelix/model/lazy/RepositoryId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listRepositories (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun loadVersion (Ljava/lang/String;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun loadVersion (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun poll (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pollHash (Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pollHash (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pull (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pullHash (Lorg/modelix/model/lazy/BranchReference;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pullIfExists (Lorg/modelix/model/lazy/BranchReference;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun push (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun query (Lorg/modelix/model/lazy/BranchReference;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun query (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/client2/ModelClientV2 : org/modelix/model/client2/Closable, org/modelix/model/client2/IModelClientV2 {
+	public static final field Companion Lorg/modelix/model/client2/ModelClientV2$Companion;
+	public fun <init> (Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)V
+	public fun close ()V
+	public fun deleteRepository (Lorg/modelix/model/lazy/RepositoryId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getBaseUrl ()Ljava/lang/String;
+	public fun getClientId ()I
+	public fun getIdGenerator ()Lorg/modelix/model/api/IIdGenerator;
+	public final fun getStore ()Lorg/modelix/model/lazy/ObjectStoreCache;
+	public fun getUserId ()Ljava/lang/String;
+	public final fun init (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun initRepository (Lorg/modelix/model/lazy/RepositoryId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun listBranches (Lorg/modelix/model/lazy/RepositoryId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun listRepositories (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun loadVersion (Ljava/lang/String;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun loadVersion (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun poll (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun pollHash (Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun pollHash (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun pull (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun pullHash (Lorg/modelix/model/lazy/BranchReference;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun pullIfExists (Lorg/modelix/model/lazy/BranchReference;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun push (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/IVersion;Lorg/modelix/model/IVersion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun query (Lorg/modelix/model/lazy/BranchReference;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun query (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setClientProvideUserId (Ljava/lang/String;)V
+	public final fun updateUserId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/client2/ModelClientV2$Companion {
+	public final fun builder ()Lorg/modelix/model/client2/ModelClientV2Builder;
+}
+
+public abstract class org/modelix/model/client2/ModelClientV2Builder {
+	public static final field Companion Lorg/modelix/model/client2/ModelClientV2Builder$Companion;
+	public fun <init> ()V
+	public final fun authToken (Lkotlin/jvm/functions/Function0;)Lorg/modelix/model/client2/ModelClientV2Builder;
+	public final fun build ()Lorg/modelix/model/client2/ModelClientV2;
+	public final fun client (Lio/ktor/client/HttpClient;)Lorg/modelix/model/client2/ModelClientV2Builder;
+	protected fun configureHttpClient (Lio/ktor/client/HttpClientConfig;)V
+	public final fun connectTimeout-LRDsOJo (J)Lorg/modelix/model/client2/ModelClientV2Builder;
+	protected abstract fun createHttpClient ()Lio/ktor/client/HttpClient;
+	protected final fun getAuthTokenProvider ()Lkotlin/jvm/functions/Function0;
+	protected final fun getBaseUrl ()Ljava/lang/String;
+	protected final fun getConnectTimeout-UwyO8pc ()J
+	protected final fun getHttpClient ()Lio/ktor/client/HttpClient;
+	protected final fun getRequestTimeout-UwyO8pc ()J
+	protected final fun getUserId ()Ljava/lang/String;
+	public final fun requestTimeout-LRDsOJo (J)Lorg/modelix/model/client2/ModelClientV2Builder;
+	protected final fun setAuthTokenProvider (Lkotlin/jvm/functions/Function0;)V
+	protected final fun setBaseUrl (Ljava/lang/String;)V
+	protected final fun setConnectTimeout-LRDsOJo (J)V
+	protected final fun setHttpClient (Lio/ktor/client/HttpClient;)V
+	protected final fun setRequestTimeout-LRDsOJo (J)V
+	protected final fun setUserId (Ljava/lang/String;)V
+	public final fun url (Ljava/lang/String;)Lorg/modelix/model/client2/ModelClientV2Builder;
+	public final fun userId (Ljava/lang/String;)Lorg/modelix/model/client2/ModelClientV2Builder;
+}
+
+public final class org/modelix/model/client2/ModelClientV2Builder$Companion {
+}
+
+public final class org/modelix/model/client2/ModelClientV2Kt {
+	public static final fun checkObjectHashes (Lorg/modelix/model/server/api/v2/VersionDelta;)V
+	public static final fun getAllObjects (Lorg/modelix/model/server/api/v2/VersionDelta;)Ljava/util/Map;
+	public static final fun readVersionDelta (Lio/ktor/client/statement/HttpResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun runWrite (Lorg/modelix/model/client2/IModelClientV2;Lorg/modelix/model/lazy/BranchReference;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun runWriteOnBranch (Lorg/modelix/model/client2/IModelClientV2;Lorg/modelix/model/lazy/BranchReference;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun useVersionStreamFormat (Lio/ktor/client/request/HttpRequestBuilder;)V
+}
+
+public final class org/modelix/model/client2/ModelClientV2PlatformSpecificBuilder : org/modelix/model/client2/ModelClientV2Builder {
+	public fun <init> ()V
+}
+
+public final class org/modelix/model/client2/ReplicatedModel {
+	public static final field Companion Lorg/modelix/model/client2/ReplicatedModel$Companion;
+	public fun <init> (Lorg/modelix/model/client2/IModelClientV2;Lorg/modelix/model/lazy/BranchReference;Lkotlinx/coroutines/CoroutineScope;)V
+	public synthetic fun <init> (Lorg/modelix/model/client2/IModelClientV2;Lorg/modelix/model/lazy/BranchReference;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun dispose ()V
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public final fun getBranchRef ()Lorg/modelix/model/lazy/BranchReference;
+	public final fun getClient ()Lorg/modelix/model/client2/IModelClientV2;
+	public final fun getCurrentVersion (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun isDisposed ()Z
+	public final fun resetToServerVersion (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/client2/ReplicatedModel$Companion {
+}
+
+public final class org/modelix/model/client2/ReplicatedModelKt {
+	public static final fun getReplicatedModel (Lorg/modelix/model/client2/IModelClientV2;Lorg/modelix/model/lazy/BranchReference;)Lorg/modelix/model/client2/ReplicatedModel;
+	public static final fun getReplicatedModel (Lorg/modelix/model/client2/IModelClientV2;Lorg/modelix/model/lazy/BranchReference;Lkotlinx/coroutines/CoroutineScope;)Lorg/modelix/model/client2/ReplicatedModel;
+}
+
+public final class org/modelix/model/metameta/MetaMetaLanguage {
+	public static final field INSTANCE Lorg/modelix/model/metameta/MetaMetaLanguage;
+	public final fun getChildLink_Concept_childLinks ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getChildLink_Concept_properties ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getChildLink_Concept_referenceLinks ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getChildLink_Concept_superConcepts ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getChildLink_Language_concepts ()Lorg/modelix/model/api/SimpleChildLink;
+	public final fun getConcept_ChildLink ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getConcept_Concept ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getConcept_ConceptReference ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getConcept_IHasUID ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getConcept_Language ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getConcept_Property ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getConcept_ReferenceLink ()Lorg/modelix/model/api/SimpleConcept;
+	public final fun getLanguage_metameta ()Lorg/modelix/model/api/SimpleLanguage;
+	public final fun getProperty_ChildLink_multiple ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_ChildLink_name ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_ChildLink_optional ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_Concept_abstract ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_Concept_name ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_IHasUID_uid ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_Language_name ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_Property_name ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_ReferenceLink_name ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getProperty_ReferenceLink_optional ()Lorg/modelix/model/api/SimpleProperty;
+	public final fun getReferenceLink_ChildLink_childConcept ()Lorg/modelix/model/api/SimpleReferenceLink;
+	public final fun getReferenceLink_ConceptReference_concept ()Lorg/modelix/model/api/SimpleReferenceLink;
+	public final fun getReferenceLink_ReferenceLink_targetConcept ()Lorg/modelix/model/api/SimpleReferenceLink;
+}
+
+public final class org/modelix/model/metameta/MetaModelBranch : org/modelix/model/api/IBranch {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeReadT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWriteT (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public final fun getDisabled ()Z
+	public fun getId ()Ljava/lang/String;
+	public fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public final fun resolveConcept (Lorg/modelix/model/api/IConceptReference;Lorg/modelix/model/api/ITree;)Lorg/modelix/model/api/IConcept;
+	public fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runReadT (Lkotlin/jvm/functions/Function1;)V
+	public fun runWrite (Lkotlin/jvm/functions/Function0;)V
+	public fun runWriteT (Lkotlin/jvm/functions/Function1;)V
+	public final fun setDisabled (Z)V
+	public final fun toGlobalConcept (Lorg/modelix/model/api/IConcept;Lorg/modelix/model/api/ITree;)Lorg/modelix/model/api/IConcept;
+	public final fun toGlobalConceptRef (Lorg/modelix/model/api/IConceptReference;Lorg/modelix/model/api/ITree;)Lorg/modelix/model/api/IConceptReference;
+	public final fun toLocalConcept (Lorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/IConcept;
+	public final fun wrapTree (Lorg/modelix/model/api/ITree;)Lorg/modelix/model/metameta/MetaModelBranch$MMTree;
+}
+
+public final class org/modelix/model/metameta/MetaModelBranch$MMBranchListener : org/modelix/model/api/IBranchListener {
+	public fun <init> (Lorg/modelix/model/metameta/MetaModelBranch;Lorg/modelix/model/api/IBranchListener;)V
+	public final fun getListener ()Lorg/modelix/model/api/IBranchListener;
+	public fun treeChanged (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITree;)V
+}
+
+public final class org/modelix/model/metameta/MetaModelBranch$MMBulkTree : org/modelix/model/metameta/MetaModelBranch$MMTree, org/modelix/model/lazy/IBulkTree, org/modelix/model/lazy/ITreeWrapper {
+	public fun <init> (Lorg/modelix/model/metameta/MetaModelBranch;Lorg/modelix/model/lazy/IBulkTree;)V
+	public fun getAncestors (Ljava/lang/Iterable;Z)Ljava/util/Set;
+	public fun getDescendants (JZ)Ljava/lang/Iterable;
+	public fun getDescendants (Ljava/lang/Iterable;Z)Ljava/lang/Iterable;
+	public synthetic fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getTree ()Lorg/modelix/model/lazy/IBulkTree;
+	public fun getWrappedTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/metameta/MetaModelBranch$MMReadTransaction : org/modelix/model/ITransactionWrapper, org/modelix/model/api/IReadTransaction {
+	public fun <init> (Lorg/modelix/model/metameta/MetaModelBranch;Lorg/modelix/model/api/IReadTransaction;)V
+	public fun containsNode (J)Z
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public final fun getTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun unwrap ()Lorg/modelix/model/api/ITransaction;
+}
+
+public class org/modelix/model/metameta/MetaModelBranch$MMTree : org/modelix/model/api/ITree {
+	public fun <init> (Lorg/modelix/model/metameta/MetaModelBranch;Lorg/modelix/model/api/ITree;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public fun containsNode (J)Z
+	public fun deleteNode (J)Lorg/modelix/model/api/ITree;
+	public fun deleteNodes ([J)Lorg/modelix/model/api/ITree;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getAllChildrenAsFlow (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getAllReferenceTargetsAsFlow (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getChildRoles (J)Ljava/lang/Iterable;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getChildrenAsFlow (JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getDescendantsAsFlow (JZ)Lkotlinx/coroutines/flow/Flow;
+	public fun getId ()Ljava/lang/String;
+	public fun getParent (J)J
+	public fun getParentAsFlow (J)Lkotlinx/coroutines/flow/Flow;
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getPropertyValueAsFlow (JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTargetAsFlow (JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public fun getRole (J)Ljava/lang/String;
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun hashCode ()I
+	public fun moveChild (JLjava/lang/String;IJ)Lorg/modelix/model/api/ITree;
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)Lorg/modelix/model/api/ITree;
+	public fun setReferenceTarget (JLjava/lang/String;J)Lorg/modelix/model/api/ITree;
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/ITree;
+	public fun toString ()Ljava/lang/String;
+	public fun usesRoleIds ()Z
+	public fun visitChanges (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITreeChangeVisitor;)V
+}
+
+public final class org/modelix/model/metameta/MetaModelBranch$MMWriteTransaction : org/modelix/model/ITransactionWrapper, org/modelix/model/api/IWriteTransaction {
+	public fun <init> (Lorg/modelix/model/metameta/MetaModelBranch;Lorg/modelix/model/api/IWriteTransaction;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public fun containsNode (J)Z
+	public fun deleteNode (J)V
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public final fun getTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun moveChild (JLjava/lang/String;IJ)V
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setTree (Lorg/modelix/model/api/ITree;)V
+	public fun unwrap ()Lorg/modelix/model/api/ITransaction;
+}
+
+public final class org/modelix/model/metameta/MetaModelIndex {
+	public static final field Companion Lorg/modelix/model/metameta/MetaModelIndex$Companion;
+	public static final field LANGUAGES_ROLE Ljava/lang/String;
+	public synthetic fun <init> (Lorg/modelix/model/api/ITree;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getChildLinkId (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Long;
+	public final fun getConceptId (Lorg/modelix/model/api/IConcept;)Ljava/lang/Long;
+	public final fun getLanguageId (Lorg/modelix/model/api/ILanguage;)Ljava/lang/Long;
+	public final fun getPropertyId (Lorg/modelix/model/api/IProperty;)Ljava/lang/Long;
+	public final fun getReferenceLinkId (Lorg/modelix/model/api/IReferenceLink;)Ljava/lang/Long;
+	public final fun getTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/metameta/MetaModelIndex$Companion {
+	public final fun fromTree (Lorg/modelix/model/api/ITree;)Lorg/modelix/model/metameta/MetaModelIndex;
+	public final fun incremental (Lorg/modelix/model/metameta/MetaModelIndex;Lorg/modelix/model/api/ITree;)Lorg/modelix/model/metameta/MetaModelIndex;
+}
+
+public final class org/modelix/model/metameta/MetaModelSynchronizer {
+	public fun <init> (Lorg/modelix/model/api/IBranch;)V
+	public final fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public final fun getChildLinkId (Lorg/modelix/model/api/IChildLink;)J
+	public final fun getConceptId (Lorg/modelix/model/api/IConcept;)J
+	public final fun getIndex ()Lorg/modelix/model/metameta/MetaModelIndex;
+	public final fun getLanguageId (Lorg/modelix/model/api/ILanguage;)J
+	public final fun getPropertyId (Lorg/modelix/model/api/IProperty;)J
+	public final fun getReferenceLinkId (Lorg/modelix/model/api/IReferenceLink;)J
+	public final fun prefetch ()V
+}
+
+public final class org/modelix/model/metameta/PersistedConcept : org/modelix/model/api/IConcept, org/modelix/model/api/IConceptReference {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lorg/modelix/model/metameta/PersistedConcept;
+	public static synthetic fun copy$default (Lorg/modelix/model/metameta/PersistedConcept;JLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/metameta/PersistedConcept;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildLinks ()Ljava/util/List;
+	public fun getAllProperties ()Ljava/util/List;
+	public fun getAllReferenceLinks ()Ljava/util/List;
+	public fun getChildLink (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public fun getDirectSuperConcepts ()Ljava/util/List;
+	public final fun getId ()J
+	public fun getLanguage ()Lorg/modelix/model/api/ILanguage;
+	public fun getLongName ()Ljava/lang/String;
+	public fun getOwnChildLinks ()Ljava/util/List;
+	public fun getOwnProperties ()Ljava/util/List;
+	public fun getOwnReferenceLinks ()Ljava/util/List;
+	public fun getProperty (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getReferenceLink (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public fun getShortName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public final fun getUid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isAbstract ()Z
+	public fun isExactly (Lorg/modelix/model/api/IConcept;)Z
+	public fun isSubConceptOf (Lorg/modelix/model/api/IConcept;)Z
+	public fun resolve (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/IConcept;
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/oauth/ModelixOAuthClient {
+	public static final field INSTANCE Lorg/modelix/model/oauth/ModelixOAuthClient;
+	public final fun authorize (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getTokens ()Lcom/google/api/client/auth/oauth2/StoredCredential;
+	public final fun installAuth (Lio/ktor/client/HttpClientConfig;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun installAuth$default (Lorg/modelix/model/oauth/ModelixOAuthClient;Lio/ktor/client/HttpClientConfig;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
+public final class org/modelix/model/util/StreamUtils {
+	public static final field INSTANCE Lorg/modelix/model/util/StreamUtils;
+	public final fun indexOf (Ljava/util/stream/LongStream;J)I
+	public final fun intersection (Ljava/util/stream/Stream;Ljava/util/Set;)Ljava/util/Set;
+	public final fun last (Ljava/util/List;)Ljava/lang/Object;
+	public final fun removeLast (Ljava/util/List;)Ljava/lang/Object;
+	public final fun toList (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun toStream (Ljava/lang/Iterable;)Ljava/util/stream/Stream;
+}
+
+public abstract interface class org/modelix/model/util/pmap/CustomPMap {
+	public abstract fun containsKey (Ljava/lang/Object;)Z
+	public abstract fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun keys ()Ljava/lang/Iterable;
+	public abstract fun put (Ljava/lang/Object;Ljava/lang/Object;)Lorg/modelix/model/util/pmap/CustomPMap;
+	public abstract fun remove (Ljava/lang/Object;)Lorg/modelix/model/util/pmap/CustomPMap;
+	public abstract fun values ()Ljava/lang/Iterable;
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap {
+	public static final field Companion Lorg/modelix/model/util/pmap/LongKeyPMap$Companion;
+	public fun <init> ()V
+	public final fun get (J)Ljava/lang/Object;
+	public final fun put (JLjava/lang/Object;)Lorg/modelix/model/util/pmap/LongKeyPMap;
+	public final fun remove (J)Lorg/modelix/model/util/pmap/LongKeyPMap;
+	public final fun visitChanges (Lorg/modelix/model/util/pmap/LongKeyPMap;Lorg/modelix/model/util/pmap/LongKeyPMap$IChangeVisitor;)V
+	public final fun visitEntries (Ljava/util/function/BiPredicate;)V
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap$Companion {
+	public final fun isBitNotSet (II)Z
+	public final fun logicalToPhysicalIndex (II)I
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap$EmptyNode : org/modelix/model/util/pmap/LongKeyPMap$INode {
+	public fun <init> ()V
+	public fun get (JI)Ljava/lang/Object;
+	public fun put (JLjava/lang/Object;I)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun remove (JI)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun visitChanges (Lorg/modelix/model/util/pmap/LongKeyPMap$INode;Lorg/modelix/model/util/pmap/LongKeyPMap$IChangeVisitor;)V
+	public fun visitEntries (Ljava/util/function/BiPredicate;)Z
+}
+
+public abstract interface class org/modelix/model/util/pmap/LongKeyPMap$IChangeVisitor {
+	public abstract fun entryAdded (JLjava/lang/Object;)V
+	public abstract fun entryChanged (JLjava/lang/Object;Ljava/lang/Object;)V
+	public abstract fun entryRemoved (JLjava/lang/Object;)V
+}
+
+public abstract interface class org/modelix/model/util/pmap/LongKeyPMap$INode {
+	public abstract fun get (JI)Ljava/lang/Object;
+	public abstract fun put (JLjava/lang/Object;I)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public abstract fun remove (JI)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public abstract fun visitChanges (Lorg/modelix/model/util/pmap/LongKeyPMap$INode;Lorg/modelix/model/util/pmap/LongKeyPMap$IChangeVisitor;)V
+	public abstract fun visitEntries (Ljava/util/function/BiPredicate;)Z
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap$InternalNode : org/modelix/model/util/pmap/LongKeyPMap$INode {
+	public static final field Companion Lorg/modelix/model/util/pmap/LongKeyPMap$InternalNode$Companion;
+	public fun <init> (I[Lorg/modelix/model/util/pmap/LongKeyPMap$INode;)V
+	public final fun deleteChild (I)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun get (JI)Ljava/lang/Object;
+	public final fun getChild (I)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun put (JLjava/lang/Object;I)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun remove (JI)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public final fun setChild (ILorg/modelix/model/util/pmap/LongKeyPMap$INode;)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun visitChanges (Lorg/modelix/model/util/pmap/LongKeyPMap$INode;Lorg/modelix/model/util/pmap/LongKeyPMap$IChangeVisitor;)V
+	public fun visitEntries (Ljava/util/function/BiPredicate;)Z
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap$InternalNode$Companion {
+	public final fun empty ()Lorg/modelix/model/util/pmap/LongKeyPMap$InternalNode;
+	public final fun getEMPTY ()Lorg/modelix/model/util/pmap/LongKeyPMap$InternalNode;
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap$LeafNode : org/modelix/model/util/pmap/LongKeyPMap$INode {
+	public static final field Companion Lorg/modelix/model/util/pmap/LongKeyPMap$LeafNode$Companion;
+	public fun <init> (JLjava/lang/Object;)V
+	public fun get (JI)Ljava/lang/Object;
+	public final fun getKey ()J
+	public final fun getValue ()Ljava/lang/Object;
+	public fun put (JLjava/lang/Object;I)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun remove (JI)Lorg/modelix/model/util/pmap/LongKeyPMap$INode;
+	public fun visitChanges (Lorg/modelix/model/util/pmap/LongKeyPMap$INode;Lorg/modelix/model/util/pmap/LongKeyPMap$IChangeVisitor;)V
+	public fun visitEntries (Ljava/util/function/BiPredicate;)Z
+}
+
+public final class org/modelix/model/util/pmap/LongKeyPMap$LeafNode$Companion {
+	public final fun create (JLjava/lang/Object;)Lorg/modelix/model/util/pmap/LongKeyPMap$LeafNode;
+}
+
+public abstract class org/modelix/model/util/pmap/SmallPMap : org/modelix/model/util/pmap/CustomPMap {
+	public static final field Companion Lorg/modelix/model/util/pmap/SmallPMap$Companion;
+	public fun <init> ()V
+	public abstract fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun keys ()Ljava/lang/Iterable;
+	public abstract fun put (Ljava/lang/Object;Ljava/lang/Object;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public abstract fun remove (Ljava/lang/Object;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public abstract fun values ()Ljava/lang/Iterable;
+}
+
+public final class org/modelix/model/util/pmap/SmallPMap$Companion {
+	public final fun createS (Ljava/lang/Iterable;Ljava/lang/Iterable;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public final fun empty ()Lorg/modelix/model/util/pmap/SmallPMap;
+}
+
+public final class org/modelix/model/util/pmap/SmallPMap$Multiple : org/modelix/model/util/pmap/SmallPMap {
+	public fun <init> ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public fun containsKey (Ljava/lang/Object;)Z
+	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun keys ()Ljava/lang/Iterable;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Lorg/modelix/model/util/pmap/CustomPMap;
+	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public synthetic fun remove (Ljava/lang/Object;)Lorg/modelix/model/util/pmap/CustomPMap;
+	public fun remove (Ljava/lang/Object;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public fun values ()Ljava/lang/Iterable;
+}
+
+public final class org/modelix/model/util/pmap/SmallPMap$Single : org/modelix/model/util/pmap/SmallPMap {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun containsKey (Ljava/lang/Object;)Z
+	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun keys ()Ljava/lang/Iterable;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Lorg/modelix/model/util/pmap/CustomPMap;
+	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public synthetic fun remove (Ljava/lang/Object;)Lorg/modelix/model/util/pmap/CustomPMap;
+	public fun remove (Ljava/lang/Object;)Lorg/modelix/model/util/pmap/SmallPMap;
+	public fun values ()Ljava/lang/Iterable;
+}
+

--- a/model-datastructure/api/model-datastructure.api
+++ b/model-datastructure/api/model-datastructure.api
@@ -1,0 +1,1329 @@
+public abstract interface class org/modelix/model/IKeyListener {
+	public static final field Companion Lorg/modelix/model/IKeyListener$Companion;
+	public static final field NULL_VALUE Ljava/lang/String;
+	public abstract fun changed (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/IKeyListener$Companion {
+	public static final field NULL_VALUE Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/IKeyValueStore {
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getA (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getA$suspendImpl (Lorg/modelix/model/IKeyValueStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public abstract fun getPendingSize ()I
+	public abstract fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun newBulkQuery (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+	public abstract fun prefetch (Ljava/lang/String;)V
+	public abstract fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun putAll (Ljava/util/Map;)V
+	public abstract fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public final class org/modelix/model/IKeyValueStore$DefaultImpls {
+	public static fun getA (Lorg/modelix/model/IKeyValueStore;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun newBulkQuery (Lorg/modelix/model/IKeyValueStore;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+}
+
+public abstract interface class org/modelix/model/ITransactionWrapper : org/modelix/model/api/ITransaction {
+	public abstract fun unwrap ()Lorg/modelix/model/api/ITransaction;
+}
+
+public final class org/modelix/model/ITransactionWrapperKt {
+	public static final fun unwrapAll (Lorg/modelix/model/api/ITransaction;)Ljava/util/List;
+}
+
+public abstract interface class org/modelix/model/IVersion {
+	public abstract fun getContentHash ()Ljava/lang/String;
+	public abstract fun getTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/InMemoryModel {
+	public static final field Companion Lorg/modelix/model/InMemoryModel$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lorg/modelix/model/lazy/KVEntryReference;Lgnu/trove/map/TLongObjectMap;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getArea ()Lorg/modelix/model/InMemoryModel$Area;
+	public final fun getBranchId ()Ljava/lang/String;
+	public final fun getLoadedMapRef ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getNode (J)Lorg/modelix/model/InMemoryNode;
+	public final fun getNodeData (J)Lorg/modelix/model/persistent/CPNode;
+	public final fun getNodeMap ()Lgnu/trove/map/TLongObjectMap;
+	public final fun getUseRoleIds ()Z
+	public final fun loadIncremental (Lorg/modelix/model/lazy/CLTree;)Lorg/modelix/model/InMemoryModel;
+	public final fun loadIncremental (Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/IKeyValueStore;Z)Lorg/modelix/model/InMemoryModel;
+}
+
+public final class org/modelix/model/InMemoryModel$Area : org/modelix/model/area/IArea {
+	public fun <init> (Lorg/modelix/model/InMemoryModel;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/model/InMemoryModel$Companion {
+	public final fun load (Ljava/lang/String;Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/IKeyValueStore;Z)Lorg/modelix/model/InMemoryModel;
+	public final fun load (Lorg/modelix/model/lazy/CLTree;)Lorg/modelix/model/InMemoryModel;
+}
+
+public final class org/modelix/model/InMemoryModelLoader {
+	public fun <init> (Lorg/modelix/model/IncrementalInMemoryModel;Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+	public final fun getIncrementalModel ()Lorg/modelix/model/IncrementalInMemoryModel;
+	public final fun getModel (Lorg/modelix/model/lazy/CLTree;)Lkotlinx/coroutines/Deferred;
+}
+
+public final class org/modelix/model/InMemoryModels {
+	public fun <init> ()V
+	public final fun dispose ()V
+	public final fun getModel (Lorg/modelix/model/lazy/CLTree;)Lkotlinx/coroutines/Deferred;
+}
+
+public final class org/modelix/model/InMemoryNode : org/modelix/model/api/INode, org/modelix/model/api/INodeReference {
+	public fun <init> (Lorg/modelix/model/InMemoryModel;J)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public final fun component1 ()Lorg/modelix/model/InMemoryModel;
+	public final fun component2 ()J
+	public final fun copy (Lorg/modelix/model/InMemoryModel;J)Lorg/modelix/model/InMemoryNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/InMemoryNode;Lorg/modelix/model/InMemoryModel;JILjava/lang/Object;)Lorg/modelix/model/InMemoryNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public final fun getModel ()Lorg/modelix/model/InMemoryModel;
+	public final fun getNodeData ()Lorg/modelix/model/persistent/CPNode;
+	public final fun getNodeId ()J
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun serialize ()Ljava/lang/String;
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun toString ()Ljava/lang/String;
+	public fun usesRoleIds ()Z
+}
+
+public final class org/modelix/model/IncrementalInMemoryModel {
+	public fun <init> ()V
+	public final fun getLoadedModel ()Lorg/modelix/model/InMemoryModel;
+	public final fun getModel (Lorg/modelix/model/lazy/CLTree;)Lorg/modelix/model/InMemoryModel;
+}
+
+public final class org/modelix/model/LinearHistory {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun load ([Lorg/modelix/model/lazy/CLVersion;)Ljava/util/List;
+}
+
+public final class org/modelix/model/PlatformSpecificKt {
+	public static final fun bitCount (I)I
+	public static final fun createLRUMap (I)Ljava/util/Map;
+	public static final fun randomUUID ()Ljava/lang/String;
+	public static final fun sleep (J)V
+}
+
+public final class org/modelix/model/VersionMerger {
+	public static final field Companion Lorg/modelix/model/VersionMerger$Companion;
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;Lorg/modelix/model/api/IIdGenerator;)V
+	public final fun checkRepositoryIds (Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;)V
+	public final fun mergeChange (Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;)Lorg/modelix/model/lazy/CLVersion;
+}
+
+public final class org/modelix/model/VersionMerger$Companion {
+	public final fun commonBaseVersion (Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;)Lorg/modelix/model/lazy/CLVersion;
+}
+
+public final class org/modelix/model/client/IdGenerator : org/modelix/model/api/IIdGenerator {
+	public static final field Companion Lorg/modelix/model/client/IdGenerator$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun generate ()J
+	public final fun generate (I)Lkotlin/ranges/LongRange;
+}
+
+public final class org/modelix/model/client/IdGenerator$Companion {
+	public final fun getInstance (I)Lorg/modelix/model/client/IdGenerator;
+	public final fun newInstance (I)Lorg/modelix/model/client/IdGenerator;
+}
+
+public final class org/modelix/model/lazy/BranchReference {
+	public static final field Companion Lorg/modelix/model/lazy/BranchReference$Companion;
+	public fun <init> (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;)V
+	public final fun component1 ()Lorg/modelix/model/lazy/RepositoryId;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;)Lorg/modelix/model/lazy/BranchReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/lazy/BranchReference;Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/lazy/BranchReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranchName ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getRepositoryId ()Lorg/modelix/model/lazy/RepositoryId;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/lazy/BranchReference$Companion {
+	public final fun tryParseBranch (Ljava/lang/String;)Lorg/modelix/model/lazy/BranchReference;
+}
+
+public final class org/modelix/model/lazy/BulkQuery : org/modelix/model/lazy/IBulkQuery {
+	public static final field Companion Lorg/modelix/model/lazy/BulkQuery$Companion;
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun constant (Ljava/lang/Object;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun get (Lorg/modelix/model/lazy/KVEntryReference;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun map (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun process ()V
+	public final fun query (Lorg/modelix/model/lazy/KVEntryReference;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/lazy/BulkQuery$Companion {
+	public final fun getBATCH_SIZE ()I
+}
+
+public final class org/modelix/model/lazy/BulkQuery$Value : org/modelix/model/lazy/IBulkQuery$Value {
+	public fun <init> (Lorg/modelix/model/lazy/BulkQuery;)V
+	public fun <init> (Lorg/modelix/model/lazy/BulkQuery;Ljava/lang/Object;)V
+	public fun execute ()Ljava/lang/Object;
+	public fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun mapBulk (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun onSuccess (Lkotlin/jvm/functions/Function1;)V
+	public final fun success (Ljava/lang/Object;)V
+}
+
+public final class org/modelix/model/lazy/CLNode {
+	public static final field Companion Lorg/modelix/model/lazy/CLNode$Companion;
+	public fun <init> (Lorg/modelix/model/lazy/CLTree;JLjava/lang/String;JLjava/lang/String;[J[Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;[Lorg/modelix/model/persistent/CPNodeRef;)V
+	public fun <init> (Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/persistent/CPNode;)V
+	public static final fun create (Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/persistent/CPNode;)Lorg/modelix/model/lazy/CLNode;
+	public final fun getAncestors (Lorg/modelix/model/lazy/IBulkQuery;Z)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getChildren (Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getConcept ()Ljava/lang/String;
+	public final fun getData ()Lorg/modelix/model/persistent/CPNode;
+	public final fun getDescendants (Lorg/modelix/model/lazy/IBulkQuery;Z)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getId ()J
+	public final fun getParent ()Lorg/modelix/model/lazy/CLNode;
+	public final fun getParentId ()J
+	public final fun getRef ()Lorg/modelix/model/lazy/CLNodeRef;
+	public final fun getRoleInParent ()Ljava/lang/String;
+	public final fun getTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/lazy/CLNode$Companion {
+	public final fun create (Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/persistent/CPNode;)Lorg/modelix/model/lazy/CLNode;
+}
+
+public final class org/modelix/model/lazy/CLNodeRef {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lorg/modelix/model/lazy/CLNodeRef;
+	public static synthetic fun copy$default (Lorg/modelix/model/lazy/CLNodeRef;JILjava/lang/Object;)Lorg/modelix/model/lazy/CLNodeRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/lazy/CLTree : org/modelix/model/api/ITree, org/modelix/model/lazy/IBulkTree {
+	public static final field Companion Lorg/modelix/model/lazy/CLTree$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun <init> (Lorg/modelix/model/lazy/RepositoryId;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun <init> (Lorg/modelix/model/persistent/CPTree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun <init> (Lorg/modelix/model/persistent/CPTree;Lorg/modelix/model/lazy/RepositoryId;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;Z)V
+	public synthetic fun <init> (Lorg/modelix/model/persistent/CPTree;Lorg/modelix/model/lazy/RepositoryId;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/ITree;
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/ITree;
+	public fun containsNode (J)Z
+	public final fun createElement (Lorg/modelix/model/lazy/KVEntryReference;)Lorg/modelix/model/persistent/CPNode;
+	public final fun createElement (Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun createElements (Ljava/util/List;Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun deleteNode (J)Lorg/modelix/model/api/ITree;
+	public fun deleteNodes ([J)Lorg/modelix/model/api/ITree;
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getAncestors (Ljava/lang/Iterable;Z)Ljava/util/Set;
+	public fun getChildRoles (J)Ljava/lang/Iterable;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public final fun getData ()Lorg/modelix/model/persistent/CPTree;
+	public fun getDescendants (JZ)Ljava/lang/Iterable;
+	public fun getDescendants (Ljava/lang/Iterable;Z)Ljava/lang/Iterable;
+	public final fun getHash ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public final fun getNodesMap ()Lorg/modelix/model/persistent/CPHamtNode;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public final fun getRoot ()Lorg/modelix/model/persistent/CPNode;
+	public final fun getSize ()J
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun moveChild (JLjava/lang/String;IJ)Lorg/modelix/model/api/ITree;
+	public final fun prefetchAll ()V
+	public final fun resolveElement (J)Lorg/modelix/model/persistent/CPNode;
+	public final fun resolveElement (JLorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun resolveElement (Lorg/modelix/model/persistent/CPNodeRef;)Lorg/modelix/model/persistent/CPNode;
+	public final fun resolveElements (Ljava/lang/Iterable;Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)Lorg/modelix/model/api/ITree;
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/ITree;
+	public fun toString ()Ljava/lang/String;
+	public fun usesRoleIds ()Z
+	public fun visitChanges (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITreeChangeVisitor;)V
+	public final fun visitChanges (Lorg/modelix/model/api/ITree;Lorg/modelix/model/api/ITreeChangeVisitor;Lorg/modelix/model/lazy/IBulkQuery;)V
+}
+
+public final class org/modelix/model/lazy/CLTree$Builder {
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public final fun build ()Lorg/modelix/model/lazy/CLTree;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public final fun repositoryId (Ljava/lang/String;)Lorg/modelix/model/lazy/CLTree$Builder;
+	public final fun repositoryId (Lorg/modelix/model/lazy/RepositoryId;)Lorg/modelix/model/lazy/CLTree$Builder;
+	public final fun setStore (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public final fun useRoleIds (Z)Lorg/modelix/model/lazy/CLTree$Builder;
+	public static synthetic fun useRoleIds$default (Lorg/modelix/model/lazy/CLTree$Builder;ZILjava/lang/Object;)Lorg/modelix/model/lazy/CLTree$Builder;
+}
+
+public final class org/modelix/model/lazy/CLTree$Companion {
+	public final fun builder (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/CLTree$Builder;
+}
+
+public final class org/modelix/model/lazy/CLVersion : org/modelix/model/IVersion {
+	public static final field Companion Lorg/modelix/model/lazy/CLVersion$Companion;
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;[Lorg/modelix/model/operations/IOperation;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun <init> (Lorg/modelix/model/persistent/CPVersion;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthor ()Ljava/lang/String;
+	public final fun getBaseVersion ()Lorg/modelix/model/lazy/CLVersion;
+	public fun getContentHash ()Ljava/lang/String;
+	public final fun getData ()Lorg/modelix/model/persistent/CPVersion;
+	public final fun getHash ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getMergedVersion1 ()Lorg/modelix/model/lazy/CLVersion;
+	public final fun getMergedVersion2 ()Lorg/modelix/model/lazy/CLVersion;
+	public final fun getNumberOfOperations ()I
+	public final fun getOperations ()Ljava/lang/Iterable;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public final fun getTime ()Ljava/lang/String;
+	public final fun getTimestamp ()Lkotlinx/datetime/Instant;
+	public synthetic fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getTree ()Lorg/modelix/model/lazy/CLTree;
+	public final fun getTreeHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getTree_() ()Lorg/modelix/model/lazy/CLTree;
+	public fun hashCode ()I
+	public final fun isMerge ()Z
+	public final fun operationsInlined ()Z
+	public final fun setStore (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun toString ()Ljava/lang/String;
+	public final fun write ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/lazy/CLVersion$Companion {
+	public final fun createAutoMerge (JLorg/modelix/model/lazy/CLTree;Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;[Lorg/modelix/model/operations/IOperation;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun createRegularVersion (JLjava/lang/String;Ljava/lang/String;Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/lazy/CLVersion;[Lorg/modelix/model/operations/IOperation;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun createRegularVersion (JLkotlinx/datetime/Instant;Ljava/lang/String;Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/lazy/CLVersion;[Lorg/modelix/model/operations/IOperation;)Lorg/modelix/model/lazy/CLVersion;
+	public static synthetic fun createRegularVersion$default (Lorg/modelix/model/lazy/CLVersion$Companion;JLkotlinx/datetime/Instant;Ljava/lang/String;Lorg/modelix/model/lazy/CLTree;Lorg/modelix/model/lazy/CLVersion;[Lorg/modelix/model/operations/IOperation;ILjava/lang/Object;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun getINLINED_OPS_LIMIT ()I
+	public final fun loadFromHash (Ljava/lang/String;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/CLVersion;
+}
+
+public final class org/modelix/model/lazy/CLVersionKt {
+	public static final fun computeDelta (Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/lazy/CLVersion;)Ljava/util/Map;
+	public static final fun filterNotNullValues (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun runWrite (Lorg/modelix/model/lazy/CLVersion;Lorg/modelix/model/api/IIdGenerator;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/CLVersion;
+}
+
+public final class org/modelix/model/lazy/COWArrays {
+	public static final field INSTANCE Lorg/modelix/model/lazy/COWArrays;
+	public final fun add ([JJ)[J
+	public final fun add ([J[J)[J
+	public final fun add ([Ljava/lang/Object;Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun addIfAbsent ([Ljava/lang/Object;Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun arraycopy ([JI[JII)V
+	public final fun arraycopy ([Ljava/lang/Object;I[Ljava/lang/Object;II)V
+	public final fun concat ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun copy ([J)[J
+	public final fun copy ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public final fun indexOf ([JJ)I
+	public final fun indexOf ([Ljava/lang/Object;Ljava/lang/Object;)I
+	public final fun insert ([JIJ)[J
+	public final fun insert ([JI[J)[J
+	public final fun remove ([JJ)[J
+	public final fun removeAll ([J[J)[J
+	public final fun removeAt ([JI)[J
+	public final fun set ([JIJ)[J
+	public final fun set ([Ljava/lang/Object;ILjava/lang/Object;)[Ljava/lang/Object;
+}
+
+public final class org/modelix/model/lazy/DuplicateNodeId : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class org/modelix/model/lazy/IBulkQuery {
+	public abstract fun constant (Ljava/lang/Object;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public abstract fun get (Lorg/modelix/model/lazy/KVEntryReference;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public abstract fun map (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public abstract fun process ()V
+}
+
+public abstract interface class org/modelix/model/lazy/IBulkQuery$Value {
+	public abstract fun execute ()Ljava/lang/Object;
+	public abstract fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public abstract fun mapBulk (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public abstract fun onSuccess (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class org/modelix/model/lazy/IBulkTree : org/modelix/model/api/ITree {
+	public abstract fun getAncestors (Ljava/lang/Iterable;Z)Ljava/util/Set;
+	public abstract fun getDescendants (JZ)Ljava/lang/Iterable;
+	public abstract fun getDescendants (Ljava/lang/Iterable;Z)Ljava/lang/Iterable;
+}
+
+public final class org/modelix/model/lazy/IBulkTree$DefaultImpls {
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/lazy/IBulkTree;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/lazy/IBulkTree;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/lazy/IBulkTree;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/lazy/IBulkTree;JZ)Lkotlinx/coroutines/flow/Flow;
+	public static fun getParentAsFlow (Lorg/modelix/model/lazy/IBulkTree;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/lazy/IBulkTree;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/lazy/IBulkTree;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun setReferenceTarget (Lorg/modelix/model/lazy/IBulkTree;JLjava/lang/String;J)Lorg/modelix/model/api/ITree;
+}
+
+public abstract interface class org/modelix/model/lazy/IDeserializingKeyValueStore {
+	public abstract fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun getAll (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/lang/Iterable;
+	public abstract fun getKeyValueStore ()Lorg/modelix/model/IKeyValueStore;
+	public fun newBulkQuery ()Lorg/modelix/model/lazy/IBulkQuery;
+	public fun newBulkQuery (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+	public abstract fun prefetch (Ljava/lang/String;)V
+	public abstract fun put (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/lazy/IDeserializingKeyValueStore$DefaultImpls {
+	public static fun newBulkQuery (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+	public static fun newBulkQuery (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+}
+
+public abstract interface class org/modelix/model/lazy/IKVEntryReference {
+	public abstract fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getHash ()Ljava/lang/String;
+	public abstract fun getValue (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/IKVValue;
+	public abstract fun write (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+}
+
+public abstract interface class org/modelix/model/lazy/INodeReferenceSerializer : org/modelix/model/api/INodeReferenceSerializer {
+	public static final field Companion Lorg/modelix/model/lazy/INodeReferenceSerializer$Companion;
+	public abstract fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public abstract fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/lazy/INodeReferenceSerializer$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public final fun register (Lorg/modelix/model/lazy/INodeReferenceSerializer;)V
+	public final fun serialize (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+	public final fun unregister (Lorg/modelix/model/lazy/INodeReferenceSerializer;)V
+}
+
+public abstract interface class org/modelix/model/lazy/ITreeWrapper : org/modelix/model/api/ITree {
+	public abstract fun getWrappedTree ()Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/lazy/ITreeWrapper$DefaultImpls {
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;JZ)Lkotlinx/coroutines/flow/Flow;
+	public static fun getParentAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;J)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/lazy/ITreeWrapper;JLjava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public static fun setReferenceTarget (Lorg/modelix/model/lazy/ITreeWrapper;JLjava/lang/String;J)Lorg/modelix/model/api/ITree;
+}
+
+public final class org/modelix/model/lazy/ITreeWrapperKt {
+	public static final fun unwrap (Lorg/modelix/model/api/ITree;)Lorg/modelix/model/api/ITree;
+}
+
+public abstract class org/modelix/model/lazy/IndirectObjectStore : org/modelix/model/lazy/IDeserializingKeyValueStore {
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun getAll (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/lang/Iterable;
+	public fun getKeyValueStore ()Lorg/modelix/model/IKeyValueStore;
+	public abstract fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/lazy/KVEntryReference : org/modelix/model/lazy/IKVEntryReference {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Lorg/modelix/model/lazy/IKVEntryReference;)V
+	public fun <init> (Lorg/modelix/model/persistent/IKVValue;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public fun getValue (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/IKVValue;
+	public fun hashCode ()I
+	public final fun isWritten ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun write (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+}
+
+public final class org/modelix/model/lazy/NodeNotFoundException : java/lang/RuntimeException {
+	public fun <init> (J)V
+}
+
+public final class org/modelix/model/lazy/NonBulkQuery : org/modelix/model/lazy/IBulkQuery {
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun constant (Ljava/lang/Object;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun get (Lorg/modelix/model/lazy/KVEntryReference;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun map (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun process ()V
+}
+
+public final class org/modelix/model/lazy/NonBulkQuery$Value : org/modelix/model/lazy/IBulkQuery$Value {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun execute ()Ljava/lang/Object;
+	public fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun mapBulk (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun onSuccess (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/lazy/NonCachingObjectStore : org/modelix/model/lazy/IDeserializingKeyValueStore {
+	public fun <init> (Lorg/modelix/model/IKeyValueStore;)V
+	public fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun getAll (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/lang/Iterable;
+	public fun getKeyValueStore ()Lorg/modelix/model/IKeyValueStore;
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/lazy/NonWrittenEntry : org/modelix/model/lazy/IKVEntryReference {
+	public fun <init> (Lorg/modelix/model/persistent/IKVValue;)V
+	public final fun getDeserialized ()Lorg/modelix/model/persistent/IKVValue;
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public final fun getSerialized ()Ljava/lang/String;
+	public fun getValue (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/IKVValue;
+	public final fun isWritten ()Z
+	public fun write (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+}
+
+public final class org/modelix/model/lazy/ObjectStoreCache : org/modelix/model/lazy/IDeserializingKeyValueStore {
+	public static final field Companion Lorg/modelix/model/lazy/ObjectStoreCache$Companion;
+	public fun <init> (Lorg/modelix/model/IKeyValueStore;)V
+	public final fun clearCache ()V
+	public fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun getAll (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/lang/Iterable;
+	public fun getKeyValueStore ()Lorg/modelix/model/IKeyValueStore;
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/lazy/ObjectStoreCache$Companion {
+}
+
+public final class org/modelix/model/lazy/OperationsCompressor {
+	public fun <init> (Lorg/modelix/model/lazy/CLTree;)V
+	public final fun compressOperations ([Lorg/modelix/model/operations/IOperation;)[Lorg/modelix/model/operations/IOperation;
+	public final fun getResultTree ()Lorg/modelix/model/lazy/CLTree;
+}
+
+public final class org/modelix/model/lazy/PrefetchCache : org/modelix/model/lazy/IDeserializingKeyValueStore {
+	public static final field Companion Lorg/modelix/model/lazy/PrefetchCache$Companion;
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun get (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun getAll (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function2;)Ljava/lang/Iterable;
+	public fun getKeyValueStore ()Lorg/modelix/model/IKeyValueStore;
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/lazy/PrefetchCache$Companion {
+	public final fun contextIndirectCache (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public final fun unwrap (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public final fun with (Lorg/modelix/model/api/ITree;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun with (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/lazy/PrefetchCache$Companion$ContextIndirectCache : org/modelix/model/lazy/IndirectObjectStore {
+	public fun <init> (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public final fun getDirectStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+}
+
+public final class org/modelix/model/lazy/RepositoryId {
+	public static final field Companion Lorg/modelix/model/lazy/RepositoryId$Companion;
+	public static final field DEFAULT_BRANCH Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/lazy/RepositoryId;
+	public static synthetic fun copy$default (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/lazy/RepositoryId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranchKey ()Ljava/lang/String;
+	public final fun getBranchKey (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getBranchReference (Ljava/lang/String;)Lorg/modelix/model/lazy/BranchReference;
+	public static synthetic fun getBranchReference$default (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/lazy/BranchReference;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun random ()Lorg/modelix/model/lazy/RepositoryId;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/lazy/RepositoryId$Companion {
+	public final fun getVALID_ID_PATTERN ()Lkotlin/text/Regex;
+	public final fun random ()Lorg/modelix/model/lazy/RepositoryId;
+}
+
+public final class org/modelix/model/lazy/WrittenEntry : org/modelix/model/lazy/IKVEntryReference {
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public fun getValue (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/IKVValue;
+	public fun write (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+}
+
+public abstract class org/modelix/model/operations/AbstractOperation : org/modelix/model/operations/IOperation {
+	public static final field Companion Lorg/modelix/model/operations/AbstractOperation$Companion;
+	public fun <init> ()V
+	protected final fun getAncestors (Lorg/modelix/model/api/ITree;J)[J
+	protected final fun getDetachedNodesEndPosition (Lorg/modelix/model/api/ITree;)Lorg/modelix/model/operations/PositionInRole;
+	protected final fun getNodePosition (Lorg/modelix/model/api/ITree;J)Lorg/modelix/model/operations/PositionInRole;
+	public fun getReferencedEntries ()Ljava/util/List;
+}
+
+public abstract class org/modelix/model/operations/AbstractOperation$Applied {
+	public fun <init> (Lorg/modelix/model/operations/AbstractOperation;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/AbstractOperation$Companion {
+}
+
+public final class org/modelix/model/operations/AddNewChildOp : org/modelix/model/operations/AddNewChildrenOp {
+	public fun <init> (Lorg/modelix/model/operations/PositionInRole;JLorg/modelix/model/api/IConceptReference;)V
+	public final fun getChildId ()J
+	public final fun getConcept ()Lorg/modelix/model/api/IConceptReference;
+	public fun toString ()Ljava/lang/String;
+	public final fun withConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/operations/AddNewChildOp;
+	public fun withPosition (Lorg/modelix/model/operations/PositionInRole;)Lorg/modelix/model/operations/AddNewChildOp;
+	public synthetic fun withPosition (Lorg/modelix/model/operations/PositionInRole;)Lorg/modelix/model/operations/AddNewChildrenOp;
+}
+
+public final class org/modelix/model/operations/AddNewChildSubtreeOp : org/modelix/model/operations/AbstractOperation {
+	public fun <init> (Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/operations/PositionInRole;JLorg/modelix/model/api/IConceptReference;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public final fun decompress (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;Lkotlin/jvm/functions/Function1;)V
+	public final fun getChildId ()J
+	public final fun getConcept ()Lorg/modelix/model/api/IConceptReference;
+	public final fun getPosition ()Lorg/modelix/model/operations/PositionInRole;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getResultTreeHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun toString ()Ljava/lang/String;
+	public final fun withPosition (Lorg/modelix/model/operations/PositionInRole;)Lorg/modelix/model/operations/AddNewChildSubtreeOp;
+}
+
+public final class org/modelix/model/operations/AddNewChildSubtreeOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/AddNewChildSubtreeOp;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun getOriginalOp ()Lorg/modelix/model/operations/AddNewChildSubtreeOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun invert ()Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/AddNewChildSubtreeOp$Intend : org/modelix/model/operations/IOperationIntend {
+	public fun <init> (Lorg/modelix/model/operations/AddNewChildSubtreeOp;Lorg/modelix/model/operations/CapturedInsertPosition;)V
+	public final fun getCapturedPosition ()Lorg/modelix/model/operations/CapturedInsertPosition;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/AddNewChildSubtreeOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public class org/modelix/model/operations/AddNewChildrenOp : org/modelix/model/operations/AbstractOperation {
+	public fun <init> (Lorg/modelix/model/operations/PositionInRole;[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public final fun getChildIds ()[J
+	public final fun getConcepts ()[Lorg/modelix/model/api/IConceptReference;
+	public final fun getPosition ()Lorg/modelix/model/operations/PositionInRole;
+	public fun toString ()Ljava/lang/String;
+	public fun withPosition (Lorg/modelix/model/operations/PositionInRole;)Lorg/modelix/model/operations/AddNewChildrenOp;
+}
+
+public final class org/modelix/model/operations/AddNewChildrenOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/AddNewChildrenOp;)V
+	public fun getOriginalOp ()Lorg/modelix/model/operations/AddNewChildrenOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun invert ()Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/AddNewChildrenOp$Intend : org/modelix/model/operations/IOperationIntend {
+	public fun <init> (Lorg/modelix/model/operations/AddNewChildrenOp;Lorg/modelix/model/operations/CapturedInsertPosition;)V
+	public final fun getCapturedPosition ()Lorg/modelix/model/operations/CapturedInsertPosition;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/AddNewChildrenOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/BulkUpdateOp : org/modelix/model/operations/AbstractOperation {
+	public fun <init> (Lorg/modelix/model/lazy/KVEntryReference;J)V
+	public final fun afterApply (Lorg/modelix/model/lazy/CLTree;)Lorg/modelix/model/operations/BulkUpdateOp$Applied;
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getResultTreeHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getSubtreeRootId ()J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/BulkUpdateOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/BulkUpdateOp;Lorg/modelix/model/lazy/CLTree;)V
+	public final fun getBaseTree ()Lorg/modelix/model/lazy/CLTree;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/BulkUpdateOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun invert ()Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/BulkUpdateOp$Intend : org/modelix/model/operations/IOperationIntend {
+	public fun <init> (Lorg/modelix/model/operations/BulkUpdateOp;)V
+	public fun getOriginalOp ()Lorg/modelix/model/operations/BulkUpdateOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/CapturedInsertPosition {
+	public fun <init> (I[J)V
+	public fun <init> ([J[J)V
+	public final fun findIndex ([J)I
+	public final fun getSiblingsAfter ()[J
+	public final fun getSiblingsBefore ()[J
+}
+
+public final class org/modelix/model/operations/DeleteNodeOp : org/modelix/model/operations/AbstractOperation, org/modelix/model/operations/IOperationIntend {
+	public fun <init> (J)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public final fun getChildId ()J
+	public fun getOriginalOp ()Lorg/modelix/model/operations/DeleteNodeOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/DeleteNodeOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/DeleteNodeOp;Lorg/modelix/model/operations/PositionInRole;Lorg/modelix/model/api/IConceptReference;Ljava/util/Map;Ljava/util/Map;)V
+	public final fun getConcept ()Lorg/modelix/model/api/IConceptReference;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/DeleteNodeOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public final fun getPosition ()Lorg/modelix/model/operations/PositionInRole;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getReferences ()Ljava/util/Map;
+	public fun invert ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/operations/IAppliedOperation {
+	public abstract fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public abstract fun invert ()Ljava/util/List;
+}
+
+public abstract interface class org/modelix/model/operations/IOperation {
+	public abstract fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public abstract fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public abstract fun getReferencedEntries ()Ljava/util/List;
+}
+
+public abstract interface class org/modelix/model/operations/IOperationIntend {
+	public abstract fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public abstract fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/MoveNodeOp : org/modelix/model/operations/AbstractOperation {
+	public fun <init> (JLorg/modelix/model/operations/PositionInRole;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public final fun getChildId ()J
+	public final fun getTargetPosition ()Lorg/modelix/model/operations/PositionInRole;
+	public fun toString ()Ljava/lang/String;
+	public final fun withPos (Lorg/modelix/model/operations/PositionInRole;)Lorg/modelix/model/operations/MoveNodeOp;
+}
+
+public final class org/modelix/model/operations/MoveNodeOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/MoveNodeOp;Lorg/modelix/model/operations/PositionInRole;)V
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/MoveNodeOp;
+	public final fun getSourcePosition ()Lorg/modelix/model/operations/PositionInRole;
+	public fun invert ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/MoveNodeOp$Intend : org/modelix/model/operations/IOperationIntend {
+	public fun <init> (Lorg/modelix/model/operations/MoveNodeOp;Lorg/modelix/model/operations/CapturedInsertPosition;)V
+	public final fun getCapturedTargetPosition ()Lorg/modelix/model/operations/CapturedInsertPosition;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/MoveNodeOp;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/NoOp : org/modelix/model/operations/AbstractOperation, org/modelix/model/operations/IAppliedOperation, org/modelix/model/operations/IOperationIntend {
+	public fun <init> ()V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public synthetic fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/NoOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/NoOp;
+	public fun invert ()Ljava/util/List;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/OTBranch : org/modelix/model/api/IBranch {
+	public fun <init> (Lorg/modelix/model/api/IBranch;Lorg/modelix/model/api/IIdGenerator;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun addListener (Lorg/modelix/model/api/IBranchListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun computeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun computeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getId ()Ljava/lang/String;
+	public final fun getOperationsAndTree ()Lkotlin/Pair;
+	public final fun getPendingChanges ()Lkotlin/Pair;
+	public fun getReadTransaction ()Lorg/modelix/model/api/IReadTransaction;
+	public fun getTransaction ()Lorg/modelix/model/api/ITransaction;
+	public fun getWriteTransaction ()Lorg/modelix/model/api/IWriteTransaction;
+	public final fun isInBulkMode ()Z
+	public final fun operationApplied (Lorg/modelix/model/operations/IAppliedOperation;)V
+	public fun removeListener (Lorg/modelix/model/api/IBranchListener;)V
+	public final fun runBulkUpdate (JLkotlin/jvm/functions/Function0;)V
+	public static synthetic fun runBulkUpdate$default (Lorg/modelix/model/operations/OTBranch;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public fun runRead (Lkotlin/jvm/functions/Function0;)V
+	public fun runWrite (Lkotlin/jvm/functions/Function0;)V
+	public final fun wrap (Lorg/modelix/model/api/ITransaction;)Lorg/modelix/model/api/ITransaction;
+	public final fun wrap (Lorg/modelix/model/api/IWriteTransaction;)Lorg/modelix/model/api/IWriteTransaction;
+}
+
+public final class org/modelix/model/operations/OTWriteTransaction : org/modelix/model/ITransactionWrapper, org/modelix/model/api/IWriteTransaction {
+	public fun <init> (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/operations/OTBranch;Lorg/modelix/model/api/IIdGenerator;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConcept;)V
+	public fun addNewChild (JLjava/lang/String;IJLorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConcept;)J
+	public fun addNewChild (JLjava/lang/String;ILorg/modelix/model/api/IConceptReference;)J
+	public fun addNewChildren (JLjava/lang/String;I[J[Lorg/modelix/model/api/IConceptReference;)V
+	public fun addNewChildren (JLjava/lang/String;I[Lorg/modelix/model/api/IConceptReference;)[J
+	public final fun apply (Lorg/modelix/model/operations/IOperation;)V
+	public fun containsNode (J)Z
+	public fun deleteNode (J)V
+	public fun getAllChildren (J)Ljava/lang/Iterable;
+	public fun getBranch ()Lorg/modelix/model/api/IBranch;
+	public fun getChildren (JLjava/lang/String;)Ljava/lang/Iterable;
+	public fun getConcept (J)Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference (J)Lorg/modelix/model/api/IConceptReference;
+	public fun getParent (J)J
+	public fun getProperty (JLjava/lang/String;)Ljava/lang/String;
+	public fun getPropertyRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceRoles (J)Ljava/lang/Iterable;
+	public fun getReferenceTarget (JLjava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRole (J)Ljava/lang/String;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun getTree ()Lorg/modelix/model/api/ITree;
+	public fun getUserObject (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun moveChild (JLjava/lang/String;IJ)V
+	public fun putUserObject (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun setProperty (JLjava/lang/String;Ljava/lang/String;)V
+	public fun setReferenceTarget (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun setTree (Lorg/modelix/model/api/ITree;)V
+	public fun unwrap ()Lorg/modelix/model/api/ITransaction;
+}
+
+public final class org/modelix/model/operations/OTWriteTransactionKt {
+	public static final fun applyOperation (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/operations/IOperation;)V
+}
+
+public final class org/modelix/model/operations/PositionInRole {
+	public fun <init> (JLjava/lang/String;I)V
+	public fun <init> (Lorg/modelix/model/operations/RoleInNode;I)V
+	public final fun component1 ()Lorg/modelix/model/operations/RoleInNode;
+	public final fun component2 ()I
+	public final fun copy (Lorg/modelix/model/operations/RoleInNode;I)Lorg/modelix/model/operations/PositionInRole;
+	public static synthetic fun copy$default (Lorg/modelix/model/operations/PositionInRole;Lorg/modelix/model/operations/RoleInNode;IILjava/lang/Object;)Lorg/modelix/model/operations/PositionInRole;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getNodeId ()J
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getRoleInNode ()Lorg/modelix/model/operations/RoleInNode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun withIndex (I)Lorg/modelix/model/operations/PositionInRole;
+}
+
+public final class org/modelix/model/operations/RevertToOp : org/modelix/model/operations/AbstractOperation {
+	public fun <init> (Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public final fun getLatestKnownVersionRef ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getVersionToRevertToRef ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/RevertToOp$Applied : org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/RevertToOp;Ljava/util/List;)V
+	public final fun getAppliedOps ()Ljava/util/List;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun invert ()Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/RevertToOp$Intend : org/modelix/model/operations/IOperationIntend {
+	public fun <init> (Lorg/modelix/model/operations/RevertToOp;Ljava/util/List;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public final fun getIntends ()Ljava/util/List;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/RoleInNode {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lorg/modelix/model/operations/RoleInNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/operations/RoleInNode;JLjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/operations/RoleInNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()J
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/SetPropertyOp : org/modelix/model/operations/AbstractOperation, org/modelix/model/operations/IOperationIntend {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public synthetic fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/SetPropertyOp;
+	public final fun getNodeId ()J
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/SetPropertyOp;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/SetPropertyOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/SetPropertyOp;Ljava/lang/String;)V
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/SetPropertyOp;
+	public fun invert ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/SetReferenceOp : org/modelix/model/operations/AbstractOperation, org/modelix/model/operations/IOperationIntend {
+	public fun <init> (JLjava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public synthetic fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/SetReferenceOp;
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/SetReferenceOp;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getSourceId ()J
+	public final fun getTarget ()Lorg/modelix/model/api/INodeReference;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+	public final fun withTarget (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/operations/SetReferenceOp;
+}
+
+public final class org/modelix/model/operations/SetReferenceOp$Applied : org/modelix/model/operations/AbstractOperation$Applied, org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/SetReferenceOp;Lorg/modelix/model/api/INodeReference;)V
+	public synthetic fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/SetReferenceOp;
+	public fun invert ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/UndoOp : org/modelix/model/operations/AbstractOperation {
+	public fun <init> (Lorg/modelix/model/lazy/KVEntryReference;)V
+	public fun apply (Lorg/modelix/model/api/IWriteTransaction;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IAppliedOperation;
+	public fun captureIntend (Lorg/modelix/model/api/ITree;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/operations/IOperationIntend;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getVersionHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/operations/UndoOp$Applied : org/modelix/model/operations/IAppliedOperation {
+	public fun <init> (Lorg/modelix/model/operations/UndoOp;Ljava/util/List;)V
+	public final fun getAppliedOps ()Ljava/util/List;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public fun invert ()Ljava/util/List;
+}
+
+public final class org/modelix/model/operations/UndoOp$Intend : org/modelix/model/operations/IOperationIntend {
+	public fun <init> (Lorg/modelix/model/operations/UndoOp;Ljava/util/List;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)V
+	public final fun getIntends ()Ljava/util/List;
+	public fun getOriginalOp ()Lorg/modelix/model/operations/IOperation;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun restoreIntend (Lorg/modelix/model/api/ITree;)Ljava/util/List;
+}
+
+public final class org/modelix/model/persistent/CPHamtInternal : org/modelix/model/persistent/CPHamtNode {
+	public static final field Companion Lorg/modelix/model/persistent/CPHamtInternal$Companion;
+	public fun <init> (I[Lorg/modelix/model/lazy/KVEntryReference;)V
+	public fun calculateSize (Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun deleteChild (ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun get (JILorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getBitmap ()I
+	public final fun getChildren ()[Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getData ()Lorg/modelix/model/persistent/CPHamtInternal;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public fun put (JLorg/modelix/model/lazy/KVEntryReference;ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun remove (JILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun serialize ()Ljava/lang/String;
+	public final fun setChild (ILorg/modelix/model/persistent/CPHamtNode;ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun visitChanges (Lorg/modelix/model/persistent/CPHamtNode;ILorg/modelix/model/persistent/CPHamtNode$IChangeVisitor;Lorg/modelix/model/lazy/IBulkQuery;)V
+	public fun visitEntries (Lorg/modelix/model/lazy/IBulkQuery;Lkotlin/jvm/functions/Function2;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+}
+
+public final class org/modelix/model/persistent/CPHamtInternal$Companion {
+	public final fun create (I[Lorg/modelix/model/lazy/KVEntryReference;)Lorg/modelix/model/persistent/CPHamtInternal;
+	public final fun create (JLorg/modelix/model/lazy/KVEntryReference;ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public final fun createEmpty ()Lorg/modelix/model/persistent/CPHamtInternal;
+	public final fun replace (Lorg/modelix/model/persistent/CPHamtSingle;)Lorg/modelix/model/persistent/CPHamtInternal;
+}
+
+public final class org/modelix/model/persistent/CPHamtLeaf : org/modelix/model/persistent/CPHamtNode {
+	public static final field Companion Lorg/modelix/model/persistent/CPHamtLeaf$Companion;
+	public fun <init> (JLorg/modelix/model/lazy/KVEntryReference;)V
+	public fun calculateSize (Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun get (JILorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getKey ()J
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getValue ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun put (JLorg/modelix/model/lazy/KVEntryReference;ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun remove (JILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun serialize ()Ljava/lang/String;
+	public fun visitChanges (Lorg/modelix/model/persistent/CPHamtNode;ILorg/modelix/model/persistent/CPHamtNode$IChangeVisitor;Lorg/modelix/model/lazy/IBulkQuery;)V
+	public fun visitEntries (Lorg/modelix/model/lazy/IBulkQuery;Lkotlin/jvm/functions/Function2;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+}
+
+public final class org/modelix/model/persistent/CPHamtLeaf$Companion {
+	public final fun create (JLorg/modelix/model/lazy/KVEntryReference;)Lorg/modelix/model/persistent/CPHamtLeaf;
+}
+
+public abstract class org/modelix/model/persistent/CPHamtNode : org/modelix/model/persistent/IKVValue {
+	public static final field BITS_PER_LEVEL I
+	public static final field Companion Lorg/modelix/model/persistent/CPHamtNode$Companion;
+	public static final field ENTRIES_PER_LEVEL I
+	public static final field LEVEL_MASK J
+	public static final field MAX_BITS I
+	public static final field MAX_LEVELS I
+	public static final field MAX_SHIFT I
+	public fun <init> ()V
+	public abstract fun calculateSize (Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	protected final fun createEmptyNode ()Lorg/modelix/model/persistent/CPHamtNode;
+	public static final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPHamtNode;
+	public abstract fun get (JILorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun get (JLorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun get (JLorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getAll (Ljava/lang/Iterable;Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public fun isWritten ()Z
+	public abstract fun put (JLorg/modelix/model/lazy/KVEntryReference;ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public final fun put (JLorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public final fun put (Lorg/modelix/model/persistent/CPNode;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public abstract fun remove (JILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public final fun remove (JLorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public final fun remove (Lorg/modelix/model/persistent/CPNode;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun setWritten (Z)V
+	public abstract fun visitChanges (Lorg/modelix/model/persistent/CPHamtNode;ILorg/modelix/model/persistent/CPHamtNode$IChangeVisitor;Lorg/modelix/model/lazy/IBulkQuery;)V
+	public final fun visitChanges (Lorg/modelix/model/persistent/CPHamtNode;Lorg/modelix/model/persistent/CPHamtNode$IChangeVisitor;Lorg/modelix/model/lazy/IBulkQuery;)V
+	public abstract fun visitEntries (Lorg/modelix/model/lazy/IBulkQuery;Lkotlin/jvm/functions/Function2;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+}
+
+public final class org/modelix/model/persistent/CPHamtNode$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPHamtNode;
+	public final fun getDESERIALIZER ()Lkotlin/jvm/functions/Function1;
+	public final fun indexFromKey (JI)I
+	public final fun levelBits (JI)I
+}
+
+public abstract interface class org/modelix/model/persistent/CPHamtNode$IChangeVisitor {
+	public abstract fun entryAdded (JLorg/modelix/model/lazy/KVEntryReference;)V
+	public abstract fun entryChanged (JLorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;)V
+	public abstract fun entryRemoved (JLorg/modelix/model/lazy/KVEntryReference;)V
+	public abstract fun visitChangesOnly ()Z
+}
+
+public final class org/modelix/model/persistent/CPHamtSingle : org/modelix/model/persistent/CPHamtNode {
+	public static final field Companion Lorg/modelix/model/persistent/CPHamtSingle$Companion;
+	public fun <init> (IJLorg/modelix/model/lazy/KVEntryReference;)V
+	public fun calculateSize (Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public fun get (JILorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getBits ()J
+	public final fun getChild ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getChild (Lorg/modelix/model/lazy/IBulkQuery;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun getNumLevels ()I
+	public fun getReferencedEntries ()Ljava/util/List;
+	public fun put (JLorg/modelix/model/lazy/KVEntryReference;ILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun remove (JILorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+	public fun serialize ()Ljava/lang/String;
+	public final fun splitOneLevel ()Lorg/modelix/model/persistent/CPHamtSingle;
+	public fun visitChanges (Lorg/modelix/model/persistent/CPHamtNode;ILorg/modelix/model/persistent/CPHamtNode$IChangeVisitor;Lorg/modelix/model/lazy/IBulkQuery;)V
+	public fun visitEntries (Lorg/modelix/model/lazy/IBulkQuery;Lkotlin/jvm/functions/Function2;)Lorg/modelix/model/lazy/IBulkQuery$Value;
+	public final fun withNewChild (Lorg/modelix/model/persistent/CPHamtNode;)Lorg/modelix/model/persistent/CPHamtSingle;
+}
+
+public final class org/modelix/model/persistent/CPHamtSingle$Companion {
+	public final fun maskForLevels (I)J
+	public final fun replace (Lorg/modelix/model/persistent/CPHamtInternal;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtSingle;
+	public final fun replaceIfSingleChild (Lorg/modelix/model/persistent/CPHamtInternal;Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/persistent/CPHamtNode;
+}
+
+public final class org/modelix/model/persistent/CPNode : org/modelix/model/persistent/IKVValue {
+	public static final field Companion Lorg/modelix/model/persistent/CPNode$Companion;
+	public synthetic fun <init> (JLjava/lang/String;JLjava/lang/String;[J[Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;[Lorg/modelix/model/persistent/CPNodeRef;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (JLjava/lang/String;JLjava/lang/String;[J[Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;[Lorg/modelix/model/persistent/CPNodeRef;)Lorg/modelix/model/persistent/CPNode;
+	public static final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPNode;
+	public final fun getChildId (I)J
+	public final fun getChildrenIdArray ()[J
+	public final fun getChildrenIds ()Ljava/lang/Iterable;
+	public final fun getChildrenSize ()I
+	public final fun getConcept ()Ljava/lang/String;
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getParentId ()J
+	public final fun getPropertyRoles ()[Ljava/lang/String;
+	public final fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getPropertyValues ()[Ljava/lang/String;
+	public final fun getReferenceRoles ()[Ljava/lang/String;
+	public final fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/persistent/CPNodeRef;
+	public final fun getReferenceTargets ()[Lorg/modelix/model/persistent/CPNodeRef;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getRoleInParent ()Ljava/lang/String;
+	public fun isWritten ()Z
+	public fun serialize ()Ljava/lang/String;
+	public fun setWritten (Z)V
+	public final fun withPropertyValue (Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/persistent/CPNode;
+	public final fun withReferenceTarget (Ljava/lang/String;Lorg/modelix/model/persistent/CPNodeRef;)Lorg/modelix/model/persistent/CPNode;
+}
+
+public final class org/modelix/model/persistent/CPNode$Companion {
+	public final fun create (JLjava/lang/String;JLjava/lang/String;[J[Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;[Lorg/modelix/model/persistent/CPNodeRef;)Lorg/modelix/model/persistent/CPNode;
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPNode;
+	public final fun getDESERIALIZER ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract class org/modelix/model/persistent/CPNodeRef {
+	public static final field Companion Lorg/modelix/model/persistent/CPNodeRef$Companion;
+	public abstract fun getElementId ()J
+	public abstract fun getTreeId ()Ljava/lang/String;
+	public abstract fun isGlobal ()Z
+	public abstract fun isLocal ()Z
+}
+
+public final class org/modelix/model/persistent/CPNodeRef$Companion {
+	public final fun foreign (Ljava/lang/String;)Lorg/modelix/model/persistent/CPNodeRef;
+	public final fun fromString (Ljava/lang/String;)Lorg/modelix/model/persistent/CPNodeRef;
+	public final fun global (Ljava/lang/String;J)Lorg/modelix/model/persistent/CPNodeRef;
+	public final fun local (J)Lorg/modelix/model/persistent/CPNodeRef;
+}
+
+public final class org/modelix/model/persistent/CPNodeRef$ForeignRef : org/modelix/model/persistent/CPNodeRef {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/persistent/CPNodeRef$ForeignRef;
+	public static synthetic fun copy$default (Lorg/modelix/model/persistent/CPNodeRef$ForeignRef;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/persistent/CPNodeRef$ForeignRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getElementId ()J
+	public final fun getSerializedRef ()Ljava/lang/String;
+	public fun getTreeId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isGlobal ()Z
+	public fun isLocal ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/persistent/CPOperationsList : org/modelix/model/persistent/IKVValue {
+	public static final field Companion Lorg/modelix/model/persistent/CPOperationsList$Companion;
+	public fun <init> ([Lorg/modelix/model/operations/IOperation;)V
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public final fun getOperations ()[Lorg/modelix/model/operations/IOperation;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public fun isWritten ()Z
+	public fun serialize ()Ljava/lang/String;
+	public fun setWritten (Z)V
+}
+
+public final class org/modelix/model/persistent/CPOperationsList$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPOperationsList;
+	public final fun getDESERIALIZER ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class org/modelix/model/persistent/CPTree : org/modelix/model/persistent/IKVValue {
+	public static final field Companion Lorg/modelix/model/persistent/CPTree$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/lazy/KVEntryReference;Z)V
+	public static final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPTree;
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIdToHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getUsesRoleIds ()Z
+	public fun isWritten ()Z
+	public fun serialize ()Ljava/lang/String;
+	public final fun setIdToHash (Lorg/modelix/model/lazy/KVEntryReference;)V
+	public fun setWritten (Z)V
+}
+
+public final class org/modelix/model/persistent/CPTree$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPTree;
+	public final fun getDESERIALIZER ()Lkotlin/jvm/functions/Function1;
+	public final fun getNAMED_BASED_PERSISTENCE_VERSION ()I
+	public final fun getPERSISTENCE_VERSION ()I
+}
+
+public final class org/modelix/model/persistent/CPVersion : org/modelix/model/persistent/IKVValue {
+	public static final field Companion Lorg/modelix/model/persistent/CPVersion$Companion;
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;Lorg/modelix/model/lazy/KVEntryReference;[Lorg/modelix/model/operations/IOperation;Lorg/modelix/model/lazy/KVEntryReference;I)V
+	public final fun getAuthor ()Ljava/lang/String;
+	public final fun getBaseVersion ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public fun getHash ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getMergedVersion1 ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getMergedVersion2 ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getNumberOfOperations ()I
+	public final fun getOperations ()[Lorg/modelix/model/operations/IOperation;
+	public final fun getOperationsHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getOriginalVersion ()Lorg/modelix/model/lazy/KVEntryReference;
+	public final fun getPreviousVersion ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun getReferencedEntries ()Ljava/util/List;
+	public final fun getTime ()Ljava/lang/String;
+	public final fun getTreeHash ()Lorg/modelix/model/lazy/KVEntryReference;
+	public fun isWritten ()Z
+	public fun serialize ()Ljava/lang/String;
+	public fun setWritten (Z)V
+}
+
+public final class org/modelix/model/persistent/CPVersion$Companion {
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/persistent/CPVersion;
+	public final fun getDESERIALIZER ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class org/modelix/model/persistent/HashUtil {
+	public static final field INSTANCE Lorg/modelix/model/persistent/HashUtil;
+	public final fun checkObjectHash (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun checkObjectHashes (Ljava/util/Map;)V
+	public final fun extractSha256 (Ljava/lang/String;)Ljava/lang/Iterable;
+	public final fun getHASH_PATTERN ()Lkotlin/text/Regex;
+	public final fun isSha256 (Ljava/lang/String;)Z
+	public final fun sha256 (Ljava/lang/String;)Ljava/lang/String;
+	public final fun sha256asByteArray (Ljava/lang/String;)[B
+}
+
+public abstract interface class org/modelix/model/persistent/IKVValue {
+	public abstract fun getDeserializer ()Lkotlin/jvm/functions/Function1;
+	public abstract fun getHash ()Ljava/lang/String;
+	public abstract fun getReferencedEntries ()Ljava/util/List;
+	public abstract fun isWritten ()Z
+	public abstract fun serialize ()Ljava/lang/String;
+	public abstract fun setWritten (Z)V
+}
+
+public class org/modelix/model/persistent/MapBaseStore : org/modelix/model/persistent/MapBasedStore {
+	public fun <init> ()V
+}
+
+public class org/modelix/model/persistent/MapBasedStore : org/modelix/model/IKeyValueStore {
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public final fun getEntries ()Ljava/lang/Iterable;
+	public fun getPendingSize ()I
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun newBulkQuery (Lorg/modelix/model/lazy/IDeserializingKeyValueStore;)Lorg/modelix/model/lazy/IBulkQuery;
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public fun putAll (Ljava/util/Map;)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public final class org/modelix/model/persistent/OperationSerializer {
+	public static final field Companion Lorg/modelix/model/persistent/OperationSerializer$Companion;
+	public final fun deserialize (Ljava/lang/String;)Lorg/modelix/model/operations/IOperation;
+	public final fun registerSerializer (Lkotlin/reflect/KClass;Lorg/modelix/model/persistent/OperationSerializer$Serializer;)V
+	public final fun serialize (Lorg/modelix/model/operations/IOperation;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/persistent/OperationSerializer$Companion {
+	public final fun deserializeConcept (Ljava/lang/String;)Lorg/modelix/model/api/IConceptReference;
+	public final fun deserializeReference (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public final fun getINSTANCE ()Lorg/modelix/model/persistent/OperationSerializer;
+	public final fun serializeConcept (Lorg/modelix/model/api/IConceptReference;)Ljava/lang/String;
+	public final fun serializeReference (Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public abstract interface class org/modelix/model/persistent/OperationSerializer$Serializer {
+	public abstract fun deserialize (Ljava/lang/String;)Lorg/modelix/model/operations/IOperation;
+	public fun genericSerialize (Ljava/lang/Object;)Ljava/lang/String;
+	public abstract fun serialize (Lorg/modelix/model/operations/IOperation;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/persistent/OperationSerializer$Serializer$DefaultImpls {
+	public static fun genericSerialize (Lorg/modelix/model/persistent/OperationSerializer$Serializer;Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/persistent/PlatformSpecificHashUtil {
+	public static final field INSTANCE Lorg/modelix/model/persistent/PlatformSpecificHashUtil;
+	public final fun base64encode ([B)Ljava/lang/String;
+	public final fun sha256asByteArray (Ljava/lang/String;)[B
+}
+
+public final class org/modelix/model/persistent/Separators {
+	public static final field INSTANCE Lorg/modelix/model/persistent/Separators;
+	public static final field LEVEL1 Ljava/lang/String;
+	public static final field LEVEL2 Ljava/lang/String;
+	public static final field LEVEL3 Ljava/lang/String;
+	public static final field LEVEL4 Ljava/lang/String;
+	public static final field MAPPING Ljava/lang/String;
+	public static final field OPS Ljava/lang/String;
+	public static final field OP_PARTS Ljava/lang/String;
+}
+
+public final class org/modelix/model/persistent/SerializationUtil {
+	public static final field INSTANCE Lorg/modelix/model/persistent/SerializationUtil;
+	public final fun escape (Ljava/lang/String;)Ljava/lang/String;
+	public final fun intFromHex (Ljava/lang/String;)I
+	public final fun intToHex (I)Ljava/lang/String;
+	public final fun longFromHex (Ljava/lang/String;)J
+	public final fun longToHex (J)Ljava/lang/String;
+	public final fun unescape (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/persistent/SerializationUtilKt {
+	public static final fun emptyStringAsNull (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun nullAsEmptyString (Ljava/lang/String;)Ljava/lang/String;
+}
+

--- a/model-server-api/api/model-server-api.api
+++ b/model-server-api/api/model-server-api.api
@@ -1,0 +1,1290 @@
+public final class org/modelix/model/server/api/AddNewChildNodeOpData : org/modelix/model/server/api/OperationData {
+	public static final field Companion Lorg/modelix/model/server/api/AddNewChildNodeOpData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/AddNewChildNodeOpData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/AddNewChildNodeOpData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/AddNewChildNodeOpData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildId ()Ljava/lang/String;
+	public final fun getConcept ()Ljava/lang/String;
+	public final fun getIndex ()I
+	public final fun getParentNode ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/OperationData;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/AddNewChildNodeOpData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/AddNewChildNodeOpData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/AddNewChildNodeOpData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/AddNewChildNodeOpData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/AddNewChildNodeOpData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/AllChildrenBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> ()V
+	public fun build ()Lorg/modelix/model/server/api/QueryAllChildren;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/AncestorsBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> ()V
+	public fun build ()Lorg/modelix/model/server/api/QueryAncestors;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/AndFilter : org/modelix/model/server/api/LogicalOperatorFilter {
+	public static final field Companion Lorg/modelix/model/server/api/AndFilter$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/modelix/model/server/api/AndFilter;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/AndFilter;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/AndFilter;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/AndFilter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/AndFilter$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/AndFilter;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/AndFilter;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/AndFilter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ByIdBuilder : org/modelix/model/server/api/RootQueryBuilder {
+	public fun <init> (Ljava/lang/String;)V
+	public fun build ()Lorg/modelix/model/server/api/QueryById;
+	public synthetic fun build ()Lorg/modelix/model/server/api/RootQuery;
+	public final fun getId ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/ChildrenBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> (Ljava/lang/String;)V
+	public fun build ()Lorg/modelix/model/server/api/QueryChildren;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/ContainsOperator : org/modelix/model/server/api/StringOperator {
+	public static final field Companion Lorg/modelix/model/server/api/ContainsOperator$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/ContainsOperator;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/ContainsOperator;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/ContainsOperator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSubstring ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/ContainsOperator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/ContainsOperator$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/ContainsOperator;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/ContainsOperator;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ContainsOperator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/DeleteNodeOpData : org/modelix/model/server/api/OperationData {
+	public static final field Companion Lorg/modelix/model/server/api/DeleteNodeOpData$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/DeleteNodeOpData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/DeleteNodeOpData;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/DeleteNodeOpData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/OperationData;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/DeleteNodeOpData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/DeleteNodeOpData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/DeleteNodeOpData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/DeleteNodeOpData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/DeleteNodeOpData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/DescendantsBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> ()V
+	public fun build ()Lorg/modelix/model/server/api/QueryDescendants;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/EndsWithOperator : org/modelix/model/server/api/StringOperator {
+	public static final field Companion Lorg/modelix/model/server/api/EndsWithOperator$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/EndsWithOperator;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/EndsWithOperator;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/EndsWithOperator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSuffix ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/EndsWithOperator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/EndsWithOperator$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/EndsWithOperator;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/EndsWithOperator;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/EndsWithOperator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/EqualsOperator : org/modelix/model/server/api/StringOperator {
+	public static final field Companion Lorg/modelix/model/server/api/EqualsOperator$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/EqualsOperator;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/EqualsOperator;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/EqualsOperator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/EqualsOperator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/EqualsOperator$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/EqualsOperator;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/EqualsOperator;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/EqualsOperator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ExceptionData {
+	public static final field Companion Lorg/modelix/model/server/api/ExceptionData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lorg/modelix/model/server/api/ExceptionData;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lorg/modelix/model/server/api/ExceptionData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun allMessages ()Lkotlin/sequences/Sequence;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lorg/modelix/model/server/api/ExceptionData;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lorg/modelix/model/server/api/ExceptionData;)Lorg/modelix/model/server/api/ExceptionData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/ExceptionData;Ljava/lang/String;Ljava/util/List;Lorg/modelix/model/server/api/ExceptionData;ILjava/lang/Object;)Lorg/modelix/model/server/api/ExceptionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCause ()Lorg/modelix/model/server/api/ExceptionData;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStacktrace ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/ExceptionData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/ExceptionData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/ExceptionData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/ExceptionData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ExceptionData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/Filter {
+	public static final field Companion Lorg/modelix/model/server/api/Filter$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lorg/modelix/model/server/api/Filter;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/model/server/api/Filter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/FilterByConceptId : org/modelix/model/server/api/Filter {
+	public static final field Companion Lorg/modelix/model/server/api/FilterByConceptId$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/FilterByConceptId;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/FilterByConceptId;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/FilterByConceptId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConceptUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/FilterByConceptId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/FilterByConceptId$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/FilterByConceptId;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/FilterByConceptId;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/FilterByConceptId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/FilterByConceptLongName : org/modelix/model/server/api/Filter {
+	public static final field Companion Lorg/modelix/model/server/api/FilterByConceptLongName$Companion;
+	public fun <init> (Lorg/modelix/model/server/api/StringOperator;)V
+	public final fun component1 ()Lorg/modelix/model/server/api/StringOperator;
+	public final fun copy (Lorg/modelix/model/server/api/StringOperator;)Lorg/modelix/model/server/api/FilterByConceptLongName;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/FilterByConceptLongName;Lorg/modelix/model/server/api/StringOperator;ILjava/lang/Object;)Lorg/modelix/model/server/api/FilterByConceptLongName;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperator ()Lorg/modelix/model/server/api/StringOperator;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/FilterByConceptLongName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/FilterByConceptLongName$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/FilterByConceptLongName;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/FilterByConceptLongName;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/FilterByConceptLongName$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/FilterByProperty : org/modelix/model/server/api/Filter {
+	public static final field Companion Lorg/modelix/model/server/api/FilterByProperty$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/model/server/api/StringOperator;)V
+	public final fun getOperator ()Lorg/modelix/model/server/api/StringOperator;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/FilterByProperty$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/FilterByProperty$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/FilterByProperty;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/FilterByProperty;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/FilterByProperty$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public class org/modelix/model/server/api/FilterListBuilder {
+	public fun <init> ()V
+	protected final fun addFilter (Lorg/modelix/model/server/api/Filter;)V
+	public final fun and (Lkotlin/jvm/functions/Function1;)V
+	protected final fun getFilters ()Ljava/util/ArrayList;
+	public final fun not (Lkotlin/jvm/functions/Function1;)V
+	public final fun or (Lkotlin/jvm/functions/Function1;)V
+	public final fun whereConcept (Ljava/lang/String;)V
+	public final fun whereConceptName ()Lorg/modelix/model/server/api/FilterListBuilder$StringFilterBuilder;
+	public final fun whereProperty (Ljava/lang/String;)Lorg/modelix/model/server/api/FilterListBuilder$StringFilterBuilder;
+}
+
+public final class org/modelix/model/server/api/FilterListBuilder$StringFilterBuilder {
+	public fun <init> (Lorg/modelix/model/server/api/FilterListBuilder;Lkotlin/jvm/functions/Function1;)V
+	public final fun contains (Ljava/lang/String;)V
+	public final fun endsWith (Ljava/lang/String;)V
+	public final fun equalTo (Ljava/lang/String;)V
+	public final fun getFilterBuilder ()Lkotlin/jvm/functions/Function1;
+	public final fun isNotNull ()V
+	public final fun isNull ()V
+	public final fun matches (Lkotlin/text/Regex;)V
+	public final fun startsWith (Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/server/api/IsNotNullOperator : org/modelix/model/server/api/StringOperator {
+	public static final field INSTANCE Lorg/modelix/model/server/api/IsNotNullOperator;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/IsNullOperator : org/modelix/model/server/api/StringOperator {
+	public static final field INSTANCE Lorg/modelix/model/server/api/IsNullOperator;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/LogicalOperatorFilter : org/modelix/model/server/api/Filter {
+	public abstract fun getFilters ()Ljava/util/List;
+}
+
+public final class org/modelix/model/server/api/MatchesRegexOperator : org/modelix/model/server/api/StringOperator {
+	public static final field Companion Lorg/modelix/model/server/api/MatchesRegexOperator$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/MatchesRegexOperator;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/MatchesRegexOperator;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/MatchesRegexOperator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPattern ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/MatchesRegexOperator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/MatchesRegexOperator$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/MatchesRegexOperator;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/MatchesRegexOperator;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/MatchesRegexOperator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/MessageFromClient {
+	public static final field Companion Lorg/modelix/model/server/api/MessageFromClient$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/util/List;Lorg/modelix/model/server/api/ModelQuery;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/util/List;Lorg/modelix/model/server/api/ModelQuery;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lorg/modelix/model/server/api/ModelQuery;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Integer;Ljava/util/List;Lorg/modelix/model/server/api/ModelQuery;Ljava/lang/String;Ljava/lang/Integer;)Lorg/modelix/model/server/api/MessageFromClient;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/MessageFromClient;Ljava/lang/Integer;Ljava/util/List;Lorg/modelix/model/server/api/ModelQuery;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/modelix/model/server/api/MessageFromClient;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseChangeSet ()Ljava/lang/Integer;
+	public final fun getBaseVersionHash ()Ljava/lang/String;
+	public final fun getChangeSetId ()Ljava/lang/Integer;
+	public final fun getOperations ()Ljava/util/List;
+	public final fun getQuery ()Lorg/modelix/model/server/api/ModelQuery;
+	public fun hashCode ()I
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/MessageFromClient$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/MessageFromClient$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/MessageFromClient;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/MessageFromClient;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/MessageFromClient$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lorg/modelix/model/server/api/MessageFromClient;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/MessageFromServer {
+	public static final field Companion Lorg/modelix/model/server/api/MessageFromServer$Companion;
+	public fun <init> ()V
+	public fun <init> (Lorg/modelix/model/server/api/VersionData;Ljava/util/Map;Ljava/lang/Integer;Lorg/modelix/model/server/api/ExceptionData;)V
+	public synthetic fun <init> (Lorg/modelix/model/server/api/VersionData;Ljava/util/Map;Ljava/lang/Integer;Lorg/modelix/model/server/api/ExceptionData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/modelix/model/server/api/VersionData;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Lorg/modelix/model/server/api/ExceptionData;
+	public final fun copy (Lorg/modelix/model/server/api/VersionData;Ljava/util/Map;Ljava/lang/Integer;Lorg/modelix/model/server/api/ExceptionData;)Lorg/modelix/model/server/api/MessageFromServer;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/MessageFromServer;Lorg/modelix/model/server/api/VersionData;Ljava/util/Map;Ljava/lang/Integer;Lorg/modelix/model/server/api/ExceptionData;ILjava/lang/Object;)Lorg/modelix/model/server/api/MessageFromServer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppliedChangeSet ()Ljava/lang/Integer;
+	public final fun getException ()Lorg/modelix/model/server/api/ExceptionData;
+	public final fun getReplacedIds ()Ljava/util/Map;
+	public final fun getVersion ()Lorg/modelix/model/server/api/VersionData;
+	public fun hashCode ()I
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/MessageFromServer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/MessageFromServer$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/MessageFromServer;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/MessageFromServer;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/MessageFromServer$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lorg/modelix/model/server/api/MessageFromServer;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ModelQuery : org/modelix/model/server/api/QueryOwner {
+	public static final field Companion Lorg/modelix/model/server/api/ModelQuery$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/modelix/model/server/api/ModelQuery;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/ModelQuery;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/ModelQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun toJson ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/ModelQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/ModelQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/ModelQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/ModelQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ModelQuery$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lorg/modelix/model/server/api/ModelQuery;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ModelQueryBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/modelix/model/server/api/ModelQuery;
+	public final fun resolve (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun resolve$default (Lorg/modelix/model/server/api/ModelQueryBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun root (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/server/api/ModelQueryBuilderKt {
+	public static final fun buildModelQuery (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/ModelQuery;
+}
+
+public final class org/modelix/model/server/api/MoveNodeOpData : org/modelix/model/server/api/OperationData {
+	public static final field Companion Lorg/modelix/model/server/api/MoveNodeOpData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)Lorg/modelix/model/server/api/MoveNodeOpData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/MoveNodeOpData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/MoveNodeOpData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildId ()Ljava/lang/String;
+	public final fun getNewIndex ()I
+	public final fun getNewParentNode ()Ljava/lang/String;
+	public final fun getNewRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/OperationData;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/MoveNodeOpData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/MoveNodeOpData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/MoveNodeOpData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/MoveNodeOpData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/MoveNodeOpData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/NodeData {
+	public static final field Companion Lorg/modelix/model/server/api/NodeData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lorg/modelix/model/server/api/NodeData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/NodeData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lorg/modelix/model/server/api/NodeData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/Map;
+	public final fun getConcept ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getParent ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getReferences ()Ljava/util/Map;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/NodeData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/NodeData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/NodeData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/NodeData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/NodeData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/NodeDataKt {
+	public static final fun allReferencedIds (Lorg/modelix/model/server/api/NodeData;)Ljava/util/List;
+	public static final fun replaceChildren (Lorg/modelix/model/server/api/NodeData;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/NodeData;
+	public static final fun replaceChildren (Lorg/modelix/model/server/api/NodeData;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/NodeData;
+	public static final fun replaceContainment (Lorg/modelix/model/server/api/NodeData;Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/NodeData;
+	public static final fun replaceId (Lorg/modelix/model/server/api/NodeData;Ljava/lang/String;)Lorg/modelix/model/server/api/NodeData;
+	public static final fun replaceReferences (Lorg/modelix/model/server/api/NodeData;Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/NodeData;
+}
+
+public final class org/modelix/model/server/api/NodeUpdateData {
+	public static final field Companion Lorg/modelix/model/server/api/NodeUpdateData$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/NodeUpdateData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/Map;
+	public final fun getConcept ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getReferences ()Ljava/util/Map;
+	public final fun getTemporaryNodeId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public fun toString ()Ljava/lang/String;
+	public final fun withChildren (Ljava/lang/String;Ljava/util/List;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public final fun withConcept (Ljava/lang/String;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public final fun withProperty (Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public final fun withReference (Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/NodeUpdateData;
+}
+
+public final class org/modelix/model/server/api/NodeUpdateData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/NodeUpdateData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/NodeUpdateData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/NodeUpdateData$Companion {
+	public final fun newNode (Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public final fun nothing (Ljava/lang/String;)Lorg/modelix/model/server/api/NodeUpdateData;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/NotFilter : org/modelix/model/server/api/Filter {
+	public static final field Companion Lorg/modelix/model/server/api/NotFilter$Companion;
+	public fun <init> (Lorg/modelix/model/server/api/Filter;)V
+	public final fun component1 ()Lorg/modelix/model/server/api/Filter;
+	public final fun copy (Lorg/modelix/model/server/api/Filter;)Lorg/modelix/model/server/api/NotFilter;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/NotFilter;Lorg/modelix/model/server/api/Filter;ILjava/lang/Object;)Lorg/modelix/model/server/api/NotFilter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lorg/modelix/model/server/api/Filter;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/NotFilter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/NotFilter$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/NotFilter;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/NotFilter;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/NotFilter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/OperationData {
+	public static final field Companion Lorg/modelix/model/server/api/OperationData$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/OperationData;
+	public static final synthetic fun write$Self (Lorg/modelix/model/server/api/OperationData;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/model/server/api/OperationData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/OrFilter : org/modelix/model/server/api/LogicalOperatorFilter {
+	public static final field Companion Lorg/modelix/model/server/api/OrFilter$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/modelix/model/server/api/OrFilter;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/OrFilter;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/OrFilter;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/OrFilter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/OrFilter$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/OrFilter;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/OrFilter;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/OrFilter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ParentBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> ()V
+	public fun build ()Lorg/modelix/model/server/api/QueryParent;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/QueryAllChildren : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryAllChildren$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryAllChildren;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryAllChildren;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryAllChildren;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryAllChildren$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryAllChildren$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryAllChildren;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryAllChildren;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryAllChildren$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryAncestors : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryAncestors$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryAncestors;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryAncestors;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryAncestors;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryAncestors$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryAncestors$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryAncestors;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryAncestors;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryAncestors$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryById : org/modelix/model/server/api/RootQuery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryById$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lorg/modelix/model/server/api/QueryById;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryById;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryById;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()Ljava/lang/String;
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryById$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryById$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryById;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryById;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryById$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryChildren : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryChildren$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryChildren;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryChildren;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryChildren;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryChildren$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryChildren$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryChildren;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryChildren;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryChildren$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryDescendants : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryDescendants$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryDescendants;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryDescendants;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryDescendants;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryDescendants$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryDescendants$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryDescendants;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryDescendants;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryDescendants$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/QueryOwner {
+	public static final field Companion Lorg/modelix/model/server/api/QueryOwner$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun getQueries ()Ljava/util/List;
+	public static final synthetic fun write$Self (Lorg/modelix/model/server/api/QueryOwner;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/model/server/api/QueryOwner$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/QueryOwnerBuilder : org/modelix/model/server/api/FilterListBuilder {
+	public fun <init> ()V
+	protected final fun addSubquery (Lorg/modelix/model/server/api/Subquery;)V
+	public final fun allChildren (Lkotlin/jvm/functions/Function1;)V
+	public final fun ancestors (Lkotlin/jvm/functions/Function1;)V
+	public final fun children (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun descendants (Lkotlin/jvm/functions/Function1;)V
+	protected final fun getSubqueries ()Ljava/util/ArrayList;
+	public final fun parent (Lkotlin/jvm/functions/Function1;)V
+	public final fun reference (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun references (Lkotlin/jvm/functions/Function1;)V
+	public final fun referencesAndChildren (Lkotlin/jvm/functions/Function1;)V
+	public final fun referencesAndChildrenRecursive (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/server/api/QueryParent : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryParent$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryParent;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryParent;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryParent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryParent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryParent$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryParent;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryParent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryParent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryReference : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryReference$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryReference;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryReference$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryReference;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryReference;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryReference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryReferences : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryReferences$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryReferences;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryReferences;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryReferences;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryReferences$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryReferences$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryReferences;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryReferences;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryReferences$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryReferencesAndChildren : org/modelix/model/server/api/Subquery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryReferencesAndChildren$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/List;Ljava/util/List;)Lorg/modelix/model/server/api/QueryReferencesAndChildren;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryReferencesAndChildren;ZLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryReferencesAndChildren;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFilters ()Ljava/util/List;
+	public fun getQueries ()Ljava/util/List;
+	public final fun getRecursive ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryReferencesAndChildren$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryReferencesAndChildren$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryReferencesAndChildren;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryReferencesAndChildren;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryReferencesAndChildren$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryRootNode : org/modelix/model/server/api/RootQuery {
+	public static final field Companion Lorg/modelix/model/server/api/QueryRootNode$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/modelix/model/server/api/QueryRootNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/QueryRootNode;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/QueryRootNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getQueries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/QueryRootNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/QueryRootNode$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/QueryRootNode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/QueryRootNode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/QueryRootNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/ReferenceBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> (Ljava/lang/String;)V
+	public fun build ()Lorg/modelix/model/server/api/QueryReference;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/ReferencesAndChildrenBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> (Z)V
+	public fun build ()Lorg/modelix/model/server/api/QueryReferencesAndChildren;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/ReferencesBuilder : org/modelix/model/server/api/SubqueryBuilder {
+	public fun <init> ()V
+	public fun build ()Lorg/modelix/model/server/api/QueryReferences;
+	public synthetic fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/RootNodeBuilder : org/modelix/model/server/api/RootQueryBuilder {
+	public fun <init> ()V
+	public fun build ()Lorg/modelix/model/server/api/QueryRootNode;
+	public synthetic fun build ()Lorg/modelix/model/server/api/RootQuery;
+}
+
+public abstract class org/modelix/model/server/api/RootOrSubquery : org/modelix/model/server/api/QueryOwner {
+	public abstract fun getQueries ()Ljava/util/List;
+}
+
+public abstract class org/modelix/model/server/api/RootQuery : org/modelix/model/server/api/RootOrSubquery {
+	public static final field Companion Lorg/modelix/model/server/api/RootQuery$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun getQueries ()Ljava/util/List;
+	public static final synthetic fun write$Self (Lorg/modelix/model/server/api/RootQuery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/model/server/api/RootQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/RootQueryBuilder : org/modelix/model/server/api/QueryOwnerBuilder {
+	public abstract fun build ()Lorg/modelix/model/server/api/RootQuery;
+}
+
+public final class org/modelix/model/server/api/SetPropertyOpData : org/modelix/model/server/api/OperationData {
+	public static final field Companion Lorg/modelix/model/server/api/SetPropertyOpData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/SetPropertyOpData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/SetPropertyOpData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/SetPropertyOpData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNode ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/OperationData;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/SetPropertyOpData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/SetPropertyOpData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/SetPropertyOpData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/SetPropertyOpData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/SetPropertyOpData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/SetReferenceOpData : org/modelix/model/server/api/OperationData {
+	public static final field Companion Lorg/modelix/model/server/api/SetReferenceOpData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/model/server/api/SetReferenceOpData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/SetReferenceOpData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/SetReferenceOpData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNode ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun replaceIds (Lkotlin/jvm/functions/Function1;)Lorg/modelix/model/server/api/OperationData;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/SetReferenceOpData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/SetReferenceOpData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/SetReferenceOpData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/SetReferenceOpData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/SetReferenceOpData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/StartsWithOperator : org/modelix/model/server/api/StringOperator {
+	public static final field Companion Lorg/modelix/model/server/api/StartsWithOperator$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/server/api/StartsWithOperator;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/StartsWithOperator;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/server/api/StartsWithOperator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrefix ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/StartsWithOperator$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/StartsWithOperator$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/StartsWithOperator;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/StartsWithOperator;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/StartsWithOperator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/StringOperator {
+	public static final field Companion Lorg/modelix/model/server/api/StringOperator$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lorg/modelix/model/server/api/StringOperator;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/model/server/api/StringOperator$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/Subquery : org/modelix/model/server/api/RootOrSubquery {
+	public static final field Companion Lorg/modelix/model/server/api/Subquery$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun getFilters ()Ljava/util/List;
+	public abstract fun getQueries ()Ljava/util/List;
+	public static final synthetic fun write$Self (Lorg/modelix/model/server/api/Subquery;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/model/server/api/Subquery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/model/server/api/SubqueryBuilder : org/modelix/model/server/api/QueryOwnerBuilder {
+	public abstract fun build ()Lorg/modelix/model/server/api/Subquery;
+}
+
+public final class org/modelix/model/server/api/VersionData {
+	public static final field Companion Lorg/modelix/model/server/api/VersionData$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;)Lorg/modelix/model/server/api/VersionData;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/api/VersionData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;ILjava/lang/Object;)Lorg/modelix/model/server/api/VersionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodes ()Ljava/util/List;
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getRootNodeId ()Ljava/lang/String;
+	public final fun getUsesRoleIds ()Z
+	public final fun getVersionHash ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/VersionData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/VersionData$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/VersionData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/VersionData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/VersionData$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/VersionDataKt {
+	public static final fun merge (Lorg/modelix/model/server/api/VersionData;Lorg/modelix/model/server/api/VersionData;)Lorg/modelix/model/server/api/VersionData;
+}
+
+public final class org/modelix/model/server/api/v2/VersionDelta {
+	public static final field Companion Lorg/modelix/model/server/api/v2/VersionDelta$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBaseVersionHash ()Ljava/lang/String;
+	public final fun getObjects ()Ljava/util/Set;
+	public final fun getObjectsMap ()Ljava/util/Map;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/v2/VersionDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/api/v2/VersionDelta$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/api/v2/VersionDelta;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/api/v2/VersionDelta;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/v2/VersionDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/api/v2/VersionDeltaKt {
+	public static final fun asStream (Lorg/modelix/model/server/api/v2/VersionDelta;)Lorg/modelix/model/server/api/v2/VersionDeltaStream;
+	public static final fun toMap (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/server/api/v2/VersionDeltaStream {
+	public static final field Companion Lorg/modelix/model/server/api/v2/VersionDeltaStream$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/coroutines/flow/Flow;Lkotlin/sequences/Sequence;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/coroutines/flow/Flow;Lkotlin/sequences/Sequence;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getObjectsAsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getObjectsFlow ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getObjectsSequence ()Lkotlin/sequences/Sequence;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/api/v2/VersionDeltaStream$Companion {
+	public final fun getCONTENT_TYPE ()Lio/ktor/http/ContentType;
+}
+

--- a/model-server-lib/api/model-server-lib.api
+++ b/model-server-lib/api/model-server-lib.api
@@ -1,0 +1,78 @@
+public final class org/modelix/model/server/light/BulkModelQueryExecutorKt {
+	public static final fun execute (Lorg/modelix/model/server/api/ModelQuery;Lorg/modelix/model/api/INode;)Ljava/util/Set;
+}
+
+public final class org/modelix/model/server/light/IncrementalModelQueryExecutor {
+	public fun <init> (Lorg/modelix/model/api/INode;)V
+	public final fun getRootNode ()Lorg/modelix/model/api/INode;
+	public final fun invalidate (Ljava/util/Set;)V
+	public final fun update (Lorg/modelix/model/server/api/ModelQuery;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/model/server/light/LightModelServer {
+	public static final field Companion Lorg/modelix/model/server/light/LightModelServer$Companion;
+	public fun <init> (ILkotlin/jvm/functions/Function0;)V
+	public fun <init> (ILkotlin/jvm/functions/Function0;Ljava/util/Set;)V
+	public fun <init> (ILkotlin/jvm/functions/Function0;Ljava/util/Set;Ljava/util/List;)V
+	public synthetic fun <init> (ILkotlin/jvm/functions/Function0;Ljava/util/Set;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILorg/modelix/model/api/INode;Ljava/util/Set;Ljava/util/List;)V
+	public synthetic fun <init> (ILorg/modelix/model/api/INode;Ljava/util/Set;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIgnoredRoles ()Ljava/util/Set;
+	public final fun getPort ()I
+	public final fun getRootNode ()Lorg/modelix/model/api/INode;
+	public final fun getRootNodeProvider ()Lkotlin/jvm/functions/Function0;
+	public final fun installHandlers (Lio/ktor/server/application/Application;)V
+	public final fun nodeChanged (Lorg/modelix/model/api/INode;)V
+	public final fun sendUpdate ()V
+	public final fun start ()V
+	public final fun start (Z)V
+	public static synthetic fun start$default (Lorg/modelix/model/server/light/LightModelServer;ZILjava/lang/Object;)V
+	public final fun stop ()V
+}
+
+public final class org/modelix/model/server/light/LightModelServer$Companion {
+	public final fun builder ()Lorg/modelix/model/server/light/LightModelServerBuilder;
+}
+
+public abstract interface class org/modelix/model/server/light/LightModelServer$IHealthCheck {
+	public abstract fun getEnabledByDefault ()Z
+	public abstract fun getId ()Ljava/lang/String;
+	public fun getValidParameterNames ()Ljava/util/Set;
+	public abstract fun run (Ljava/lang/StringBuilder;)Z
+	public fun run (Ljava/lang/StringBuilder;Ljava/util/Map;)Z
+}
+
+public final class org/modelix/model/server/light/LightModelServer$IHealthCheck$DefaultImpls {
+	public static fun getValidParameterNames (Lorg/modelix/model/server/light/LightModelServer$IHealthCheck;)Ljava/util/Set;
+	public static fun run (Lorg/modelix/model/server/light/LightModelServer$IHealthCheck;Ljava/lang/StringBuilder;Ljava/util/Map;)Z
+}
+
+public final class org/modelix/model/server/light/LightModelServer$SessionData {
+	public fun <init> (Lorg/modelix/model/server/light/LightModelServer;Lio/ktor/server/websocket/DefaultWebSocketServerSession;)V
+	public final fun applyUpdate (Ljava/util/List;Ljava/lang/Integer;)Lorg/modelix/model/server/api/MessageFromServer;
+	public final fun createUpdate ()Lorg/modelix/model/server/api/VersionData;
+	public final fun createUpdateMessage ()Lorg/modelix/model/server/api/MessageFromServer;
+	public final fun getWebsocketSession ()Lio/ktor/server/websocket/DefaultWebSocketServerSession;
+	public final fun nodeChanged (Lorg/modelix/model/api/INode;)V
+	public final fun replaceQuery (Lorg/modelix/model/server/api/ModelQuery;)V
+	public final fun sendMessage (Lorg/modelix/model/server/api/MessageFromServer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun sendUpdate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/server/light/LightModelServerBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/modelix/model/server/light/LightModelServer;
+	public final fun healthCheck (Lorg/modelix/model/server/light/LightModelServer$IHealthCheck;)Lorg/modelix/model/server/light/LightModelServerBuilder;
+	public final fun ignoreRole (Lorg/modelix/model/api/IRole;)Lorg/modelix/model/server/light/LightModelServerBuilder;
+	public final fun port (I)Lorg/modelix/model/server/light/LightModelServerBuilder;
+	public final fun rootNode (Lkotlin/jvm/functions/Function0;)Lorg/modelix/model/server/light/LightModelServerBuilder;
+	public final fun rootNode (Lorg/modelix/model/api/INode;)Lorg/modelix/model/server/light/LightModelServerBuilder;
+}
+
+public final class org/modelix/model/server/light/QueryImplementationKt {
+	public static final fun apply (Lorg/modelix/model/server/api/Filter;Lorg/modelix/model/api/INode;)Z
+	public static final fun apply (Lorg/modelix/model/server/api/StringOperator;Ljava/lang/String;)Z
+	public static final fun applyFilters (Lorg/modelix/model/server/api/RootOrSubquery;Lorg/modelix/model/api/INode;)Z
+	public static final fun queryNodes (Lorg/modelix/model/server/api/RootOrSubquery;Lorg/modelix/model/api/INode;)Lkotlin/sequences/Sequence;
+}
+

--- a/model-server/api/model-server.api
+++ b/model-server/api/model-server.api
@@ -1,0 +1,1519 @@
+public final class org/modelix/api/deprecated/DefaultApiKt {
+	public static final fun DefaultApi (Lio/ktor/server/routing/Route;)V
+}
+
+public final class org/modelix/api/deprecated/Paths {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonGenerateIdsPost {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonGenerateIdsPost$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getQuantity ()Ljava/lang/Integer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonGenerateIdsPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonGenerateIdsPost$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonGenerateIdsPost;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonGenerateIdsPost;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonGenerateIdsPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonGet {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonGet$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdGet {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdGet$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getRepositoryId ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getRepositoryId ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdInitPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashPollGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdVersionHashUpdatePost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet {
+	public static final field Companion Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getConnection ()Ljava/lang/String;
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getSecWebSocketKey ()Ljava/lang/String;
+	public final fun getUpgrade ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/deprecated/Paths$jsonRepositoryIdWsGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/ContentExplorerExpandedNodes {
+	public static final field Companion Lorg/modelix/api/html/ContentExplorerExpandedNodes$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;)Lorg/modelix/api/html/ContentExplorerExpandedNodes;
+	public static synthetic fun copy$default (Lorg/modelix/api/html/ContentExplorerExpandedNodes;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lorg/modelix/api/html/ContentExplorerExpandedNodes;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpandAll ()Ljava/lang/Boolean;
+	public final fun getExpandedNodeIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/ContentExplorerExpandedNodes$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/ContentExplorerExpandedNodes$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/ContentExplorerExpandedNodes;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/ContentExplorerExpandedNodes;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/ContentExplorerExpandedNodes$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/DefaultApiKt {
+	public static final fun DefaultApi (Lio/ktor/server/routing/Route;)V
+}
+
+public final class org/modelix/api/html/Paths {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths;
+}
+
+public final class org/modelix/api/html/Paths$getContent {
+	public static final field Companion Lorg/modelix/api/html/Paths$getContent$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/html/Paths$getContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getContent$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getContent;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getContent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getContent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getContentRepositoryBranchLatest {
+	public static final field Companion Lorg/modelix/api/html/Paths$getContentRepositoryBranchLatest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/Paths$getContentRepositoryBranchLatest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getContentRepositoryBranchLatest$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getContentRepositoryBranchLatest;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getContentRepositoryBranchLatest;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getContentRepositoryBranchLatest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getHistory {
+	public static final field Companion Lorg/modelix/api/html/Paths$getHistory$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/html/Paths$getHistory$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getHistory$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getHistory;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getHistory;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getHistory$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getIndex {
+	public static final field Companion Lorg/modelix/api/html/Paths$getIndex$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/html/Paths$getIndex$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getIndex$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getIndex;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getIndex;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getIndex$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getNodeIdForVersionHash {
+	public static final field Companion Lorg/modelix/api/html/Paths$getNodeIdForVersionHash$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/Paths$getNodeIdForVersionHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getNodeIdForVersionHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getNodeIdForVersionHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getNodeIdForVersionHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getNodeIdForVersionHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getRepoAndBranch {
+	public static final field Companion Lorg/modelix/api/html/Paths$getRepoAndBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getHead ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/String;
+	public final fun getRepoId ()Ljava/lang/String;
+	public final fun getSkip ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/Paths$getRepoAndBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getRepoAndBranch$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getRepoAndBranch;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getRepoAndBranch;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getRepoAndBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getRepos {
+	public static final field Companion Lorg/modelix/api/html/Paths$getRepos$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/html/Paths$getRepos$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getRepos$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getRepos;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getRepos;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getRepos$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getVersionHash {
+	public static final field Companion Lorg/modelix/api/html/Paths$getVersionHash$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/Paths$getVersionHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$getVersionHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$getVersionHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$getVersionHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$getVersionHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$postVersionHash {
+	public static final field Companion Lorg/modelix/api/html/Paths$postVersionHash$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/api/html/ContentExplorerExpandedNodes;)V
+	public final fun getContentExplorerExpandedNodes ()Lorg/modelix/api/html/ContentExplorerExpandedNodes;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/Paths$postVersionHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$postVersionHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$postVersionHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$postVersionHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$postVersionHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$revertBranch {
+	public static final field Companion Lorg/modelix/api/html/Paths$revertBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getFrom ()Ljava/lang/String;
+	public final fun getRepoId ()Ljava/lang/String;
+	public final fun getTo ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/html/Paths$revertBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/html/Paths$revertBranch$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/html/Paths$revertBranch;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/html/Paths$revertBranch;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/html/Paths$revertBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/light/DefaultApiKt {
+	public static final fun DefaultApi (Lio/ktor/server/routing/Route;)V
+}
+
+public final class org/modelix/api/light/Paths {
+	public static final field INSTANCE Lorg/modelix/api/light/Paths;
+}
+
+public final class org/modelix/api/light/Paths$jsonV2RepositoryIdWsGet {
+	public static final field Companion Lorg/modelix/api/light/Paths$jsonV2RepositoryIdWsGet$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getConnection ()Ljava/lang/String;
+	public final fun getRepositoryId ()Ljava/lang/String;
+	public final fun getSecWebSocketKey ()Ljava/lang/String;
+	public final fun getUpgrade ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/light/Paths$jsonV2RepositoryIdWsGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/light/Paths$jsonV2RepositoryIdWsGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/light/Paths$jsonV2RepositoryIdWsGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/light/Paths$jsonV2RepositoryIdWsGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/light/Paths$jsonV2RepositoryIdWsGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/operative/DefaultApiKt {
+	public static final fun DefaultApi (Lio/ktor/server/routing/Route;)V
+}
+
+public final class org/modelix/api/operative/Paths {
+	public static final field INSTANCE Lorg/modelix/api/operative/Paths;
+}
+
+public final class org/modelix/api/operative/Paths$getMetrics {
+	public static final field Companion Lorg/modelix/api/operative/Paths$getMetrics$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/operative/Paths$getMetrics$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/operative/Paths$getMetrics$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/operative/Paths$getMetrics;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/operative/Paths$getMetrics;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/operative/Paths$getMetrics$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/DefaultApiKt {
+	public static final fun DefaultApi (Lio/ktor/server/routing/Route;)V
+}
+
+public final class org/modelix/api/public/MapItem {
+	public static final field Companion Lorg/modelix/api/public/MapItem$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/api/public/MapItem;
+	public static synthetic fun copy$default (Lorg/modelix/api/public/MapItem;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/api/public/MapItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue1 ()Ljava/lang/String;
+	public final fun getValue2 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/MapItem$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/MapItem$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/MapItem;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/MapItem;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/MapItem$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths;
+}
+
+public final class org/modelix/api/public/Paths$counterKeyPost {
+	public static final field Companion Lorg/modelix/api/public/Paths$counterKeyPost$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getKey ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$counterKeyPost$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$counterKeyPost$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$counterKeyPost;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$counterKeyPost;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$counterKeyPost$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$deleteRepository {
+	public static final field Companion Lorg/modelix/api/public/Paths$deleteRepository$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$deleteRepository$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$deleteRepository$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$deleteRepository;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$deleteRepository;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$deleteRepository$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getAllPut {
+	public static final field Companion Lorg/modelix/api/public/Paths$getAllPut$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getAllPut$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getAllPut$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getAllPut;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getAllPut;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getAllPut$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getEmailGet {
+	public static final field Companion Lorg/modelix/api/public/Paths$getEmailGet$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getEmailGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getEmailGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getEmailGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getEmailGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getEmailGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getHeaders {
+	public static final field Companion Lorg/modelix/api/public/Paths$getHeaders$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getHeaders$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getHeaders$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getHeaders;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getHeaders;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getHeaders$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getHealth {
+	public static final field Companion Lorg/modelix/api/public/Paths$getHealth$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getHealth$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getHealth$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getHealth;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getHealth;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getHealth$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getKeyGet {
+	public static final field Companion Lorg/modelix/api/public/Paths$getKeyGet$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getKey ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getKeyGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getKeyGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getKeyGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getKeyGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getKeyGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getOldestVersionHash {
+	public static final field Companion Lorg/modelix/api/public/Paths$getOldestVersionHash$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getOldestVersionHash ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getOldestVersionHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getOldestVersionHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getOldestVersionHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getOldestVersionHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getOldestVersionHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getOldestVersionHashForVersion {
+	public static final field Companion Lorg/modelix/api/public/Paths$getOldestVersionHashForVersion$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getOldestVersionHash ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getOldestVersionHashForVersion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getOldestVersionHashForVersion$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getOldestVersionHashForVersion;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getOldestVersionHashForVersion;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getOldestVersionHashForVersion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRecursivelyKeyGet {
+	public static final field Companion Lorg/modelix/api/public/Paths$getRecursivelyKeyGet$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getKey ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getRecursivelyKeyGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getRecursivelyKeyGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getRecursivelyKeyGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getRecursivelyKeyGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRecursivelyKeyGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositories {
+	public static final field Companion Lorg/modelix/api/public/Paths$getRepositories$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getRepositories$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getRepositories$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getRepositories;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getRepositories;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositories$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranch {
+	public static final field Companion Lorg/modelix/api/public/Paths$getRepositoryBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getLastKnown ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getRepositoryBranch$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getRepositoryBranch;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getRepositoryBranch;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranchHash {
+	public static final field Companion Lorg/modelix/api/public/Paths$getRepositoryBranchHash$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranchHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getRepositoryBranchHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getRepositoryBranchHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getRepositoryBranchHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranchHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranches {
+	public static final field Companion Lorg/modelix/api/public/Paths$getRepositoryBranches$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranches$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getRepositoryBranches$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getRepositoryBranches;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getRepositoryBranches;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryBranches$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryVersionHash {
+	public static final field Companion Lorg/modelix/api/public/Paths$getRepositoryVersionHash$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getLastKnown ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryVersionHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getRepositoryVersionHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getRepositoryVersionHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getRepositoryVersionHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getRepositoryVersionHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getServerId {
+	public static final field Companion Lorg/modelix/api/public/Paths$getServerId$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getServerId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getServerId$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getServerId;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getServerId;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getServerId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getUserId {
+	public static final field Companion Lorg/modelix/api/public/Paths$getUserId$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$getUserId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getUserId$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getUserId;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getUserId;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getUserId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getVersionHash {
+	public static final field Companion Lorg/modelix/api/public/Paths$getVersionHash$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getLastKnown ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$getVersionHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$getVersionHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$getVersionHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$getVersionHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$getVersionHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$initializeRepository {
+	public static final field Companion Lorg/modelix/api/public/Paths$initializeRepository$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getRepository ()Ljava/lang/String;
+	public final fun getUseRoleIds ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$initializeRepository$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$initializeRepository$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$initializeRepository;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$initializeRepository;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$initializeRepository$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$listenRepositoryBranch {
+	public static final field Companion Lorg/modelix/api/public/Paths$listenRepositoryBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getConnection ()Ljava/lang/String;
+	public final fun getLastKnown ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+	public final fun getSecWebSocketKey ()Ljava/lang/String;
+	public final fun getUpgrade ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$listenRepositoryBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$listenRepositoryBranch$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$listenRepositoryBranch;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$listenRepositoryBranch;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$listenRepositoryBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$pollKeyGet {
+	public static final field Companion Lorg/modelix/api/public/Paths$pollKeyGet$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLastKnownValue ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$pollKeyGet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$pollKeyGet$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$pollKeyGet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$pollKeyGet;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$pollKeyGet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$pollRepositoryBranch {
+	public static final field Companion Lorg/modelix/api/public/Paths$pollRepositoryBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getLastKnown ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$pollRepositoryBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$pollRepositoryBranch$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$pollRepositoryBranch;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$pollRepositoryBranch;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$pollRepositoryBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$pollRepositoryBranchHash {
+	public static final field Companion Lorg/modelix/api/public/Paths$pollRepositoryBranchHash$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getLastKnown ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$pollRepositoryBranchHash$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$pollRepositoryBranchHash$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$pollRepositoryBranchHash;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$pollRepositoryBranchHash;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$pollRepositoryBranchHash$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postGenerateClientId {
+	public static final field Companion Lorg/modelix/api/public/Paths$postGenerateClientId$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$postGenerateClientId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$postGenerateClientId$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$postGenerateClientId;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$postGenerateClientId;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postGenerateClientId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryBranch {
+	public static final field Companion Lorg/modelix/api/public/Paths$postRepositoryBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$postRepositoryBranch$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$postRepositoryBranch;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$postRepositoryBranch;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryBranchQuery {
+	public static final field Companion Lorg/modelix/api/public/Paths$postRepositoryBranchQuery$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryBranchQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$postRepositoryBranchQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$postRepositoryBranchQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$postRepositoryBranchQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryBranchQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryVersionHashQuery {
+	public static final field Companion Lorg/modelix/api/public/Paths$postRepositoryVersionHashQuery$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getRepository ()Ljava/lang/String;
+	public final fun getVersionHash ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryVersionHashQuery$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$postRepositoryVersionHashQuery$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$postRepositoryVersionHashQuery;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$postRepositoryVersionHashQuery;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$postRepositoryVersionHashQuery$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$putAllPut {
+	public static final field Companion Lorg/modelix/api/public/Paths$putAllPut$Companion;
+	public fun <init> ()V
+}
+
+public final class org/modelix/api/public/Paths$putAllPut$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$putAllPut$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$putAllPut;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$putAllPut;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$putAllPut$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$putKeyPut {
+	public static final field Companion Lorg/modelix/api/public/Paths$putKeyPut$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getKey ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$putKeyPut$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$putKeyPut$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$putKeyPut;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$putKeyPut;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$putKeyPut$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$putRepositoryObjects {
+	public static final field Companion Lorg/modelix/api/public/Paths$putRepositoryObjects$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getRepository ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/Paths$putRepositoryObjects$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/Paths$putRepositoryObjects$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/Paths$putRepositoryObjects;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/Paths$putRepositoryObjects;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/Paths$putRepositoryObjects$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/VersionDelta {
+	public static final field Companion Lorg/modelix/api/public/VersionDelta$Companion;
+	public fun <init> (Ljava/lang/String;Lorg/modelix/api/public/MapItem;Lorg/modelix/api/public/MapItem;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/modelix/api/public/MapItem;Lorg/modelix/api/public/MapItem;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/modelix/api/public/MapItem;
+	public final fun component3 ()Lorg/modelix/api/public/MapItem;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lorg/modelix/api/public/MapItem;Lorg/modelix/api/public/MapItem;Ljava/lang/String;)Lorg/modelix/api/public/VersionDelta;
+	public static synthetic fun copy$default (Lorg/modelix/api/public/VersionDelta;Ljava/lang/String;Lorg/modelix/api/public/MapItem;Lorg/modelix/api/public/MapItem;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/api/public/VersionDelta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseVersion ()Ljava/lang/String;
+	public final fun getObjects ()Lorg/modelix/api/public/MapItem;
+	public final fun getObjectsMap ()Lorg/modelix/api/public/MapItem;
+	public final fun getVersionHash ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/api/public/VersionDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/api/public/VersionDelta$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/api/public/VersionDelta;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/api/public/VersionDelta;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/api/public/VersionDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/FileConverter : com/beust/jcommander/IStringConverter {
+	public fun <init> ()V
+	public fun convert (Ljava/lang/String;)Ljava/io/File;
+	public synthetic fun convert (Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/server/Main {
+	public static final field DEFAULT_PORT I
+	public static final field INSTANCE Lorg/modelix/model/server/Main;
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/server/handlers/ContainmentData {
+	public fun <init> (JLjava/lang/String;I)V
+	public final fun getIndex ()I
+	public final fun getParent ()J
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/handlers/ContentExplorer {
+	public fun <init> (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/server/handlers/RepositoriesManager;)V
+	public final fun init (Lio/ktor/server/application/Application;)V
+}
+
+public final class org/modelix/model/server/handlers/ContentExplorerExpandedNodes {
+	public static final field Companion Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes$Companion;
+	public fun <init> (Ljava/util/Set;Z)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/util/Set;Z)Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes;
+	public static synthetic fun copy$default (Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes;Ljava/util/Set;ZILjava/lang/Object;)Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpandAll ()Z
+	public final fun getExpandedNodeIds ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/handlers/ContentExplorerExpandedNodes$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/server/handlers/ContentExplorerExpandedNodes;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/handlers/ContentExplorerExpandedNodes$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/model/server/handlers/DeprecatedLightModelServer {
+	public fun <init> (Lorg/modelix/model/server/store/LocalModelClient;)V
+	public final fun getClient ()Lorg/modelix/model/server/store/LocalModelClient;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public final fun init (Lio/ktor/server/application/Application;)V
+}
+
+public final class org/modelix/model/server/handlers/HistoryHandler {
+	public fun <init> (Lorg/modelix/model/client/IModelClient;Lorg/modelix/model/server/handlers/RepositoriesManager;)V
+	public final fun getClient ()Lorg/modelix/model/client/IModelClient;
+	public final fun init (Lio/ktor/server/application/Application;)V
+	public final fun revert (Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/server/handlers/JsonUtilsKt {
+	public static final fun arrayEntries (Lorg/json/JSONObject;)Ljava/util/Map;
+	public static final fun asLongList (Lorg/json/JSONArray;)Ljava/util/List;
+	public static final fun asObjectList (Lorg/json/JSONArray;)Ljava/util/List;
+	public static final fun buildJSONArray ([Ljava/lang/Object;)Lorg/json/JSONArray;
+	public static final fun buildJSONObject (Lkotlin/jvm/functions/Function1;)Lorg/json/JSONObject;
+	public static final fun entries (Lorg/json/JSONObject;)Ljava/util/Map;
+	public static final fun jsonNullToJavaNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun longEntries (Lorg/json/JSONObject;)Ljava/util/Map;
+	public static final fun stringEntries (Lorg/json/JSONObject;)Ljava/util/Map;
+	public static final fun toJsonArray (Ljava/lang/Iterable;)Lorg/json/JSONArray;
+}
+
+public final class org/modelix/model/server/handlers/KeyValueLikeModelServer {
+	public static final field Companion Lorg/modelix/model/server/handlers/KeyValueLikeModelServer$Companion;
+	public static final field PROTECTED_PREFIX Ljava/lang/String;
+	public fun <init> (Lorg/modelix/model/server/handlers/RepositoriesManager;)V
+	public final fun collect (Ljava/lang/String;)Lorg/json/JSONArray;
+	public final fun getRepositoriesManager ()Lorg/modelix/model/server/handlers/RepositoriesManager;
+	public final fun getStoreClient ()Lorg/modelix/model/server/store/IStoreClient;
+	public final fun init (Lio/ktor/server/application/Application;)V
+	public final fun isHealthy ()Z
+	public final fun setSharedSecret (Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/server/handlers/KeyValueLikeModelServer$Companion {
+	public final fun getHASH_PATTERN ()Ljava/util/regex/Pattern;
+	public final fun getHEALTH_KEY ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/handlers/KeyValueLikeModelServerKt {
+	public static final fun getMODEL_SERVER_ENTRY ()Lorg/modelix/authorization/KeycloakResourceType;
+	public static final fun getPERMISSION_MODEL_SERVER ()Lorg/modelix/authorization/KeycloakResource;
+}
+
+public final class org/modelix/model/server/handlers/LightModelServer {
+	public static final field Companion Lorg/modelix/model/server/handlers/LightModelServer$Companion;
+	public fun <init> (Lorg/modelix/model/server/store/LocalModelClient;)V
+	public final fun getClient ()Lorg/modelix/model/server/store/LocalModelClient;
+	public final fun getStore ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public final fun init (Lio/ktor/server/application/Application;)V
+}
+
+public final class org/modelix/model/server/handlers/LightModelServer$Companion {
+}
+
+public final class org/modelix/model/server/handlers/MetricsHandler {
+	public fun <init> ()V
+	public final fun init (Lio/ktor/server/application/Application;)V
+}
+
+public final class org/modelix/model/server/handlers/ModelReplicationServer {
+	public static final field Companion Lorg/modelix/model/server/handlers/ModelReplicationServer$Companion;
+	public fun <init> (Lorg/modelix/model/server/handlers/RepositoriesManager;)V
+	public fun <init> (Lorg/modelix/model/server/store/IStoreClient;)V
+	public fun <init> (Lorg/modelix/model/server/store/LocalModelClient;)V
+	public final fun getRepositoriesManager ()Lorg/modelix/model/server/handlers/RepositoriesManager;
+	public final fun init (Lio/ktor/server/application/Application;)V
+}
+
+public final class org/modelix/model/server/handlers/ModelReplicationServer$Companion {
+}
+
+public final class org/modelix/model/server/handlers/RepositoriesManager {
+	public static final field Companion Lorg/modelix/model/server/handlers/RepositoriesManager$Companion;
+	public static final field KEY_PREFIX Ljava/lang/String;
+	public static final field LEGACY_SERVER_ID_KEY Ljava/lang/String;
+	public static final field LEGACY_SERVER_ID_KEY2 Ljava/lang/String;
+	public static final field SERVER_ID_KEY Ljava/lang/String;
+	public fun <init> (Lorg/modelix/model/server/store/LocalModelClient;)V
+	public final fun computeDelta (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public final fun createRepository (Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;Z)Lorg/modelix/model/lazy/CLVersion;
+	public static synthetic fun createRepository$default (Lorg/modelix/model/server/handlers/RepositoriesManager;Lorg/modelix/model/lazy/RepositoryId;Ljava/lang/String;ZILjava/lang/Object;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun dispose ()V
+	public final fun generateClientId (Lorg/modelix/model/lazy/RepositoryId;)J
+	public final fun getBranchNames (Lorg/modelix/model/lazy/RepositoryId;)Ljava/util/Set;
+	public final fun getBranches (Lorg/modelix/model/lazy/RepositoryId;)Ljava/util/Set;
+	public final fun getClient ()Lorg/modelix/model/server/store/LocalModelClient;
+	public final fun getInMemoryModels ()Lorg/modelix/model/InMemoryModels;
+	public final fun getRepositories ()Ljava/util/Set;
+	public final fun getVersion (Lorg/modelix/model/lazy/BranchReference;)Lorg/modelix/model/lazy/CLVersion;
+	public final fun getVersionHash (Lorg/modelix/model/lazy/BranchReference;)Ljava/lang/String;
+	public final fun maybeInitAndGetSeverId ()Ljava/lang/String;
+	public final fun mergeChanges (Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;)Ljava/lang/String;
+	public final fun migrateLegacyRepositoriesList ()V
+	public final fun pollVersionHash (Lorg/modelix/model/lazy/BranchReference;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun removeBranches (Lorg/modelix/model/lazy/RepositoryId;Ljava/util/Set;)V
+	public final fun removeRepository (Lorg/modelix/model/lazy/RepositoryId;)Z
+}
+
+public final class org/modelix/model/server/handlers/RepositoriesManager$Companion {
+}
+
+public final class org/modelix/model/server/handlers/RepositoryAlreadyExistsException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/handlers/RepositoryOverview {
+	public fun <init> (Lorg/modelix/model/server/handlers/RepositoriesManager;)V
+	public final fun init (Lio/ktor/server/application/Application;)V
+}
+
+public final class org/modelix/model/server/handlers/RepositoryOverviewKt {
+	public static final fun buildHistoryLink (Lkotlinx/html/FlowOrInteractiveOrPhrasingContent;Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class org/modelix/model/server/store/ChangeNotifier {
+	public fun <init> (Lorg/modelix/model/server/store/IStoreClient;)V
+	public final fun addListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public final fun getStore ()Lorg/modelix/model/server/store/IStoreClient;
+	public final fun notifyListeners (Ljava/lang/String;)V
+	public final fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public final class org/modelix/model/server/store/ClientIdProcessor : javax/cache/processor/EntryProcessor {
+	public fun <init> ()V
+	public fun process (Ljavax/cache/processor/MutableEntry;[Ljava/lang/Object;)Ljava/lang/Long;
+	public synthetic fun process (Ljavax/cache/processor/MutableEntry;[Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/model/server/store/IStoreClient : java/lang/AutoCloseable {
+	public abstract fun generateId (Ljava/lang/String;)J
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getAll ()Ljava/util/Map;
+	public abstract fun getAll (Ljava/util/List;)Ljava/util/List;
+	public abstract fun getAll (Ljava/util/Set;)Ljava/util/Map;
+	public abstract fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public abstract fun put (Ljava/lang/String;Ljava/lang/String;Z)V
+	public static synthetic fun put$default (Lorg/modelix/model/server/store/IStoreClient;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)V
+	public abstract fun putAll (Ljava/util/Map;Z)V
+	public static synthetic fun putAll$default (Lorg/modelix/model/server/store/IStoreClient;Ljava/util/Map;ZILjava/lang/Object;)V
+	public abstract fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public abstract fun runTransaction (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/server/store/IStoreClient$DefaultImpls {
+	public static synthetic fun put$default (Lorg/modelix/model/server/store/IStoreClient;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)V
+	public static synthetic fun putAll$default (Lorg/modelix/model/server/store/IStoreClient;Ljava/util/Map;ZILjava/lang/Object;)V
+}
+
+public final class org/modelix/model/server/store/IStoreClientKt {
+	public static final fun loadDump (Lorg/modelix/model/server/store/IStoreClient;Ljava/io/File;)I
+	public static final fun pollEntry (Lorg/modelix/model/server/store/IStoreClient;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun writeDump (Lorg/modelix/model/server/store/IStoreClient;Ljava/io/File;)V
+}
+
+public final class org/modelix/model/server/store/IgniteStoreClient : java/lang/AutoCloseable, org/modelix/model/server/store/IStoreClient {
+	public fun <init> ()V
+	public fun <init> (Ljava/io/File;Z)V
+	public synthetic fun <init> (Ljava/io/File;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun dispose ()V
+	public fun generateId (Ljava/lang/String;)J
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll ()Ljava/util/Map;
+	public fun getAll (Ljava/util/List;)Ljava/util/List;
+	public fun getAll (Ljava/util/Set;)Ljava/util/Map;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;Z)V
+	public fun putAll (Ljava/util/Map;Z)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun runTransaction (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/server/store/InMemoryStoreClient : org/modelix/model/server/store/IStoreClient {
+	public static final field Companion Lorg/modelix/model/server/store/InMemoryStoreClient$Companion;
+	public fun <init> ()V
+	public fun close ()V
+	public fun generateId (Ljava/lang/String;)J
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll ()Ljava/util/Map;
+	public fun getAll (Ljava/util/List;)Ljava/util/List;
+	public fun getAll (Ljava/util/Set;)Ljava/util/Map;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;Z)V
+	public fun putAll (Ljava/util/Map;Z)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun runTransaction (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/model/server/store/InMemoryStoreClient$Companion {
+}
+
+public final class org/modelix/model/server/store/InMemoryStoreClientKt {
+	public static final fun generateId (Ljava/lang/String;)J
+}
+
+public final class org/modelix/model/server/store/LocalModelClient : org/modelix/model/client/IModelClient {
+	public fun <init> (Lorg/modelix/model/server/store/IStoreClient;)V
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAll (Ljava/lang/Iterable;)Ljava/util/Map;
+	public fun getAsyncStore ()Lorg/modelix/model/IKeyValueStore;
+	public fun getClientId ()I
+	public fun getIdGenerator ()Lorg/modelix/model/api/IIdGenerator;
+	public fun getPendingSize ()I
+	public final fun getStore ()Lorg/modelix/model/server/store/IStoreClient;
+	public fun getStoreCache ()Lorg/modelix/model/lazy/IDeserializingKeyValueStore;
+	public fun listen (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+	public fun prefetch (Ljava/lang/String;)V
+	public fun put (Ljava/lang/String;Ljava/lang/String;)V
+	public fun putAll (Ljava/util/Map;)V
+	public fun removeListener (Ljava/lang/String;Lorg/modelix/model/IKeyListener;)V
+}
+
+public final class org/modelix/model/server/store/PendingChangeMessages {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun entryChanged (Ljava/lang/String;)V
+	public final fun flushChangeMessages ()V
+}
+
+public final class org/modelix/model/server/store/PostgresDialect : org/apache/ignite/cache/store/jdbc/dialect/BasicJdbcDialect {
+	public fun <init> ()V
+	public fun hasMerge ()Z
+	public fun mergeQuery (Ljava/lang/String;Ljava/util/Collection;Ljava/util/Collection;)Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/templates/PageWithMenuBar : io/ktor/server/html/Template {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lkotlinx/html/HTML;)V
+	public final fun getActivePage ()Ljava/lang/String;
+	public final fun getBaseUrl ()Ljava/lang/String;
+	public final fun getBodyContent ()Lio/ktor/server/html/Placeholder;
+	public final fun getHeadContent ()Lio/ktor/server/html/Placeholder;
+}
+

--- a/modelql-client/api/modelql-client.api
+++ b/modelql-client/api/modelql-client.api
@@ -1,0 +1,134 @@
+public final class org/modelix/modelql/client/ModelQLArea : org/modelix/model/area/IArea {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public final fun component1 ()Lorg/modelix/modelql/client/ModelQLClient;
+	public final fun copy (Lorg/modelix/modelql/client/ModelQLClient;)Lorg/modelix/modelql/client/ModelQLArea;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/client/ModelQLArea;Lorg/modelix/modelql/client/ModelQLClient;ILjava/lang/Object;)Lorg/modelix/modelql/client/ModelQLArea;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getClient ()Lorg/modelix/modelql/client/ModelQLClient;
+	public fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/client/ModelQLClient {
+	public static final field Companion Lorg/modelix/modelql/client/ModelQLClient$Companion;
+	public fun <init> (Ljava/lang/String;Lio/ktor/client/HttpClient;Lkotlinx/serialization/modules/SerializersModule;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/ktor/client/HttpClient;Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getArea ()Lorg/modelix/model/area/IArea;
+	public final fun getClient ()Lio/ktor/client/HttpClient;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/modelql/client/ModelQLNodeWithConceptQuery;
+	public final fun getRootNode ()Lorg/modelix/model/api/INode;
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun query (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun runQuery (Lorg/modelix/modelql/core/IUnboundQuery;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/client/ModelQLClient$Companion {
+	public final fun builder ()Lorg/modelix/modelql/client/ModelQLClientBuilder;
+}
+
+public abstract class org/modelix/modelql/client/ModelQLClientBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/modelix/modelql/client/ModelQLClient;
+	protected abstract fun getDefaultEngineFactory ()Lio/ktor/client/engine/HttpClientEngineFactory;
+	public final fun httpClient (Lio/ktor/client/HttpClient;)Lorg/modelix/modelql/client/ModelQLClientBuilder;
+	public final fun httpEngine (Lio/ktor/client/engine/HttpClientEngine;)Lorg/modelix/modelql/client/ModelQLClientBuilder;
+	public final fun httpEngine (Lio/ktor/client/engine/HttpClientEngineFactory;)Lorg/modelix/modelql/client/ModelQLClientBuilder;
+	public final fun serializersModule (Lkotlinx/serialization/modules/SerializersModule;)Lorg/modelix/modelql/client/ModelQLClientBuilder;
+	public final fun url (Ljava/lang/String;)Lorg/modelix/modelql/client/ModelQLClientBuilder;
+}
+
+public final class org/modelix/modelql/client/ModelQLClientKt {
+	public static final fun blockingQuery (Lorg/modelix/modelql/client/ModelQLClient;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract class org/modelix/modelql/client/ModelQLNode : org/modelix/model/api/INode, org/modelix/modelql/core/IQueryExecutor, org/modelix/modelql/untyped/ISupportsModelQL {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;)V
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public final fun blockingQuery (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun createFlow (Lorg/modelix/modelql/core/IUnboundQuery;)Lkotlinx/coroutines/flow/Flow;
+	public fun createQueryExecutor ()Lorg/modelix/modelql/core/IQueryExecutor;
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Ljava/lang/String;)Ljava/lang/Iterable;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public final fun getClient ()Lorg/modelix/modelql/client/ModelQLClient;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyRoles ()Ljava/util/List;
+	public fun getPropertyValue (Ljava/lang/String;)Ljava/lang/String;
+	public fun getReferenceRoles ()Ljava/util/List;
+	public fun getReferenceTarget (Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public fun getRoleInParent ()Ljava/lang/String;
+	public fun isValid ()Z
+	public fun moveChild (Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public fun moveChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	protected fun replaceQueryRoot (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public fun setPropertyValue (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public fun setReferenceTarget (Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public fun usesRoleIds ()Z
+}
+
+public final class org/modelix/modelql/client/ModelQLNodeSerializer : org/modelix/modelql/untyped/NodeKSerializer {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;)V
+	public final fun getClient ()Lorg/modelix/modelql/client/ModelQLClient;
+}
+
+public abstract class org/modelix/modelql/client/ModelQLNodeWithConceptCache : org/modelix/modelql/client/ModelQLNode {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;)V
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/ConceptReference;
+	public synthetic fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+}
+
+public final class org/modelix/modelql/client/ModelQLNodeWithConceptQuery : org/modelix/modelql/client/ModelQLNodeWithConceptCache {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;Lorg/modelix/model/api/NodeReference;)V
+	public synthetic fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReference ()Lorg/modelix/model/api/NodeReference;
+}
+
+public final class org/modelix/modelql/client/ModelQLNodeWithKnownConcept : org/modelix/modelql/client/ModelQLNode {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;Lorg/modelix/model/api/NodeReference;Lorg/modelix/model/api/ConceptReference;)V
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/ConceptReference;
+	public synthetic fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public synthetic fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReference ()Lorg/modelix/model/api/NodeReference;
+}
+
+public final class org/modelix/modelql/client/ModelQLRootNode : org/modelix/modelql/client/ModelQLNodeWithConceptCache {
+	public fun <init> (Lorg/modelix/modelql/client/ModelQLClient;)V
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+}
+
+public final class org/modelix/modelql/client/ModelQLRootNodeReference : org/modelix/model/api/INodeReference {
+	public fun <init> ()V
+	public fun resolveNode (Lorg/modelix/model/area/IArea;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/modelql/client/PlatformSpecificModelQLClientBuilder : org/modelix/modelql/client/ModelQLClientBuilder {
+	public fun <init> ()V
+}
+

--- a/modelql-core/api/modelql-core.api
+++ b/modelql-core/api/modelql-core.api
@@ -1,0 +1,2771 @@
+public abstract class org/modelix/modelql/core/AggregationStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	protected abstract fun aggregate (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public final fun connectAndDowncast (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IMonoStep;
+	protected fun createFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun inputIsConsumedMultipleTimes ()Z
+	public fun needsCoroutineScope ()Z
+	public fun requiresSingularQueryInput ()Z
+}
+
+public final class org/modelix/modelql/core/AllowEmptyStep : org/modelix/modelql/core/IdentityStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/AllowEmptyStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/AllowEmptyStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/AllowEmptyStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/AllowEmptyStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/AllowEmptyStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/AllowEmptyStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/AllowEmptyStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/AndOperatorStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/AndOperatorStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IZipOutput;)Ljava/lang/Boolean;
+}
+
+public final class org/modelix/modelql/core/AndOperatorStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/AndOperatorStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/AndOperatorStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/AndOperatorStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/AndOperatorStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/AndOperatorStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/AndOperatorStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/AndOperatorStepKt {
+	public static final fun and (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/AssertNotEmptyStep : org/modelix/modelql/core/IdentityStep {
+	public fun <init> ()V
+	public fun canBeEmpty ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/AssertNotEmptyStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/AssertNotEmptyStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/AssertNotEmptyStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/AssertNotEmptyStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/AssertNotEmptyStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/AssertNotEmptyStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/AssertNotEmptyStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/AtomicLong {
+	public fun <init> (J)V
+	public final fun incrementAndGet ()J
+}
+
+public final class org/modelix/modelql/core/BulkQueryExecutor : org/modelix/modelql/core/IBulkQueryExecutor {
+	public fun <init> ()V
+	public fun flush ()V
+	public fun request (Lorg/modelix/modelql/core/IBulkRequestType;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/modelix/modelql/core/CollectionSizeStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/util/Collection;)Ljava/lang/Integer;
+}
+
+public final class org/modelix/modelql/core/CollectionSizeStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/CollectionSizeStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/CollectionSizeStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/CollectionSizeStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/CollectionSizeStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/CollectionSizeStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/CollectionSizeStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/CollectionSizeStepKt {
+	public static final fun size (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public abstract class org/modelix/modelql/core/CollectorStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> ()V
+	protected abstract fun getOutputSerializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/CollectorStepKt {
+	public static final fun associate (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun associateBy (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun associateWith (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun toList (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun toMap (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun toSet (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun toSingletonList (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun toSingletonSet (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/CollectorStepOutput : org/modelix/modelql/core/IStepOutput {
+	public fun <init> (Ljava/util/List;Ljava/lang/Object;Ljava/lang/Object;)V
+	public final fun getInput ()Ljava/util/List;
+	public final fun getInternalCollection ()Ljava/lang/Object;
+	public final fun getOutput ()Ljava/lang/Object;
+	public fun getValue ()Ljava/lang/Object;
+}
+
+public abstract class org/modelix/modelql/core/CollectorStepOutputSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/CollectorStepOutput;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getInputElementSerializer ()Lkotlinx/serialization/KSerializer;
+	protected abstract fun inputToInternal (Ljava/util/List;)Ljava/lang/Object;
+	protected abstract fun internalToOutput (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/CollectorStepOutput;)V
+}
+
+public final class org/modelix/modelql/core/CombiningSequence : kotlin/sequences/Sequence {
+	public fun <init> ([Lkotlin/sequences/Sequence;)V
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public final class org/modelix/modelql/core/CombiningSequence$UNINITIALIZED {
+	public static final field INSTANCE Lorg/modelix/modelql/core/CombiningSequence$UNINITIALIZED;
+}
+
+public class org/modelix/modelql/core/ConstantSourceStep : org/modelix/modelql/core/ProducingStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (Ljava/lang/Object;Lkotlin/reflect/KType;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun canEvaluateStatically ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createFlow (Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun evaluateStatically ()Ljava/lang/Object;
+	public final fun getElement ()Ljava/lang/Object;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getType ()Lkotlin/reflect/KType;
+	public fun hasSideEffect ()Z
+	public fun needsCoroutineScope ()Z
+	public fun requiresSingularQueryInput ()Z
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/ConstantSourceStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/ConstantSourceStep$Descriptor$Companion;
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getElement ()Ljava/lang/Object;
+	public final fun getElementType ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/ConstantSourceStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ConstantSourceStep$Descriptor$Serializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ConstantSourceStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ConstantSourceStep$Descriptor;)V
+}
+
+public final class org/modelix/modelql/core/ConstantSourceStepKt {
+	public static final fun asMono (B)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (C)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (D)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (F)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (I)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (J)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (Ljava/util/Set;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (S)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono (Z)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Boolean;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Byte;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Character;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Double;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Float;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Integer;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Long;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/Short;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMono_nullable (Ljava/util/Set;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/ContextValue {
+	public fun <init> ()V
+	public final fun computeWith (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun getStack ()Ljava/util/List;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun tryGetValue ()Ljava/lang/Object;
+}
+
+public abstract class org/modelix/modelql/core/CoreStepDescriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/CoreStepDescriptor$Companion;
+	public synthetic fun <init> (ILjava/lang/Long;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lorg/modelix/modelql/core/CoreStepDescriptor;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/modelql/core/CoreStepDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/CountingStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/CountingStep$CountDescriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/CountingStep$CountDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/CountingStep$CountDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/CountingStep$CountDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/CountingStep$CountDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/CountingStep$CountDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/CountingStep$CountDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/CountingStep$CountDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/CountingStepKt {
+	public static final fun count (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/CrossQueryReferenceException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class org/modelix/modelql/core/DropStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (I)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/DropStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getCount ()I
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/DropStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/DropStep$Descriptor$Companion;
+	public fun <init> (I)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getCount ()I
+}
+
+public final class org/modelix/modelql/core/DropStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/DropStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/DropStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/DropStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/DropStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/DropStepKt {
+	public static final fun drop (Lorg/modelix/modelql/core/IFluxStep;I)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/EmptyStringIfNullStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/EmptyStringIfNullStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/EmptyStringIfNullStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/EmptyStringIfNullStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/EmptyStringIfNullStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/EmptyStringIfNullStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/EmptyStringIfNullStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/EmptyStringIfNullStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/EmptyStringIfNullStepKt {
+	public static final fun emptyStringIfNull (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun emptyStringIfNull (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/EqualsOperatorStep : org/modelix/modelql/core/TransformingStepWithParameter {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/EqualsOperatorStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/EqualsOperatorStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/EqualsOperatorStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/EqualsOperatorStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/EqualsOperatorStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/EqualsOperatorStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/EqualsOperatorStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/EqualsOperatorStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/EqualsOperatorStepKt {
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Boolean;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Byte;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Character;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Double;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Float;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Integer;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Long;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Short;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun equalTo (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Boolean;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Byte;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Character;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Double;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Float;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Integer;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Long;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/Short;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun notEqualTo (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/ExecuteLocalStep : org/modelix/modelql/core/LocalMappingStep {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun hasSideEffect ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/FilteringStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (Lorg/modelix/modelql/core/MonoUnboundQuery;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/FilteringStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getCondition ()Lorg/modelix/modelql/core/MonoUnboundQuery;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun validate ()V
+}
+
+public final class org/modelix/modelql/core/FilteringStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/FilteringStep$Descriptor$Companion;
+	public fun <init> (J)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getQueryId ()J
+}
+
+public final class org/modelix/modelql/core/FilteringStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/FilteringStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/FilteringStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/FilteringStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FilteringStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FilteringStepKt {
+	public static final fun filter (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun filter (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/FirstElementStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/FirstElementStep$FirstElementDescriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun requiresSingularQueryInput ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/FirstElementStep$FirstElementDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/FirstElementStep$FirstElementDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/FirstElementStep$FirstElementDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/FirstElementStep$FirstElementDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/FirstElementStep$FirstElementDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/FirstElementStep$FirstElementDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FirstElementStep$FirstElementDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FirstElementStepKt {
+	public static final fun first (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/FirstOrNullStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/FirstOrNullStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/FirstOrNullStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/FirstOrNullStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/FirstOrNullStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/FirstOrNullStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/FirstOrNullStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/FirstOrNullStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FirstOrNullStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FirstOrNullStepKt {
+	public static final fun firstOrNull (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/FlatMapStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep {
+	public fun <init> (Lorg/modelix/modelql/core/FluxUnboundQuery;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/FlatMapStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getQuery ()Lorg/modelix/modelql/core/FluxUnboundQuery;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/FlatMapStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/FlatMapStep$Descriptor$Companion;
+	public fun <init> (J)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getQueryId ()J
+}
+
+public final class org/modelix/modelql/core/FlatMapStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/FlatMapStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/FlatMapStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/FlatMapStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FlatMapStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/FlatMapStepKt {
+	public static final fun flatMap (Lorg/modelix/modelql/core/IProducingStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun flatMap (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IFluxUnboundQuery;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/FlowExtensionsKt {
+	public static final fun asSequence (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun assertNotEmpty (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function0;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun assertNotEmpty$default (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun batchTransform (Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun chunked (Lkotlinx/coroutines/flow/Flow;I)Lkotlinx/coroutines/flow/Flow;
+	public static final fun flatMapConcatConcurrent (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun flattenConcatConcurrent (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun optionalSingle (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/FlowInstantiationContext : org/modelix/modelql/core/IFlowInstantiationContext {
+	public fun <init> (Lorg/modelix/modelql/core/QueryEvaluationContext;Lkotlinx/coroutines/CoroutineScope;Lorg/modelix/modelql/core/UnboundQuery;)V
+	public fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+	public fun getEvaluationContext ()Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public fun getFlow (Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOrCreateFlow (Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getQuery ()Lorg/modelix/modelql/core/UnboundQuery;
+	public final fun put (Lorg/modelix/modelql/core/IProducingStep;Lkotlinx/coroutines/flow/Flow;)V
+	public fun setEvaluationContext (Lorg/modelix/modelql/core/QueryEvaluationContext;)V
+}
+
+public abstract class org/modelix/modelql/core/FluxTransformingStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep {
+	public fun <init> ()V
+	public final fun connectAndDowncast (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/FluxUnboundQuery : org/modelix/modelql/core/UnboundQuery, org/modelix/modelql/core/IFluxUnboundQuery {
+	public fun <init> (Lorg/modelix/modelql/core/QueryInput;Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/QueryReference;Ljava/util/List;)V
+	public fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IFluxQuery;
+	public synthetic fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IQuery;
+	public fun execute (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun flatMap (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public fun getAggregationOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getElementOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getOutputStep ()Lorg/modelix/modelql/core/IFluxStep;
+	public synthetic fun getOutputStep ()Lorg/modelix/modelql/core/IProducingStep;
+	public fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+}
+
+public abstract class org/modelix/modelql/core/FoldingStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> (Ljava/lang/Object;)V
+	protected fun aggregate (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun fold (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/FragmentBuilder : org/modelix/modelql/core/IRecursiveFragmentBuilder, org/modelix/modelql/core/IUnboundFragmentInternal {
+	public fun <init> ()V
+	public final fun checkNotSealed ()V
+	public final fun checkSealed ()V
+	public final fun compileMappingStep (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public synthetic fun getInput ()Lorg/modelix/modelql/core/IMonoStep;
+	public fun getInput ()Lorg/modelix/modelql/core/QueryInput;
+	public final fun getQuery ()Lorg/modelix/modelql/core/IMonoUnboundQuery;
+	public final fun getQueryBuilder ()Lorg/modelix/modelql/core/QueryBuilderContext;
+	public fun getQueryReference ()Lorg/modelix/modelql/core/QueryReference;
+	public fun onSuccess (Lkotlin/jvm/functions/Function1;)V
+	public fun processResult (Lorg/modelix/modelql/core/IZipOutput;Ljava/lang/Object;)V
+	public fun request (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+	public final fun seal ()V
+	public fun shared (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public fun shared (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/FragmentBuilderKt {
+	public static final fun bindFragment (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun bindFragment (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun bindFragment (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun bindFragment (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun buildModelQLFragment (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IUnboundFragment;
+	public static final fun buildModelQLFragment (ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IUnboundFragment;
+	public static final fun castToInstance (Lorg/modelix/modelql/core/IFragmentBuilder;)Lorg/modelix/modelql/core/FragmentBuilder;
+	public static final fun insertFragment (Ljava/lang/Object;Lorg/modelix/modelql/core/IBoundFragment;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IBoundFragment {
+	public abstract fun insertInto (Ljava/lang/Object;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IBulkQueryExecutor {
+	public abstract fun flush ()V
+	public abstract fun request (Lorg/modelix/modelql/core/IBulkRequestType;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IBulkRequestType {
+	public abstract fun executeRequest (Ljava/util/Collection;)Ljava/util/Map;
+	public abstract fun getMaxBatchSize ()I
+}
+
+public abstract interface class org/modelix/modelql/core/IConsumingStep : org/modelix/modelql/core/IStep {
+	public abstract fun addProducer (Lorg/modelix/modelql/core/IProducingStep;)V
+	public abstract fun getProducers ()Ljava/util/List;
+	public fun inputIsConsumedMultipleTimes ()Z
+}
+
+public final class org/modelix/modelql/core/IConsumingStep$DefaultImpls {
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IConsumingStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IConsumingStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IConsumingStep;)Z
+	public static fun inputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IConsumingStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IConsumingStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IConsumingStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IConsumingStep;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IFlowInstantiationContext {
+	public abstract fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+	public abstract fun getEvaluationContext ()Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public abstract fun getFlow (Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getOrCreateFlow (Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class org/modelix/modelql/core/IFluxOrMonoStep : org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+}
+
+public final class org/modelix/modelql/core/IFluxOrMonoStep$DefaultImpls {
+	public static fun canBeEmpty (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun canBeMultiple (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun canEvaluateStatically (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IFluxOrMonoStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun evaluateStatically (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Ljava/lang/Object;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun outputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun requiresSingularQueryInput (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IFluxOrMonoStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IFluxOrMonoStep;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IFluxQuery : org/modelix/modelql/core/IQuery {
+	public abstract fun flatMap (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxQuery;
+	public abstract fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxQuery;
+}
+
+public abstract interface class org/modelix/modelql/core/IFluxStep : org/modelix/modelql/core/IProducingStep {
+}
+
+public final class org/modelix/modelql/core/IFluxStep$DefaultImpls {
+	public static fun canBeEmpty (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun canBeMultiple (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun canEvaluateStatically (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun evaluateStatically (Lorg/modelix/modelql/core/IFluxStep;)Ljava/lang/Object;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IFluxStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun outputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun requiresSingularQueryInput (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IFluxStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IFluxStep;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IFluxUnboundQuery : org/modelix/modelql/core/IUnboundQuery {
+	public abstract fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IFluxQuery;
+	public abstract fun flatMap (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public abstract fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+}
+
+public final class org/modelix/modelql/core/IFluxUnboundQuery$DefaultImpls {
+	public static fun asFlow (Lorg/modelix/modelql/core/IFluxUnboundQuery;Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class org/modelix/modelql/core/IFragmentBuilder : org/modelix/modelql/core/IStepSharingContext, org/modelix/modelql/core/IZipBuilderContext {
+	public abstract fun getInput ()Lorg/modelix/modelql/core/IMonoStep;
+	public fun insertFragment (Ljava/lang/Object;Lorg/modelix/modelql/core/IBoundFragment;)V
+	public fun insertFragment (Ljava/lang/Object;Lorg/modelix/modelql/core/IValueRequest;)V
+	public abstract fun onSuccess (Lkotlin/jvm/functions/Function1;)V
+	public fun requestFragment (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IValueRequest;
+	public fun requestFragment (Lorg/modelix/modelql/core/IFluxStep;ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IValueRequest;
+	public fun requestFragment (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IValueRequest;
+	public fun requestFragment (Lorg/modelix/modelql/core/IMonoStep;ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IValueRequest;
+	public static synthetic fun requestFragment$default (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IFluxStep;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/modelix/modelql/core/IValueRequest;
+	public static synthetic fun requestFragment$default (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/modelix/modelql/core/IValueRequest;
+}
+
+public final class org/modelix/modelql/core/IFragmentBuilder$DefaultImpls {
+	public static fun getLater (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun insertFragment (Lorg/modelix/modelql/core/IFragmentBuilder;Ljava/lang/Object;Lorg/modelix/modelql/core/IBoundFragment;)V
+	public static fun insertFragment (Lorg/modelix/modelql/core/IFragmentBuilder;Ljava/lang/Object;Lorg/modelix/modelql/core/IValueRequest;)V
+	public static fun requestFragment (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun requestFragment (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IFluxStep;ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun requestFragment (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun requestFragment (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IValueRequest;
+	public static synthetic fun requestFragment$default (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IFluxStep;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/modelix/modelql/core/IValueRequest;
+	public static synthetic fun requestFragment$default (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/modelix/modelql/core/IValueRequest;
+}
+
+public abstract interface class org/modelix/modelql/core/ILocalMappingBuilder : org/modelix/modelql/core/IZipBuilderContext {
+	public abstract fun onSuccess (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class org/modelix/modelql/core/ILocalMappingBuilder$DefaultImpls {
+	public static fun getLater (Lorg/modelix/modelql/core/ILocalMappingBuilder;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+}
+
+public abstract interface class org/modelix/modelql/core/IMonoQuery : org/modelix/modelql/core/IQuery {
+	public abstract fun flatMap (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxQuery;
+	public abstract fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoQuery;
+}
+
+public abstract interface class org/modelix/modelql/core/IMonoStep : org/modelix/modelql/core/IProducingStep {
+}
+
+public final class org/modelix/modelql/core/IMonoStep$DefaultImpls {
+	public static fun canBeEmpty (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun canBeMultiple (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun canEvaluateStatically (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun evaluateStatically (Lorg/modelix/modelql/core/IMonoStep;)Ljava/lang/Object;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IMonoStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun outputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun requiresSingularQueryInput (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IMonoStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IMonoStep;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IMonoUnboundQuery : org/modelix/modelql/core/IUnboundQuery {
+	public abstract fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IMonoQuery;
+	public fun flatMap (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public fun map (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+	public abstract fun map (Lorg/modelix/modelql/core/IFluxUnboundQuery;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public abstract fun map (Lorg/modelix/modelql/core/IMonoUnboundQuery;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+}
+
+public final class org/modelix/modelql/core/IMonoUnboundQuery$DefaultImpls {
+	public static fun asFlow (Lorg/modelix/modelql/core/IMonoUnboundQuery;Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;)Lkotlinx/coroutines/flow/Flow;
+	public static fun flatMap (Lorg/modelix/modelql/core/IMonoUnboundQuery;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public static fun map (Lorg/modelix/modelql/core/IMonoUnboundQuery;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+}
+
+public abstract interface class org/modelix/modelql/core/IProcessingStep : org/modelix/modelql/core/IConsumingStep, org/modelix/modelql/core/IProducingStep {
+	public fun inputIsConsumedMultipleTimes ()Z
+}
+
+public final class org/modelix/modelql/core/IProcessingStep$DefaultImpls {
+	public static fun canBeEmpty (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun canBeMultiple (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun canEvaluateStatically (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IProcessingStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun evaluateStatically (Lorg/modelix/modelql/core/IProcessingStep;)Ljava/lang/Object;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IProcessingStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun inputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun outputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun requiresSingularQueryInput (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IProcessingStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IProcessingStep;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IProducingStep : org/modelix/modelql/core/IStep {
+	public abstract fun addConsumer (Lorg/modelix/modelql/core/IConsumingStep;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun canEvaluateStatically ()Z
+	public abstract fun createFlow (Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun evaluateStatically ()Ljava/lang/Object;
+	public abstract fun getConsumers ()Ljava/util/List;
+	public abstract fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun outputIsConsumedMultipleTimes ()Z
+	public fun requiresSingularQueryInput ()Z
+}
+
+public final class org/modelix/modelql/core/IProducingStep$DefaultImpls {
+	public static fun canBeEmpty (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun canBeMultiple (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun canEvaluateStatically (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun evaluateStatically (Lorg/modelix/modelql/core/IProducingStep;)Ljava/lang/Object;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IProducingStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun outputIsConsumedMultipleTimes (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun requiresSingularQueryInput (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IProducingStep;)V
+}
+
+public abstract interface class org/modelix/modelql/core/IQuery {
+	public abstract fun asFlow (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IQueryBuilderContext : org/modelix/modelql/core/IStepSharingContext {
+	public abstract fun mapRecursive (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public abstract interface class org/modelix/modelql/core/IQueryExecutor {
+	public abstract fun createFlow (Lorg/modelix/modelql/core/IUnboundQuery;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class org/modelix/modelql/core/IQueryReference {
+	public abstract fun getId ()J
+	public abstract fun getQuery ()Lorg/modelix/modelql/core/IUnboundQuery;
+}
+
+public abstract interface class org/modelix/modelql/core/IRecursiveFragmentBuilder : org/modelix/modelql/core/IFragmentBuilder, org/modelix/modelql/core/IUnboundFragment {
+}
+
+public final class org/modelix/modelql/core/IRecursiveFragmentBuilder$DefaultImpls {
+	public static fun getLater (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun insertFragment (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Ljava/lang/Object;Lorg/modelix/modelql/core/IBoundFragment;)V
+	public static fun insertFragment (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Ljava/lang/Object;Lorg/modelix/modelql/core/IValueRequest;)V
+	public static fun requestFragment (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun requestFragment (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Lorg/modelix/modelql/core/IFluxStep;ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun requestFragment (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IUnboundFragment;)Lorg/modelix/modelql/core/IValueRequest;
+	public static fun requestFragment (Lorg/modelix/modelql/core/IRecursiveFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;ZLkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IValueRequest;
+}
+
+public abstract interface class org/modelix/modelql/core/IStep {
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public abstract fun getOwner ()Lorg/modelix/modelql/core/QueryReference;
+	public fun getRootInputSteps ()Ljava/util/Set;
+	public fun hasSideEffect ()Z
+	public fun needsCoroutineScope ()Z
+	public abstract fun requiresSingularQueryInput ()Z
+	public fun requiresWriteAccess ()Z
+	public fun validate ()V
+}
+
+public final class org/modelix/modelql/core/IStep$DefaultImpls {
+	public static fun createDescriptor (Lorg/modelix/modelql/core/IStep;Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public static fun getRootInputSteps (Lorg/modelix/modelql/core/IStep;)Ljava/util/Set;
+	public static fun hasSideEffect (Lorg/modelix/modelql/core/IStep;)Z
+	public static fun needsCoroutineScope (Lorg/modelix/modelql/core/IStep;)Z
+	public static fun requiresWriteAccess (Lorg/modelix/modelql/core/IStep;)Z
+	public static fun validate (Lorg/modelix/modelql/core/IStep;)V
+}
+
+public final class org/modelix/modelql/core/IStepKt {
+	public static final fun connect (Lorg/modelix/modelql/core/IConsumingStep;Lorg/modelix/modelql/core/IProducingStep;)V
+	public static final fun connect (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IConsumingStep;)V
+	public static final fun isSingle (Lorg/modelix/modelql/core/IProducingStep;)Z
+}
+
+public abstract interface class org/modelix/modelql/core/IStepOutput {
+	public abstract fun getValue ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IStepOutputKt {
+	public static final fun asStepFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun asStepOutput (Ljava/lang/Object;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IStepOutput;
+	public static final fun getValue (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun stepOutputSerializer (Lkotlinx/serialization/KSerializer;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/SimpleStepOutputSerializer;
+	public static final fun upcast (Lorg/modelix/modelql/core/IStepOutput;)Lorg/modelix/modelql/core/IStepOutput;
+}
+
+public abstract interface class org/modelix/modelql/core/IStepSharingContext {
+	public abstract fun shared (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public abstract fun shared (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public abstract interface class org/modelix/modelql/core/IUnboundFragment {
+}
+
+public abstract interface class org/modelix/modelql/core/IUnboundQuery {
+	public static final field Companion Lorg/modelix/modelql/core/IUnboundQuery$Companion;
+	public abstract fun asFlow (Lorg/modelix/modelql/core/QueryEvaluationContext;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public fun asFlow (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IQuery;
+	public abstract fun canBeEmpty ()Z
+	public abstract fun execute (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAggregationOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public abstract fun getElementOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public abstract fun getReference ()Lorg/modelix/modelql/core/IQueryReference;
+	public abstract fun requiresWriteAccess ()Z
+}
+
+public final class org/modelix/modelql/core/IUnboundQuery$Companion {
+	public final fun buildFlux (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public final fun buildMono (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+}
+
+public final class org/modelix/modelql/core/IUnboundQuery$DefaultImpls {
+	public static fun asFlow (Lorg/modelix/modelql/core/IUnboundQuery;Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class org/modelix/modelql/core/IValueRequest {
+	public abstract fun get ()Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip1Output : org/modelix/modelql/core/IZipOutput {
+	public abstract fun getFirst ()Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip2Output : org/modelix/modelql/core/IZip1Output {
+	public abstract fun getSecond ()Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip3Output : org/modelix/modelql/core/IZip2Output {
+	public abstract fun getThird ()Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip4Output : org/modelix/modelql/core/IZip3Output {
+	public fun getForth ()Ljava/lang/Object;
+	public abstract fun getFourth ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IZip4Output$DefaultImpls {
+	public static fun getForth (Lorg/modelix/modelql/core/IZip4Output;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip5Output : org/modelix/modelql/core/IZip4Output {
+	public abstract fun getFifth ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IZip5Output$DefaultImpls {
+	public static fun getForth (Lorg/modelix/modelql/core/IZip5Output;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip6Output : org/modelix/modelql/core/IZip5Output {
+	public abstract fun getSixth ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IZip6Output$DefaultImpls {
+	public static fun getForth (Lorg/modelix/modelql/core/IZip6Output;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip7Output : org/modelix/modelql/core/IZip6Output {
+	public abstract fun getSeventh ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IZip7Output$DefaultImpls {
+	public static fun getForth (Lorg/modelix/modelql/core/IZip7Output;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip8Output : org/modelix/modelql/core/IZip7Output {
+	public abstract fun getEighth ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IZip8Output$DefaultImpls {
+	public static fun getForth (Lorg/modelix/modelql/core/IZip8Output;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZip9Output : org/modelix/modelql/core/IZip8Output {
+	public abstract fun getNinth ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IZip9Output$DefaultImpls {
+	public static fun getForth (Lorg/modelix/modelql/core/IZip9Output;)Ljava/lang/Object;
+}
+
+public abstract interface class org/modelix/modelql/core/IZipBuilderContext {
+	public fun getLater (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+	public abstract fun request (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+}
+
+public final class org/modelix/modelql/core/IZipBuilderContext$DefaultImpls {
+	public static fun getLater (Lorg/modelix/modelql/core/IZipBuilderContext;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+}
+
+public abstract interface class org/modelix/modelql/core/IZipOutput {
+	public abstract fun getValues ()Ljava/util/List;
+}
+
+public class org/modelix/modelql/core/IdentityStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxOrMonoStep {
+	public fun <init> ()V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	protected fun createFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/IdentityStep$IdentityStepDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/IdentityStep$IdentityStepDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/IdentityStep$IdentityStepDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/IdentityStep$IdentityStepDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/IdentityStep$IdentityStepDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/IdentityStep$IdentityStepDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IdentityStep$IdentityStepDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IdentityStepKt {
+	public static final fun asFlux (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun identity (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun identity (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/IfEmptyKt {
+	public static final fun ifEmpty_flux_flux (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun ifEmpty_flux_mono (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun ifEmpty_mono_flux (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun ifEmpty_mono_mono (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/IfEmptyStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxOrMonoStep {
+	public fun <init> (Lorg/modelix/modelql/core/UnboundQuery;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/IfEmptyStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getAlternative ()Lorg/modelix/modelql/core/UnboundQuery;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun requiresSingularQueryInput ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/IfEmptyStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/IfEmptyStep$Descriptor$Companion;
+	public fun <init> (J)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getAlternative ()J
+}
+
+public final class org/modelix/modelql/core/IfEmptyStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/IfEmptyStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/IfEmptyStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/IfEmptyStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IfEmptyStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/InPredicate : org/modelix/modelql/core/TransformingStepWithParameter {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/InPredicate$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/InPredicate$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/InPredicate$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/InPredicate$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/InPredicate$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/InPredicate$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/InPredicate$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/InPredicate$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/InPredicateKt {
+	public static final fun inSet (Lorg/modelix/modelql/core/IFluxStep;Ljava/util/Set;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun inSet (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun inSet (Lorg/modelix/modelql/core/IMonoStep;Ljava/util/Set;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun inSet (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/IntSumStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> (I)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/IntSumStep$IntSumDescriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getOperand ()I
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;I)Ljava/lang/Integer;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IntSumStep$IntSumDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/IntSumStep$IntSumDescriptor$Companion;
+	public fun <init> (I)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getOperand ()I
+}
+
+public final class org/modelix/modelql/core/IntSumStep$IntSumDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/IntSumStep$IntSumDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/IntSumStep$IntSumDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/IntSumStep$IntSumDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IntSumStep$IntSumDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IntSumStepKt {
+	public static final fun plus (ILorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun plus (ILorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun plus (Lorg/modelix/modelql/core/IFluxStep;I)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun plus (Lorg/modelix/modelql/core/IMonoStep;I)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/IsEmptyStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/IsEmptyStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/IsEmptyStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/IsEmptyStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/IsEmptyStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/IsEmptyStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/IsEmptyStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/IsEmptyStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IsEmptyStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IsEmptyStepKt {
+	public static final fun isEmpty (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun isNotEmpty (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/IsNullPredicateStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/IsNullPredicateStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Boolean;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/IsNullPredicateStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/IsNullPredicateStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/IsNullPredicateStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/IsNullPredicateStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/IsNullPredicateStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/IsNullPredicateStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IsNullPredicateStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/IsNullPredicateStepKt {
+	public static final fun filterNotNull (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun filterNotNull (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun isNull (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/JoinStep : org/modelix/modelql/core/ProducingStep, org/modelix/modelql/core/IConsumingStep, org/modelix/modelql/core/IFluxStep {
+	public fun <init> ()V
+	public fun addProducer (Lorg/modelix/modelql/core/IProducingStep;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/JoinStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createFlow (Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getProducers ()Ljava/util/List;
+	public fun requiresSingularQueryInput ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/JoinStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/JoinStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/JoinStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/JoinStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/JoinStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/JoinStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/JoinStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/JoinStepKt {
+	public static final fun plus (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/ListCollectorStep : org/modelix/modelql/core/CollectorStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/ListCollectorStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/ListCollectorStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/ListCollectorStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/ListCollectorStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/ListCollectorStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ListCollectorStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ListCollectorStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ListCollectorStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ListCollectorStepOutputSerializer : org/modelix/modelql/core/CollectorStepOutputSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun inputToInternal (Ljava/util/List;)Ljava/lang/Object;
+	public synthetic fun internalToOutput (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/LocalMappingSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lorg/modelix/modelql/core/LocalMappingStep;Lkotlinx/serialization/KSerializer;)V
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getInputSerializer ()Lkotlinx/serialization/KSerializer;
+	public final fun getStep ()Lorg/modelix/modelql/core/LocalMappingStep;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public class org/modelix/modelql/core/LocalMappingStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	protected fun createFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getTransformation ()Lkotlin/jvm/functions/Function1;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/LocalMappingStepKt {
+	public static final fun buildLocalMapping (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun buildLocalMapping (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun executeLocal (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun executeLocal (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun mapLocal (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun mapLocal (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun mapLocal2 (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun mapLocal2 (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/MapAccessStep : org/modelix/modelql/core/TransformingStepWithParameter {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/MapAccessStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/MapAccessStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/MapAccessStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/MapAccessStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/MapAccessStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/MapAccessStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/MapAccessStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MapAccessStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MapAccessStepKt {
+	public static final fun get (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/MapCollectorStep : org/modelix/modelql/core/CollectorStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/MapCollectorStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/MapCollectorStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/MapCollectorStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/MapCollectorStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/MapCollectorStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/MapCollectorStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/MapCollectorStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MapCollectorStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MapCollectorStepOutputSerializer : org/modelix/modelql/core/CollectorStepOutputSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun inputToInternal (Ljava/util/List;)Ljava/lang/Object;
+	public synthetic fun internalToOutput (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/MapIfNotNullStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Lorg/modelix/modelql/core/MonoUnboundQuery;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/MapIfNotNullStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getQuery ()Lorg/modelix/modelql/core/MonoUnboundQuery;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/MapIfNotNullStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/MapIfNotNullStep$Descriptor$Companion;
+	public fun <init> (J)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getQueryId ()J
+}
+
+public final class org/modelix/modelql/core/MapIfNotNullStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/MapIfNotNullStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/MapIfNotNullStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/MapIfNotNullStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MapIfNotNullStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MapIfNotNullStepKt {
+	public static final fun mapIfNotNull (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun mapIfNotNull (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/MappingStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Lorg/modelix/modelql/core/MonoUnboundQuery;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/MappingStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getQuery ()Lorg/modelix/modelql/core/MonoUnboundQuery;
+	public fun requiresSingularQueryInput ()Z
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun validate ()V
+}
+
+public final class org/modelix/modelql/core/MappingStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/MappingStep$Descriptor$Companion;
+	public fun <init> (J)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getQueryId ()J
+}
+
+public final class org/modelix/modelql/core/MappingStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/MappingStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/MappingStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/MappingStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MappingStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MappingStepKt {
+	public static final fun map (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun map (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/modelql/core/IMonoUnboundQuery;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun map (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun map (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoUnboundQuery;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public abstract class org/modelix/modelql/core/MonoTransformingStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> ()V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public final fun connectAndDowncast (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun connectAndDowncast (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/MonoUnboundQuery : org/modelix/modelql/core/UnboundQuery, org/modelix/modelql/core/IMonoUnboundQuery {
+	public fun <init> (Lorg/modelix/modelql/core/QueryInput;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/QueryReference;Ljava/util/List;)V
+	public fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IMonoQuery;
+	public synthetic fun bind (Lorg/modelix/modelql/core/IQueryExecutor;)Lorg/modelix/modelql/core/IQuery;
+	public fun execute (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IStepOutput;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAggregationOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getElementOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getOutputStep ()Lorg/modelix/modelql/core/IMonoStep;
+	public synthetic fun getOutputStep ()Lorg/modelix/modelql/core/IProducingStep;
+	public fun map (Lorg/modelix/modelql/core/IFluxUnboundQuery;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public fun map (Lorg/modelix/modelql/core/IMonoUnboundQuery;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+}
+
+public final class org/modelix/modelql/core/MultiplexedOutput : org/modelix/modelql/core/IStepOutput {
+	public fun <init> (ILorg/modelix/modelql/core/IStepOutput;)V
+	public final fun getMuxIndex ()I
+	public final fun getOutput ()Lorg/modelix/modelql/core/IStepOutput;
+	public fun getValue ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/MultiplexedOutputKt {
+	public static final fun nullSerializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/MultiplexedOutputSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lorg/modelix/modelql/core/IStep;Ljava/util/List;)V
+	public final fun component1 ()Lorg/modelix/modelql/core/IStep;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lorg/modelix/modelql/core/IStep;Ljava/util/List;)Lorg/modelix/modelql/core/MultiplexedOutputSerializer;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/MultiplexedOutputSerializer;Lorg/modelix/modelql/core/IStep;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/modelql/core/MultiplexedOutputSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/MultiplexedOutput;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getOwner ()Lorg/modelix/modelql/core/IStep;
+	public final fun getSerializers ()Ljava/util/List;
+	public fun hashCode ()I
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/MultiplexedOutput;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/NotOperatorStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/NotOperatorStep$NotDescriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Z)Ljava/lang/Boolean;
+}
+
+public final class org/modelix/modelql/core/NotOperatorStep$NotDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/NotOperatorStep$NotDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/NotOperatorStep$NotDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/NotOperatorStep$NotDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/NotOperatorStep$NotDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/NotOperatorStep$NotDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/NotOperatorStep$NotDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/NotOperatorStepKt {
+	public static final fun not (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/NullIfEmpty : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun canBeEmpty ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/NullIfEmpty$OrNullDescriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/NullIfEmpty$OrNullDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/NullIfEmpty$OrNullDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/NullIfEmpty$OrNullDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/NullIfEmpty$OrNullDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/NullIfEmpty$OrNullDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/NullIfEmpty$OrNullDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/NullIfEmpty$OrNullDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/NullIfEmptyKt {
+	public static final fun nullIfEmpty (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun nullIfEmpty (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun orNull (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun orNull (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/Optional {
+	public static final field Companion Lorg/modelix/modelql/core/Optional$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/Object;)Lorg/modelix/modelql/core/Optional;
+	public static fun constructor-impl (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun flatMap-R6ioWyk (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun get-impl (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/Object;)I
+	public static final fun isPresent-impl (Ljava/lang/Object;)Z
+	public static final fun map-R6ioWyk (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/Object;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/Optional$Companion {
+	public final fun empty-w5vQfLU ()Ljava/lang/Object;
+	public final fun of-R6ioWyk (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/OptionalKt {
+	public static final fun getOrElse-n1_DaB4 (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun presentAndEqual-n1_DaB4 (Ljava/lang/Object;Ljava/lang/Object;)Z
+}
+
+public final class org/modelix/modelql/core/OrOperatorStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/OrOperatorStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/IZipOutput;)Ljava/lang/Boolean;
+}
+
+public final class org/modelix/modelql/core/OrOperatorStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/OrOperatorStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/OrOperatorStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/OrOperatorStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/OrOperatorStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/OrOperatorStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/OrOperatorStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/OrOperatorStepKt {
+	public static final fun or (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/PortConnection {
+	public static final field Companion Lorg/modelix/modelql/core/PortConnection$Companion;
+	public fun <init> (Lorg/modelix/modelql/core/PortReference;Lorg/modelix/modelql/core/PortReference;)V
+	public final fun component1 ()Lorg/modelix/modelql/core/PortReference;
+	public final fun component2 ()Lorg/modelix/modelql/core/PortReference;
+	public final fun copy (Lorg/modelix/modelql/core/PortReference;Lorg/modelix/modelql/core/PortReference;)Lorg/modelix/modelql/core/PortConnection;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/PortConnection;Lorg/modelix/modelql/core/PortReference;Lorg/modelix/modelql/core/PortReference;ILjava/lang/Object;)Lorg/modelix/modelql/core/PortConnection;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConsumer ()Lorg/modelix/modelql/core/PortReference;
+	public final fun getProducer ()Lorg/modelix/modelql/core/PortReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/PortConnection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/PortConnection$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/PortConnection;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/PortConnection;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/PortConnection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/PortReference {
+	public static final field Companion Lorg/modelix/modelql/core/PortReference$Companion;
+	public fun <init> (II)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lorg/modelix/modelql/core/PortReference;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/PortReference;IIILjava/lang/Object;)Lorg/modelix/modelql/core/PortReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPort ()I
+	public final fun getStep ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/PortReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/PortReference$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/PortReference;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/PortReference;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/PortReference$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/PrintStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Ljava/lang/String;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getPrefix ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/PrintStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/PrintStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getPrefix ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/PrintStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/PrintStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/PrintStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/PrintStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/PrintStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/PrintStepKt {
+	public static final fun print (Lorg/modelix/modelql/core/IFluxStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun print (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static synthetic fun print$default (Lorg/modelix/modelql/core/IFluxStep;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/modelql/core/IFluxStep;
+	public static synthetic fun print$default (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public abstract class org/modelix/modelql/core/ProducingStep : org/modelix/modelql/core/IProducingStep {
+	public fun <init> ()V
+	public fun addConsumer (Lorg/modelix/modelql/core/IConsumingStep;)V
+	public fun getConsumers ()Ljava/util/List;
+	public fun getOwner ()Lorg/modelix/modelql/core/QueryReference;
+}
+
+public final class org/modelix/modelql/core/QueryBuilderContext : org/modelix/modelql/core/IQueryBuilderContext {
+	public static final field Companion Lorg/modelix/modelql/core/QueryBuilderContext$Companion;
+	public fun <init> ()V
+	public final fun computeWith (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun getInputStep ()Lorg/modelix/modelql/core/QueryInput;
+	public final fun getQueryReference ()Lorg/modelix/modelql/core/QueryReference;
+	public final fun getSharedSteps ()Ljava/util/ArrayList;
+	public fun mapRecursive (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public fun shared (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public fun shared (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun shared (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/SharedStep;
+	public final fun validateAll ()V
+	public final fun validateAllIfRoot ()V
+}
+
+public final class org/modelix/modelql/core/QueryBuilderContext$Companion {
+	public final fun getCONTEXT_VALUE ()Lorg/modelix/kotlin/utils/ContextValue;
+}
+
+public final class org/modelix/modelql/core/QueryBuilderContextKt {
+	public static final fun buildFluxQuery (Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IFluxUnboundQuery;
+	public static final fun buildMonoQuery (Lkotlin/jvm/functions/Function2;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+}
+
+public final class org/modelix/modelql/core/QueryCallStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (Lorg/modelix/modelql/core/QueryReference;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getQuery ()Lorg/modelix/modelql/core/IUnboundQuery;
+	public final fun getQueryRef ()Lorg/modelix/modelql/core/QueryReference;
+	public fun requiresSingularQueryInput ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/QueryCallStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/QueryCallStep$Descriptor$Companion;
+	public fun <init> (J)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getQueryId ()J
+}
+
+public final class org/modelix/modelql/core/QueryCallStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/QueryCallStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/QueryCallStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/QueryCallStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryCallStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryCallStepKt {
+	public static final fun callFluxQuery (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun callFluxQuery (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/QueryReference;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun callQuery (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun callQuery (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/QueryReference;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/QueryDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/QueryDescriptor$Companion;
+	public fun <init> (IILjava/util/List;ZJ)V
+	public synthetic fun <init> (IILjava/util/List;ZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun component5 ()J
+	public final fun copy (IILjava/util/List;ZJ)Lorg/modelix/modelql/core/QueryDescriptor;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/QueryDescriptor;IILjava/util/List;ZJILjava/lang/Object;)Lorg/modelix/modelql/core/QueryDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInput ()I
+	public final fun getOutput ()I
+	public final fun getQueryId ()J
+	public final fun getSharedSteps ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isFluxOutput ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/QueryDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/QueryDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/QueryDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/QueryDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryDeserializationContext {
+	public fun <init> (Lorg/modelix/modelql/core/QueryGraphDescriptor;)V
+	public final fun createConnections ()V
+	public final fun createQueries ()Ljava/util/List;
+	public final fun getGraphDescriptor ()Lorg/modelix/modelql/core/QueryGraphDescriptor;
+	public final fun getOrCreateQuery (J)Lorg/modelix/modelql/core/UnboundQuery;
+	public final fun getOrCreateQueryReference (J)Lorg/modelix/modelql/core/QueryReference;
+	public final fun getOrCreateStep (I)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/QueryEvaluationContext {
+	public static final field Companion Lorg/modelix/modelql/core/QueryEvaluationContext$Companion;
+	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/util/Map;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/util/Map;ILjava/lang/Object;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue (Lorg/modelix/modelql/core/IProducingStep;)Ljava/util/List;
+	public final fun hasValue (Lorg/modelix/modelql/core/IProducingStep;)Z
+	public fun hashCode ()I
+	public final fun plus (Lkotlin/Pair;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public final fun plus (Lorg/modelix/modelql/core/IProducingStep;Ljava/util/List;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public final fun plus (Lorg/modelix/modelql/core/QueryEvaluationContext;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/QueryEvaluationContext$Companion {
+	public final fun getEMPTY ()Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public final fun of (Lkotlin/Pair;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public final fun of (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IStepOutput;)Lorg/modelix/modelql/core/QueryEvaluationContext;
+}
+
+public final class org/modelix/modelql/core/QueryGraphDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/QueryGraphDescriptor$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/Map;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;Ljava/util/List;)Lorg/modelix/modelql/core/QueryGraphDescriptor;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/QueryGraphDescriptor;Ljava/util/List;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/modelql/core/QueryGraphDescriptor;
+	public final fun createRootQuery ()Lorg/modelix/modelql/core/UnboundQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConnections ()Ljava/util/List;
+	public final fun getQueries ()Ljava/util/List;
+	public final fun getSteps ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun initStepIds ()V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/QueryGraphDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/QueryGraphDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/QueryGraphDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/QueryGraphDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryGraphDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryGraphDescriptorBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/modelix/modelql/core/QueryGraphDescriptor;
+	public final fun createConnections ()V
+	public final fun createStep (Lorg/modelix/modelql/core/IStep;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun id (Lorg/modelix/modelql/core/IStep;)I
+	public final fun load (Lkotlin/sequences/Sequence;)V
+	public final fun load (Lorg/modelix/modelql/core/IUnboundQuery;)J
+	public final fun stepId (Lorg/modelix/modelql/core/IStep;)I
+}
+
+public final class org/modelix/modelql/core/QueryGraphDescriptorBuilder$QueryDescriptorBuilder {
+	public fun <init> (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;Lorg/modelix/modelql/core/UnboundQuery;)V
+	public final fun buildQueryDescriptor ()Lorg/modelix/modelql/core/QueryDescriptor;
+	public final fun getGraphBuilder ()Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;
+	public final fun getQuery ()Lorg/modelix/modelql/core/UnboundQuery;
+}
+
+public final class org/modelix/modelql/core/QueryInput : org/modelix/modelql/core/ProducingStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> ()V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/QueryInput$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createFlow (Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/QueryInput$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/QueryInput$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/QueryInput$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/QueryInput$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/QueryInput$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/QueryInput$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryInput$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryKt {
+	public static final fun castToInstance (Lorg/modelix/modelql/core/IFluxUnboundQuery;)Lorg/modelix/modelql/core/FluxUnboundQuery;
+	public static final fun castToInstance (Lorg/modelix/modelql/core/IMonoUnboundQuery;)Lorg/modelix/modelql/core/MonoUnboundQuery;
+	public static final fun castToInstance (Lorg/modelix/modelql/core/IUnboundQuery;)Lorg/modelix/modelql/core/UnboundQuery;
+	public static final fun evaluate (Lorg/modelix/modelql/core/IMonoUnboundQuery;Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun map (Lorg/modelix/modelql/core/IMonoUnboundQuery;Lorg/modelix/modelql/core/IUnboundQuery;)Lorg/modelix/modelql/core/IUnboundQuery;
+	public static final fun upcast (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/QueryReference : org/modelix/modelql/core/IQueryReference {
+	public static final field Companion Lorg/modelix/modelql/core/QueryReference$Companion;
+	public fun <init> (Lorg/modelix/modelql/core/IUnboundQuery;Ljava/lang/Long;Lkotlin/jvm/functions/Function0;)V
+	public fun getId ()J
+	public final fun getProvidedQuery ()Lorg/modelix/modelql/core/IUnboundQuery;
+	public fun getQuery ()Lorg/modelix/modelql/core/IUnboundQuery;
+	public final fun getQueryId ()Ljava/lang/Long;
+	public final fun setProvidedQuery (Lorg/modelix/modelql/core/IUnboundQuery;)V
+	public final fun setQueryId (Ljava/lang/Long;)V
+}
+
+public final class org/modelix/modelql/core/QueryReference$Companion {
+	public final fun getCONTEXT_VALUE ()Lorg/modelix/kotlin/utils/ContextValue;
+}
+
+public final class org/modelix/modelql/core/RecursiveQuerySerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lorg/modelix/modelql/core/IUnboundQuery;Lorg/modelix/modelql/core/QueryCallStep;Lorg/modelix/modelql/core/SerializationContext;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/IStepOutput;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getOwner ()Lorg/modelix/modelql/core/QueryCallStep;
+	public final fun getQuery ()Lorg/modelix/modelql/core/IUnboundQuery;
+	public final fun getSerializationContext ()Lorg/modelix/modelql/core/SerializationContext;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/IStepOutput;)V
+}
+
+public final class org/modelix/modelql/core/RegexPredicate : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> (Lkotlin/text/Regex;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/RegexPredicate$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRegex ()Lkotlin/text/Regex;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/String;)Ljava/lang/Boolean;
+}
+
+public final class org/modelix/modelql/core/RegexPredicate$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/RegexPredicate$Descriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getPattern ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/RegexPredicate$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/RegexPredicate$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/RegexPredicate$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/RegexPredicate$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/RegexPredicate$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/RegexPredicateKt {
+	public static final fun matches (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/text/Regex;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/SerializationContext {
+	public fun <init> (Lkotlinx/serialization/modules/SerializersModule;Ljava/util/Map;)V
+	public synthetic fun <init> (Lkotlinx/serialization/modules/SerializersModule;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getQueryInputSerializers ()Ljava/util/Map;
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+	public final fun plus (Lkotlin/Pair;)Lorg/modelix/modelql/core/SerializationContext;
+	public final fun serializer (Lkotlin/reflect/KType;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/SetCollectorStep : org/modelix/modelql/core/CollectorStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/SetCollectorStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/SetCollectorStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/SetCollectorStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/SetCollectorStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/SetCollectorStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/SetCollectorStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/SetCollectorStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/SetCollectorStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/SetCollectorStepOutputSerializer : org/modelix/modelql/core/CollectorStepOutputSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun inputToInternal (Ljava/util/List;)Ljava/lang/Object;
+	public synthetic fun internalToOutput (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/SharedStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getRootInputSteps ()Ljava/util/Set;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/SharedStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/SharedStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/SharedStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/SharedStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/SharedStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/SharedStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/SharedStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class org/modelix/modelql/core/SimpleMonoTransformingStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	protected fun createFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/SimpleQueryExecutor : org/modelix/modelql/core/IQueryExecutor {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun createFlow (Lorg/modelix/modelql/core/IUnboundQuery;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getInput ()Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/SimpleStepOutput : org/modelix/modelql/core/IStepOutput {
+	public fun <init> (Ljava/lang/Object;Lorg/modelix/modelql/core/IProducingStep;)V
+	public final fun getOwner ()Lorg/modelix/modelql/core/IProducingStep;
+	public fun getValue ()Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/SimpleStepOutputSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;Lorg/modelix/modelql/core/IProducingStep;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/SimpleStepOutput;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getOwner ()Lorg/modelix/modelql/core/IProducingStep;
+	public final fun getValueSerializer ()Lkotlinx/serialization/KSerializer;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/SimpleStepOutput;)V
+}
+
+public final class org/modelix/modelql/core/SinglePathFlowInstantiationContext : org/modelix/modelql/core/IFlowInstantiationContext {
+	public fun <init> (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/modelql/core/QueryInput;Lkotlinx/coroutines/flow/Flow;)V
+	public fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+	public fun getEvaluationContext ()Lorg/modelix/modelql/core/QueryEvaluationContext;
+	public fun getFlow (Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getInputFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getOrCreateFlow (Lorg/modelix/modelql/core/IProducingStep;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getQueryInput ()Lorg/modelix/modelql/core/QueryInput;
+}
+
+public final class org/modelix/modelql/core/SingleStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/SingleStep$Descriptor;
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/SingleStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/SingleStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/SingleStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/SingleStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/SingleStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/SingleStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/SingleStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/SingleStepKt {
+	public static final fun single (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public abstract class org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/StepDescriptor$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/lang/Long;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getId ()Ljava/lang/Integer;
+	public final fun getOwner ()Ljava/lang/Long;
+	public final fun setId (Ljava/lang/Integer;)V
+	public final fun setOwner (Ljava/lang/Long;)V
+	public static final synthetic fun write$Self (Lorg/modelix/modelql/core/StepDescriptor;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class org/modelix/modelql/core/StepDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringContainsPredicate : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getSubstring ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/String;)Ljava/lang/Boolean;
+}
+
+public final class org/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getSubstring ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringContainsPredicate$StringContainsDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringContainsPredicateKt {
+	public static final fun contains (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/StringToBooleanStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/String;)Ljava/lang/Boolean;
+}
+
+public final class org/modelix/modelql/core/StringToBooleanStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/StringToBooleanStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/StringToBooleanStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/StringToBooleanStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/StringToBooleanStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/StringToBooleanStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringToBooleanStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringToBooleanStepKt {
+	public static final fun toBoolean (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun toBoolean (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/StringToIntStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/String;)Ljava/lang/Integer;
+}
+
+public final class org/modelix/modelql/core/StringToIntStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/StringToIntStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/StringToIntStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/StringToIntStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/StringToIntStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/StringToIntStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringToIntStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/StringToIntStepKt {
+	public static final fun toInt (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun toInt (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/TakeStep : org/modelix/modelql/core/TransformingStep, org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (I)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/TakeStep$Descriptor;
+	public final fun getCount ()I
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/TakeStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/TakeStep$Descriptor$Companion;
+	public fun <init> (I)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getCount ()I
+}
+
+public final class org/modelix/modelql/core/TakeStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/TakeStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/TakeStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/TakeStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/TakeStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/TakeStepKt {
+	public static final fun take (Lorg/modelix/modelql/core/IFluxStep;I)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/ToStringStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/ToStringStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/ToStringStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/ToStringStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/ToStringStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ToStringStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ToStringStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ToStringStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ToStringStepKt {
+	public static final fun asString (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun asString (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asStringNullable (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun asStringNullable (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public abstract class org/modelix/modelql/core/TransformingStep : org/modelix/modelql/core/ProducingStep, org/modelix/modelql/core/IProcessingStep {
+	public fun <init> ()V
+	public fun addProducer (Lorg/modelix/modelql/core/IProducingStep;)V
+	protected abstract fun createFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun createFlow (Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getProducer ()Lorg/modelix/modelql/core/IProducingStep;
+	public fun getProducers ()Ljava/util/List;
+	public fun validate ()V
+}
+
+public abstract class org/modelix/modelql/core/TransformingStepWithParameter : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun addProducer (Lorg/modelix/modelql/core/IProducingStep;)V
+	protected fun createFlow (Lkotlinx/coroutines/flow/Flow;Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public final fun getInputProducer ()Lorg/modelix/modelql/core/IProducingStep;
+	public final fun getParameterProducer ()Lorg/modelix/modelql/core/IProducingStep;
+	public fun getProducers ()Ljava/util/List;
+	protected abstract fun transformElement (Lorg/modelix/modelql/core/IStepOutput;Lorg/modelix/modelql/core/IStepOutput;)Lorg/modelix/modelql/core/IStepOutput;
+	public fun validate ()V
+}
+
+public abstract class org/modelix/modelql/core/UnboundQuery : org/modelix/modelql/core/IUnboundQuery {
+	public static final field Companion Lorg/modelix/modelql/core/UnboundQuery$Companion;
+	public fun <init> (Lorg/modelix/modelql/core/QueryInput;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/QueryReference;Ljava/util/List;)V
+	public fun asFlow (Lorg/modelix/modelql/core/QueryEvaluationContext;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public fun canBeEmpty ()Z
+	public final fun createDescriptor ()Lorg/modelix/modelql/core/QueryGraphDescriptor;
+	public final fun getAllSteps ()Ljava/util/Set;
+	public final fun getInputStep ()Lorg/modelix/modelql/core/QueryInput;
+	public fun getOutputStep ()Lorg/modelix/modelql/core/IProducingStep;
+	public final fun getOwnSteps ()Ljava/util/List;
+	public synthetic fun getReference ()Lorg/modelix/modelql/core/IQueryReference;
+	public fun getReference ()Lorg/modelix/modelql/core/QueryReference;
+	public final fun getSharedSteps ()Ljava/util/List;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+	public final fun validate ()V
+}
+
+public final class org/modelix/modelql/core/UnboundQuery$Companion {
+	public final fun generateId ()J
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class org/modelix/modelql/core/VersionAndData {
+	public static final field Companion Lorg/modelix/modelql/core/VersionAndData$Companion;
+	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
+	public final fun getData ()Ljava/lang/Object;
+	public final fun getVersion ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/VersionAndData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/VersionAndData;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/VersionAndData;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/VersionAndData$Companion {
+	public final fun deserialize (Ljava/lang/String;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/json/Json;)Lorg/modelix/modelql/core/VersionAndData;
+	public final fun readVersionOnly (Ljava/lang/String;)Ljava/lang/String;
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/VersionKt {
+	public static final field modelqlVersion Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/WhenStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Ljava/util/List;Lorg/modelix/modelql/core/IMonoUnboundQuery;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getCases ()Ljava/util/List;
+	public final fun getElseCase ()Lorg/modelix/modelql/core/IMonoUnboundQuery;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/WhenStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/WhenStep$Descriptor$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getCases ()Ljava/util/List;
+	public final fun getElseCase ()Ljava/lang/Long;
+}
+
+public final class org/modelix/modelql/core/WhenStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/WhenStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/WhenStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/WhenStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/WhenStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/WhenStepBuilder {
+	public fun <init> (Lorg/modelix/modelql/core/IMonoStep;)V
+	public final fun else (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun if (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/WhenStepBuilder$CaseBuilder;
+}
+
+public final class org/modelix/modelql/core/WhenStepBuilder$CaseBuilder {
+	public fun <init> (Lorg/modelix/modelql/core/WhenStepBuilder;Lorg/modelix/modelql/core/IMonoUnboundQuery;)V
+	public final fun getCondition ()Lorg/modelix/modelql/core/IMonoUnboundQuery;
+	public final fun then (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/WhenStepBuilder;
+}
+
+public final class org/modelix/modelql/core/WhenStepKt {
+	public static final fun when (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/WhenStepBuilder;
+}
+
+public final class org/modelix/modelql/core/WithIndexStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun requiresSingularQueryInput ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/WithIndexStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/WithIndexStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/WithIndexStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/WithIndexStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/WithIndexStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/WithIndexStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/WithIndexStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/WithIndexStepKt {
+	public static final fun getIndex (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getValue (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun withIndex (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/ZipBuilder {
+	public fun <init> ()V
+	public final fun compileOutputStep ()Lorg/modelix/modelql/core/IMonoStep;
+	public final fun request (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IValueRequest;
+	public final fun withResult (Lorg/modelix/modelql/core/IZipOutput;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class org/modelix/modelql/core/ZipElementAccessStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (I)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getIndex ()I
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/ZipElementAccessStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/ZipElementAccessStep$Descriptor$Companion;
+	public fun <init> (I)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getIndex ()I
+}
+
+public final class org/modelix/modelql/core/ZipElementAccessStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/ZipElementAccessStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ZipElementAccessStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ZipElementAccessStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ZipElementAccessStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ZipElementAccessStepKt {
+	public static final fun component1 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component2 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component3 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component4 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component5 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component6 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component7 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component8 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component9 (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getEighth (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getFifth (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getFirst (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getForth (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getFourth (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getNinth (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getSecond (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getSeventh (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getSixth (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getThird (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/core/ZipOutput : org/modelix/modelql/core/IZip9Output {
+	public static final field Companion Lorg/modelix/modelql/core/ZipOutput$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/modelix/modelql/core/ZipOutput;
+	public static synthetic fun copy$default (Lorg/modelix/modelql/core/ZipOutput;Ljava/util/List;ILjava/lang/Object;)Lorg/modelix/modelql/core/ZipOutput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (I)Ljava/lang/Object;
+	public fun getEighth ()Ljava/lang/Object;
+	public fun getFifth ()Ljava/lang/Object;
+	public fun getFirst ()Ljava/lang/Object;
+	public fun getFourth ()Ljava/lang/Object;
+	public fun getNinth ()Ljava/lang/Object;
+	public fun getSecond ()Ljava/lang/Object;
+	public fun getSeventh ()Ljava/lang/Object;
+	public fun getSixth ()Ljava/lang/Object;
+	public fun getThird ()Ljava/lang/Object;
+	public fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/core/ZipOutput$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public synthetic fun <init> (Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;)V
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ZipOutput;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ZipOutput;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ZipOutput$Companion {
+	public final fun serializer (Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ZipOutputSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ([Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ZipStepOutput;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getElementSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ZipStepOutput;)V
+}
+
+public class org/modelix/modelql/core/ZipStep : org/modelix/modelql/core/ProducingStep, org/modelix/modelql/core/IConsumingStep, org/modelix/modelql/core/IFluxStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> ()V
+	public fun addProducer (Lorg/modelix/modelql/core/IProducingStep;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/ZipStep$Descriptor;
+	public fun createFlow (Lorg/modelix/modelql/core/IFlowInstantiationContext;)Lkotlinx/coroutines/flow/Flow;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun getProducers ()Ljava/util/List;
+	public fun requiresSingularQueryInput ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun validate ()V
+}
+
+public final class org/modelix/modelql/core/ZipStep$Descriptor : org/modelix/modelql/core/CoreStepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/core/ZipStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/core/ZipStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/core/ZipStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/core/ZipStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/core/ZipStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ZipStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/core/ZipStepKt {
+	public static final fun allowEmpty (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun allowEmpty (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun assertNotEmpty (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun assertNotEmpty (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun component1 (Lorg/modelix/modelql/core/IZip1Output;)Ljava/lang/Object;
+	public static final fun component2 (Lorg/modelix/modelql/core/IZip2Output;)Ljava/lang/Object;
+	public static final fun component3 (Lorg/modelix/modelql/core/IZip3Output;)Ljava/lang/Object;
+	public static final fun component4 (Lorg/modelix/modelql/core/IZip4Output;)Ljava/lang/Object;
+	public static final fun component5 (Lorg/modelix/modelql/core/IZip5Output;)Ljava/lang/Object;
+	public static final fun component6 (Lorg/modelix/modelql/core/IZip6Output;)Ljava/lang/Object;
+	public static final fun component7 (Lorg/modelix/modelql/core/IZip7Output;)Ljava/lang/Object;
+	public static final fun component8 (Lorg/modelix/modelql/core/IZip8Output;)Ljava/lang/Object;
+	public static final fun component9 (Lorg/modelix/modelql/core/IZip9Output;)Ljava/lang/Object;
+	public static final fun zip (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IMonoStep;[Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun zip (Lorg/modelix/modelql/core/IProducingStep;[Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun zipList ([Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zipN (Lorg/modelix/modelql/core/IMonoStep;[Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun zipN (Lorg/modelix/modelql/core/IProducingStep;[Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/core/ZipStepOutput : org/modelix/modelql/core/IStepOutput {
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue ()Lorg/modelix/modelql/core/IZipOutput;
+	public final fun getValues ()Ljava/util/List;
+}
+

--- a/modelql-html/api/modelql-html.api
+++ b/modelql-html/api/modelql-html.api
@@ -1,0 +1,20 @@
+public final class org/modelix/modelql/html/HtmlTemplatesKt {
+	public static final fun buildHtmlQuery (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoUnboundQuery;
+	public static final fun insert (Ljava/lang/Object;Lorg/modelix/modelql/html/ModelQLTemplateInstance;Lio/ktor/server/html/TemplatePlaceholder;)V
+	public static final fun insert (Ljava/lang/Object;Lorg/modelix/modelql/html/ModelQLTemplateInstance;Lkotlin/jvm/functions/Function1;)V
+	public static final fun requestTemplate (Lorg/modelix/modelql/core/IFragmentBuilder;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/modelql/html/IModelQLTemplate;)Lorg/modelix/modelql/html/ModelQLTemplateInstance;
+	public static final fun toKotlinTemplate (Lorg/modelix/modelql/core/IBoundFragment;)Lio/ktor/server/html/Template;
+	public static final fun toKotlinTemplate (Lorg/modelix/modelql/core/IValueRequest;)Lio/ktor/server/html/Template;
+	public static final fun toKotlinTemplate (Lorg/modelix/modelql/html/ModelQLTemplateInstance;)Lio/ktor/server/html/Template;
+}
+
+public abstract interface class org/modelix/modelql/html/IModelQLTemplate {
+	public abstract fun buildFragment (Lorg/modelix/modelql/core/IFragmentBuilder;)V
+}
+
+public final class org/modelix/modelql/html/ModelQLTemplateInstance {
+	public fun <init> (Lorg/modelix/modelql/html/IModelQLTemplate;Lorg/modelix/modelql/core/IValueRequest;)V
+	public final fun getFragment ()Lorg/modelix/modelql/core/IValueRequest;
+	public final fun getTemplate ()Lorg/modelix/modelql/html/IModelQLTemplate;
+}
+

--- a/modelql-server/api/modelql-server.api
+++ b/modelql-server/api/modelql-server.api
@@ -1,0 +1,24 @@
+public final class org/modelix/modelql/server/ModelQLServer {
+	public static final field Companion Lorg/modelix/modelql/server/ModelQLServer$Companion;
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lorg/modelix/model/area/IArea;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getArea ()Lorg/modelix/model/area/IArea;
+	public final fun getRootNodeProvider ()Lkotlin/jvm/functions/Function0;
+	public final fun installHandler (Lio/ktor/server/routing/Route;)V
+}
+
+public final class org/modelix/modelql/server/ModelQLServer$Builder {
+	public fun <init> ()V
+	public final fun area (Lorg/modelix/model/area/IArea;)Lorg/modelix/modelql/server/ModelQLServer$Builder;
+	public final fun build ()Lorg/modelix/modelql/server/ModelQLServer;
+	public final fun rootNode (Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/server/ModelQLServer$Builder;
+	public final fun rootNode (Lorg/modelix/model/api/INode;)Lorg/modelix/modelql/server/ModelQLServer$Builder;
+}
+
+public final class org/modelix/modelql/server/ModelQLServer$Companion {
+	public final fun builder (Lkotlin/jvm/functions/Function0;)Lorg/modelix/modelql/server/ModelQLServer$Builder;
+	public final fun builder (Lorg/modelix/model/api/INode;)Lorg/modelix/modelql/server/ModelQLServer$Builder;
+	public final fun handleCall (Lio/ktor/server/application/ApplicationCall;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun handleCall (Lio/ktor/server/application/ApplicationCall;Lorg/modelix/model/api/INode;Lorg/modelix/model/area/IArea;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun handleCall$default (Lorg/modelix/modelql/server/ModelQLServer$Companion;Lio/ktor/server/application/ApplicationCall;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+

--- a/modelql-typed/api/modelql-typed.api
+++ b/modelql-typed/api/modelql-typed.api
@@ -1,0 +1,115 @@
+public final class org/modelix/modelql/typed/ConceptSwitchBuilder {
+	public fun <init> (Lorg/modelix/modelql/core/IMonoStep;)V
+	public final fun else (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun if (Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/typed/ConceptSwitchBuilder$CaseBuilder;
+}
+
+public final class org/modelix/modelql/typed/ConceptSwitchBuilder$CaseBuilder {
+	public fun <init> (Lorg/modelix/modelql/typed/ConceptSwitchBuilder;Lorg/modelix/metamodel/IConceptOfTypedNode;)V
+	public final fun getConcept ()Lorg/modelix/metamodel/IConceptOfTypedNode;
+	public final fun then (Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/typed/ConceptSwitchBuilder;
+}
+
+public final class org/modelix/modelql/typed/ConceptSwitchKt {
+	public static final fun conceptSwitch (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/typed/ConceptSwitchBuilder;
+	public static final fun conceptSwitchFragment (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/typed/ConceptSwitchBuilder;
+	public static final fun elseFragment (Lorg/modelix/modelql/typed/ConceptSwitchBuilder;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun thenFragment (Lorg/modelix/modelql/typed/ConceptSwitchBuilder$CaseBuilder;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/typed/ConceptSwitchBuilder;
+}
+
+public final class org/modelix/modelql/typed/TypedModelQL {
+	public static final field INSTANCE Lorg/modelix/modelql/typed/TypedModelQL;
+	public final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedChildListLink;ILorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IMonoStep;
+	public static synthetic fun addNewChild$default (Lorg/modelix/modelql/typed/TypedModelQL;Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedChildListLink;ILorg/modelix/metamodel/IConceptOfTypedNode;ILjava/lang/Object;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun booleanProperty (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun booleanProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun children (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedChildLink;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun children (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedMandatorySingleChildLink;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun children (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedSingleChildLink;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun children (Lorg/modelix/modelql/core/IProducingStep;Lorg/modelix/metamodel/ITypedChildListLink;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+	public final fun intProperty (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun intProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun optionalStringProperty (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun optionalStringProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun rawProperty (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun rawProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun reference (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedReferenceLink;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun reference (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedReferenceLink;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun referenceOrNull (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedReferenceLink;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun referenceOrNull (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedReferenceLink;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun setChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedSingleChildLink;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun setProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun setReference (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedReferenceLink;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun setStringProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public final fun stringProperty (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IFluxStep;
+	public final fun stringProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedProperty;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/typed/TypedModelQLKt {
+	public static final fun conceptReference (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun conceptReference (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun descendants (Lorg/modelix/modelql/core/IFluxStep;Z)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun descendants (Lorg/modelix/modelql/core/IMonoStep;Z)Lorg/modelix/modelql/core/IFluxStep;
+	public static synthetic fun descendants$default (Lorg/modelix/modelql/core/IFluxStep;ZILjava/lang/Object;)Lorg/modelix/modelql/core/IFluxStep;
+	public static synthetic fun descendants$default (Lorg/modelix/modelql/core/IMonoStep;ZILjava/lang/Object;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun instanceOf (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun instanceOfExactly_typed_typed (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedConcept;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun instanceOfExactly_typed_untyped (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IConcept;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun instanceOfExactly_untyped_typed (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/ITypedConcept;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun instanceOfExactly_untyped_untyped (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IConcept;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun instanceOf_untyped (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun instanceOf_untyped_untyped (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IConcept;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun nodeReference (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun nodeReference (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun nodeReferenceAsString (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun nodeReferenceAsString (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun ofConcept (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun ofConcept (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun ofConcept_untyped (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun ofConcept_untyped (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/metamodel/IConceptOfTypedNode;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun query (Lorg/modelix/metamodel/ITypedNode;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun typedUnsafe (Lorg/modelix/modelql/core/IFluxStep;Lkotlin/reflect/KClass;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun typedUnsafe (Lorg/modelix/modelql/core/IMonoStep;Lkotlin/reflect/KClass;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun untyped (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun untyped (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun untyped_nullable (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun untyped_nullable (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/typed/TypedNodeSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/metamodel/ITypedNode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getNodeClass ()Lkotlin/reflect/KClass;
+	public final fun getUntypedSerializer ()Lkotlinx/serialization/KSerializer;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/metamodel/ITypedNode;)V
+}
+
+public final class org/modelix/modelql/typed/TypedNodeStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getNodeClass ()Lkotlin/reflect/KClass;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/typed/UntypedNodeSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/api/INode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun getTypedSerializer ()Lkotlinx/serialization/KSerializer;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/api/INode;)V
+}
+
+public final class org/modelix/modelql/typed/UntypedNodeStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/modelql-untyped/api/modelql-untyped.api
+++ b/modelql-untyped/api/modelql-untyped.api
@@ -1,0 +1,825 @@
+public final class org/modelix/modelql/untyped/AddNewChildNodeStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> (Ljava/lang/String;ILorg/modelix/model/api/ConceptReference;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getConcept ()Lorg/modelix/model/api/ConceptReference;
+	public final fun getIndex ()I
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INode;
+}
+
+public final class org/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor$Companion;
+	public fun <init> (Ljava/lang/String;ILorg/modelix/model/api/ConceptReference;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getConcept ()Lorg/modelix/model/api/ConceptReference;
+	public final fun getIndex ()I
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/AddNewChildNodeStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/AddNewChildNodeStepKt {
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;I)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;ILorg/modelix/model/api/ConceptReference;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;Lorg/modelix/model/api/ConceptReference;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IChildLink;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IChildLink;I)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/ConceptReference;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun addNewChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IChildLink;Lorg/modelix/model/api/ConceptReference;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/AllChildrenTraversalStep : org/modelix/modelql/core/FluxTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/AllChildrenTraversalStep$AllChildrenStepDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/AllChildrenTraversalStepKt {
+	public static final fun allChildren (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/untyped/AllReferencesTraversalStep : org/modelix/modelql/core/FluxTransformingStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/AllReferencesTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/AllReferencesTraversalStepKt {
+	public static final fun allReferences (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/untyped/ChildrenTraversalStep : org/modelix/modelql/core/FluxTransformingStep, org/modelix/modelql/core/IFluxStep {
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ChildrenTraversalStep$ChildrenStepDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ChildrenTraversalStepKt {
+	public static final fun children (Lorg/modelix/modelql/core/IProducingStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceTraversalStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/ConceptReference;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceTraversalStepKt {
+	public static final fun conceptReference (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun conceptReference (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/ConceptReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStepKt {
+	public static final fun getUID (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun getUID (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun getUID_nullable (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun getUID_nullable (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep : org/modelix/modelql/core/FluxTransformingStep, org/modelix/modelql/core/IFluxStep {
+	public fun <init> (Z)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getIncludeSelf ()Z
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep$WithSelfDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStep$WithoutSelfDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/DescendantsTraversalStepKt {
+	public static final fun descendants (Lorg/modelix/modelql/core/IProducingStep;Z)Lorg/modelix/modelql/core/IFluxStep;
+	public static synthetic fun descendants$default (Lorg/modelix/modelql/core/IProducingStep;ZILjava/lang/Object;)Lorg/modelix/modelql/core/IFluxStep;
+}
+
+public abstract interface class org/modelix/modelql/untyped/ISupportsModelQL : org/modelix/model/api/INode {
+	public abstract fun createQueryExecutor ()Lorg/modelix/modelql/core/IQueryExecutor;
+}
+
+public final class org/modelix/modelql/untyped/ISupportsModelQL$DefaultImpls {
+	public static fun addNewChild (Lorg/modelix/modelql/untyped/ISupportsModelQL;Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChildren (Lorg/modelix/modelql/untyped/ISupportsModelQL;Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public static fun getAllChildrenAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllProperties (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefs (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefsAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargets (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Ljava/util/List;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildren (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public static fun getChildrenAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getContainmentLink (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Lorg/modelix/model/api/IChildLink;
+	public static fun getDescendantsAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;Z)Lkotlinx/coroutines/flow/Flow;
+	public static fun getOriginalReference (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Ljava/lang/String;
+	public static fun getParentAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyLinks (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Ljava/util/List;
+	public static fun getPropertyValue (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceLinks (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Ljava/util/List;
+	public static fun getReferenceTarget (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetRef (Lorg/modelix/modelql/untyped/ISupportsModelQL;Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRef (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRefAsFlow (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun moveChild (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public static fun removeReference (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;)V
+	public static fun setPropertyValue (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public static fun setReferenceTarget (Lorg/modelix/modelql/untyped/ISupportsModelQL;Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public static fun setReferenceTarget (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/modelql/untyped/ISupportsModelQL;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public static fun tryGetConcept (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Lorg/modelix/model/api/IConcept;
+	public static fun usesRoleIds (Lorg/modelix/modelql/untyped/ISupportsModelQL;)Z
+}
+
+public final class org/modelix/modelql/untyped/MoveNodeStep : org/modelix/modelql/core/TransformingStepWithParameter {
+	public fun <init> (Ljava/lang/String;I)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public final fun getIndex ()I
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+	public fun validate ()V
+}
+
+public final class org/modelix/modelql/untyped/MoveNodeStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/MoveNodeStep$Descriptor$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getIndex ()I
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/MoveNodeStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/MoveNodeStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/MoveNodeStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/MoveNodeStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/MoveNodeStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/MoveNodeStepKt {
+	public static final fun moveChild (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;ILorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun moveChild (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IChildLink;ILorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static synthetic fun moveChild$default (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;ILorg/modelix/modelql/core/IMonoStep;ILjava/lang/Object;)Lorg/modelix/modelql/core/IMonoStep;
+	public static synthetic fun moveChild$default (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IChildLink;ILorg/modelix/modelql/core/IMonoStep;ILjava/lang/Object;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public class org/modelix/modelql/untyped/NodeKSerializer : kotlinx/serialization/KSerializer {
+	public fun <init> ()V
+	protected fun createNode (Lorg/modelix/model/api/NodeReference;)Lorg/modelix/model/api/INode;
+	protected fun createNode (Lorg/modelix/model/api/NodeReference;Lorg/modelix/model/api/ConceptReference;)Lorg/modelix/model/api/INode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/model/api/INode;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/model/api/INode;)V
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/INodeReference;)Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStepKt {
+	public static final fun nodeReferenceAsString (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun nodeReferenceAsString (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun serialize (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun serialize (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceSourceStep : org/modelix/modelql/core/ConstantSourceStep {
+	public fun <init> (Lorg/modelix/model/api/INodeReference;)V
+	public fun canEvaluateStatically ()Z
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor;
+	public synthetic fun evaluateStatically ()Ljava/lang/Object;
+	public fun evaluateStatically ()Lorg/modelix/model/api/INodeReference;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor$Companion;
+	public fun <init> (Lorg/modelix/model/api/INodeReference;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getElement ()Lorg/modelix/model/api/INodeReference;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceSourceStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceSourceStepKt {
+	public static final fun asMono (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun asMonoNullable (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceTraversalStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/INode;)Lorg/modelix/model/api/INodeReference;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/NodeReferenceTraversalStepKt {
+	public static final fun nodeReference (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun nodeReference (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/OfConceptStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> (Ljava/util/Set;)V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/OfConceptStep$Descriptor;
+	public final fun getConceptUIDs ()Ljava/util/Set;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/OfConceptStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/OfConceptStep$Descriptor$Companion;
+	public fun <init> (Ljava/util/Set;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getConceptUIDs ()Ljava/util/Set;
+}
+
+public final class org/modelix/modelql/untyped/OfConceptStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/OfConceptStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/OfConceptStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/OfConceptStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/OfConceptStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/OfConceptStepKt {
+	public static final fun ofConcept (Lorg/modelix/modelql/core/IFluxStep;Lorg/modelix/model/api/IConcept;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun ofConcept (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IConcept;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/ParentTraversalStep : org/modelix/modelql/core/MonoTransformingStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> ()V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/ParentTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ParentTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/ParentTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/ParentTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/ParentTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/ParentTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/ParentTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ParentTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ParentTraversalStepKt {
+	public static final fun parent (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun parent (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/PropertyTraversalStep : org/modelix/modelql/core/SimpleMonoTransformingStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (Ljava/lang/String;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/INode;)Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/PropertyTraversalStep$PropertyStepDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/PropertyTraversalStepKt {
+	public static final fun property (Lorg/modelix/modelql/core/IFluxStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun property (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/ReferenceTraversalStep : org/modelix/modelql/core/MonoTransformingStep, org/modelix/modelql/core/IMonoStep {
+	public fun <init> (Ljava/lang/String;)V
+	public fun canBeEmpty ()Z
+	public fun canBeMultiple ()Z
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ReferenceTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ReferenceTraversalStepKt {
+	public static final fun reference (Lorg/modelix/modelql/core/IFluxStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun reference (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun referenceOrNull (Lorg/modelix/modelql/core/IFluxStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun referenceOrNull (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/RemoveNodeStep : org/modelix/modelql/core/AggregationStep {
+	public fun <init> ()V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/RemoveNodeStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/RemoveNodeStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/RemoveNodeStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/RemoveNodeStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/RemoveNodeStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/RemoveNodeStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/RemoveNodeStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/RemoveNodeStepKt {
+	public static final fun remove (Lorg/modelix/modelql/core/IProducingStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/ResolveNodeStep : org/modelix/modelql/core/MonoTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/ResolveNodeStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/ResolveNodeStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/ResolveNodeStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/ResolveNodeStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/ResolveNodeStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/ResolveNodeStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/ResolveNodeStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ResolveNodeStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/ResolveNodeStepKt {
+	public static final fun resolve (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun resolve (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/RoleInParentTraversalStep : org/modelix/modelql/core/SimpleMonoTransformingStep {
+	public fun <init> ()V
+	public synthetic fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun transform (Lorg/modelix/modelql/core/QueryEvaluationContext;Lorg/modelix/model/api/INode;)Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor$Companion;
+	public fun <init> ()V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+}
+
+public final class org/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/RoleInParentTraversalStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/RoleInParentTraversalStepKt {
+	public static final fun roleInParent (Lorg/modelix/modelql/core/IFluxStep;)Lorg/modelix/modelql/core/IFluxStep;
+	public static final fun roleInParent (Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/SetPropertyStep : org/modelix/modelql/core/TransformingStepWithParameter {
+	public fun <init> (Ljava/lang/String;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/SetPropertyStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/SetPropertyStep$Descriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/SetPropertyStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/SetPropertyStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/SetPropertyStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/SetPropertyStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/SetPropertyStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/SetPropertyStepKt {
+	public static final fun setProperty (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun setProperty (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun setProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun setProperty (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IProperty;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/SetReferenceStep : org/modelix/modelql/core/TransformingStepWithParameter {
+	public fun <init> (Ljava/lang/String;)V
+	public fun createDescriptor (Lorg/modelix/modelql/core/QueryGraphDescriptorBuilder;)Lorg/modelix/modelql/core/StepDescriptor;
+	public fun getOutputSerializer (Lorg/modelix/modelql/core/SerializationContext;)Lkotlinx/serialization/KSerializer;
+	public final fun getRole ()Ljava/lang/String;
+	public fun requiresWriteAccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/SetReferenceStep$Descriptor : org/modelix/modelql/core/StepDescriptor {
+	public static final field Companion Lorg/modelix/modelql/untyped/SetReferenceStep$Descriptor$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun createStep (Lorg/modelix/modelql/core/QueryDeserializationContext;)Lorg/modelix/modelql/core/IStep;
+	public final fun getRole ()Ljava/lang/String;
+}
+
+public final class org/modelix/modelql/untyped/SetReferenceStep$Descriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/SetReferenceStep$Descriptor$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/modelix/modelql/untyped/SetReferenceStep$Descriptor;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/modelix/modelql/untyped/SetReferenceStep$Descriptor;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/SetReferenceStep$Descriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/modelix/modelql/untyped/SetReferenceStepKt {
+	public static final fun setReference (Lorg/modelix/modelql/core/IMonoStep;Ljava/lang/String;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+	public static final fun setReference (Lorg/modelix/modelql/core/IMonoStep;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/modelql/core/IMonoStep;)Lorg/modelix/modelql/core/IMonoStep;
+}
+
+public final class org/modelix/modelql/untyped/UntypedModelQL {
+	public static final field INSTANCE Lorg/modelix/modelql/untyped/UntypedModelQL;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class org/modelix/modelql/untyped/UntypedModelQLKt {
+	public static final fun buildFluxQuery (Lorg/modelix/model/api/INode;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IFluxQuery;
+	public static final fun buildQuery (Lorg/modelix/model/api/INode;Lkotlin/jvm/functions/Function1;)Lorg/modelix/modelql/core/IMonoQuery;
+	public static final fun createQueryExecutor (Lorg/modelix/model/api/INode;)Lorg/modelix/modelql/core/IQueryExecutor;
+	public static final fun query (Lorg/modelix/model/api/INode;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun queryFlux (Lorg/modelix/model/api/INode;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/mps-model-adapters/api/mps-model-adapters.api
+++ b/mps-model-adapters/api/mps-model-adapters.api
@@ -1,0 +1,665 @@
+public class org/modelix/model/mpsadapters/ConceptWorkaround {
+	public field concept Lorg/jetbrains/mps/openapi/language/SAbstractConcept;
+	public fun <init> (Lorg/jetbrains/mps/openapi/language/SAbstractConcept;)V
+	public fun getSuperConcept ()Lorg/jetbrains/mps/openapi/language/SConcept;
+	public fun getSuperInterfaces ()Ljava/lang/Iterable;
+}
+
+public abstract interface class org/modelix/model/mpsadapters/IDefaultNodeAdapter : org/modelix/model/api/IDeprecatedNodeDefaults {
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getOriginalReference ()Ljava/lang/String;
+	public fun getPropertyLinks ()Ljava/util/List;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReferenceLinks ()Ljava/util/List;
+	public fun getReferenceTarget (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public fun isValid ()Z
+	public fun moveChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public fun tryGetConcept ()Lorg/modelix/model/api/IConcept;
+}
+
+public final class org/modelix/model/mpsadapters/IDefaultNodeAdapter$DefaultImpls {
+	public static fun addNewChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public static fun addNewChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public static fun addNewChildren (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;ILjava/util/List;)Ljava/util/List;
+	public static fun getAllChildren (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/lang/Iterable;
+	public static fun getAllChildrenAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllProperties (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefs (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getAllReferenceTargetRefsAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getAllReferenceTargets (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getAllReferenceTargetsAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getChildren (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;)Ljava/lang/Iterable;
+	public static fun getChildren (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public static fun getChildrenAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IChildLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getConceptReference (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Lorg/modelix/model/api/IConceptReference;
+	public static fun getDescendantsAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Z)Lkotlinx/coroutines/flow/Flow;
+	public static fun getOriginalReference (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/lang/String;
+	public static fun getParentAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getPropertyLinks (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getPropertyRoles (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getPropertyValue (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;)Ljava/lang/String;
+	public static fun getPropertyValue (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public static fun getPropertyValueAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IProperty;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceLinks (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getReferenceRoles (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/util/List;
+	public static fun getReferenceTarget (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTarget (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public static fun getReferenceTargetAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRef (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public static fun getReferenceTargetRefAsFlow (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;)Lkotlinx/coroutines/flow/Flow;
+	public static fun getRoleInParent (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Ljava/lang/String;
+	public static fun isValid (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Z
+	public static fun moveChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;ILorg/modelix/model/api/INode;)V
+	public static fun moveChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public static fun removeChild (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/INode;)V
+	public static fun removeReference (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;)V
+	public static fun setPropertyValue (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;Ljava/lang/String;)V
+	public static fun setPropertyValue (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Ljava/lang/String;Lorg/modelix/model/api/INodeReference;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public static fun setReferenceTarget (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public static fun tryGetConcept (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Lorg/modelix/model/api/IConcept;
+	public static fun usesRoleIds (Lorg/modelix/model/mpsadapters/IDefaultNodeAdapter;)Z
+}
+
+public final class org/modelix/model/mpsadapters/MPSArea : org/modelix/model/area/IArea, org/modelix/model/area/IAreaReference {
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SRepository;)V
+	public fun addListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun canRead ()Z
+	public fun canWrite ()Z
+	public fun collectAreas ()Ljava/util/List;
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SRepository;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SRepository;)Lorg/modelix/model/mpsadapters/MPSArea;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSArea;Lorg/jetbrains/mps/openapi/module/SRepository;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSArea;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun executeRead (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun executeWrite (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getReference ()Lorg/modelix/model/area/IAreaReference;
+	public final fun getRepository ()Lorg/jetbrains/mps/openapi/module/SRepository;
+	public fun getRoot ()Lorg/modelix/model/api/INode;
+	public fun hashCode ()I
+	public fun removeListener (Lorg/modelix/model/area/IAreaListener;)V
+	public fun resolveArea (Lorg/modelix/model/area/IAreaReference;)Lorg/modelix/model/area/IArea;
+	public fun resolveBranch (Ljava/lang/String;)Lorg/modelix/model/api/IBranch;
+	public fun resolveConcept (Lorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/IConcept;
+	public fun resolveNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun resolveOriginalNode (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/api/INode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSChildLink : org/modelix/model/api/IChildLink {
+	public fun <init> (Ljetbrains/mps/smodel/adapter/structure/link/SContainmentLinkAdapter;)V
+	public fun <init> (Lorg/jetbrains/mps/openapi/language/SContainmentLink;)V
+	public final fun component1 ()Ljetbrains/mps/smodel/adapter/structure/link/SContainmentLinkAdapter;
+	public final fun copy (Ljetbrains/mps/smodel/adapter/structure/link/SContainmentLinkAdapter;)Lorg/modelix/model/mpsadapters/MPSChildLink;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSChildLink;Ljetbrains/mps/smodel/adapter/structure/link/SContainmentLinkAdapter;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSChildLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getLink ()Ljetbrains/mps/smodel/adapter/structure/link/SContainmentLinkAdapter;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isMultiple ()Z
+	public fun isOptional ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSConcept : org/modelix/model/api/IConcept {
+	public fun <init> (Ljetbrains/mps/smodel/adapter/structure/concept/SAbstractConceptAdapter;)V
+	public fun <init> (Lorg/jetbrains/mps/openapi/language/SAbstractConcept;)V
+	public final fun component1 ()Ljetbrains/mps/smodel/adapter/structure/concept/SAbstractConceptAdapter;
+	public final fun copy (Ljetbrains/mps/smodel/adapter/structure/concept/SAbstractConceptAdapter;)Lorg/modelix/model/mpsadapters/MPSConcept;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSConcept;Ljetbrains/mps/smodel/adapter/structure/concept/SAbstractConceptAdapter;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSConcept;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildLinks ()Ljava/util/List;
+	public fun getAllProperties ()Ljava/util/List;
+	public fun getAllReferenceLinks ()Ljava/util/List;
+	public fun getChildLink (Ljava/lang/String;)Lorg/modelix/model/api/IChildLink;
+	public final fun getConcept ()Ljetbrains/mps/smodel/adapter/structure/concept/SAbstractConceptAdapter;
+	public fun getDirectSuperConcepts ()Ljava/util/List;
+	public fun getLanguage ()Lorg/modelix/model/api/ILanguage;
+	public fun getLongName ()Ljava/lang/String;
+	public fun getOwnChildLinks ()Ljava/util/List;
+	public fun getOwnProperties ()Ljava/util/List;
+	public fun getOwnReferenceLinks ()Ljava/util/List;
+	public fun getProperty (Ljava/lang/String;)Lorg/modelix/model/api/IProperty;
+	public fun getReference ()Lorg/modelix/model/api/ConceptReference;
+	public synthetic fun getReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getReferenceLink (Ljava/lang/String;)Lorg/modelix/model/api/IReferenceLink;
+	public fun getShortName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isAbstract ()Z
+	public fun isExactly (Lorg/modelix/model/api/IConcept;)Z
+	public fun isSubConceptOf (Lorg/modelix/model/api/IConcept;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSDevKitDependencyAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;)V
+	public synthetic fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun component2 ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun component3 ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;)Lorg/modelix/model/mpsadapters/MPSDevKitDependencyAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSDevKitDependencyAsNode;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSDevKitDependencyAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getModelImporter ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public final fun getModuleImporter ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun getModuleReference ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSDevKitDependencyReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSDevKitDependencyReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;)V
+	public synthetic fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleId;
+	public final fun component2 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun component3 ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;)Lorg/modelix/model/mpsadapters/MPSDevKitDependencyReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSDevKitDependencyReference;Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSDevKitDependencyReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsedModuleId ()Lorg/jetbrains/mps/openapi/module/SModuleId;
+	public final fun getUserModel ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun getUserModule ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSDevKitDependencyReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Ljetbrains/mps/project/facets/JavaModuleFacet;)V
+	public final fun component1 ()Ljetbrains/mps/project/facets/JavaModuleFacet;
+	public final fun copy (Ljetbrains/mps/project/facets/JavaModuleFacet;)Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode;Ljetbrains/mps/project/facets/JavaModuleFacet;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getFacet ()Ljetbrains/mps/project/facets/JavaModuleFacet;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSJavaModuleFacetReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleReference;)Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetReference;Lorg/jetbrains/mps/openapi/module/SModuleReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSJavaModuleFacetReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModuleReference ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSJavaModuleFacetReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSLanguage : org/modelix/model/api/ILanguage {
+	public fun <init> (Lorg/jetbrains/mps/openapi/language/SLanguage;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/language/SLanguage;
+	public final fun copy (Lorg/jetbrains/mps/openapi/language/SLanguage;)Lorg/modelix/model/mpsadapters/MPSLanguage;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSLanguage;Lorg/jetbrains/mps/openapi/language/SLanguage;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSLanguage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getConcepts ()Ljava/util/List;
+	public final fun getLanguage ()Lorg/jetbrains/mps/openapi/language/SLanguage;
+	public fun getName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSLanguageRepository : org/modelix/model/api/ILanguageRepository {
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SRepository;)V
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SRepository;)Lorg/modelix/model/mpsadapters/MPSLanguageRepository;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSLanguageRepository;Lorg/jetbrains/mps/openapi/module/SRepository;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSLanguageRepository;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllConcepts ()Ljava/util/List;
+	public fun getPriority ()I
+	public fun hashCode ()I
+	public synthetic fun resolveConcept (Ljava/lang/String;)Lorg/modelix/model/api/IConcept;
+	public fun resolveConcept (Ljava/lang/String;)Lorg/modelix/model/mpsadapters/MPSConcept;
+	public final fun resolveMPSConcept (Ljava/lang/String;)Lorg/jetbrains/mps/openapi/language/SAbstractConcept;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModelAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/model/SModel;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public final fun copy (Lorg/jetbrains/mps/openapi/model/SModel;)Lorg/modelix/model/mpsadapters/MPSModelAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModelAsNode;Lorg/jetbrains/mps/openapi/model/SModel;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModelAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getModel ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModelImportAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/model/SModel;Lorg/jetbrains/mps/openapi/model/SModel;)V
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getImportedModel ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public final fun getImportingModel ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTarget (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+}
+
+public final class org/modelix/model/mpsadapters/MPSModelImportReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSModelImportReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/model/SModelReference;Lorg/jetbrains/mps/openapi/model/SModelReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun component2 ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/model/SModelReference;Lorg/jetbrains/mps/openapi/model/SModelReference;)Lorg/modelix/model/mpsadapters/MPSModelImportReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModelImportReference;Lorg/jetbrains/mps/openapi/model/SModelReference;Lorg/jetbrains/mps/openapi/model/SModelReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModelImportReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImportedModel ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun getImportingModel ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModelImportReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSModelReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSModelReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/model/SModelReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/model/SModelReference;)Lorg/modelix/model/mpsadapters/MPSModelReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModelReference;Lorg/jetbrains/mps/openapi/model/SModelReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModelReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModelReference ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModelReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSModuleAsNode$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModule;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModule;)Lorg/modelix/model/mpsadapters/MPSModuleAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModuleAsNode;Lorg/jetbrains/mps/openapi/module/SModule;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModuleAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getModule ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleAsNode$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleDependencyAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;IZZLorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/module/SDependencyScope;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun component2 ()I
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun component6 ()Lorg/jetbrains/mps/openapi/module/SDependencyScope;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleReference;IZZLorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/module/SDependencyScope;)Lorg/modelix/model/mpsadapters/MPSModuleDependencyAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModuleDependencyAsNode;Lorg/jetbrains/mps/openapi/module/SModuleReference;IZZLorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/module/SDependencyScope;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModuleDependencyAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getDependencyScope ()Lorg/jetbrains/mps/openapi/module/SDependencyScope;
+	public final fun getExplicit ()Z
+	public final fun getImporter ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun getModuleReference ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun getModuleVersion ()I
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public final fun getReexport ()Z
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleDependencyReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSModuleDependencyReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleId;
+	public final fun component2 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;)Lorg/modelix/model/mpsadapters/MPSModuleDependencyReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModuleDependencyReference;Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModuleDependencyReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsedModuleId ()Lorg/jetbrains/mps/openapi/module/SModuleId;
+	public final fun getUserModuleReference ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleDependencyReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSModuleReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleReference;)Lorg/modelix/model/mpsadapters/MPSModuleReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSModuleReference;Lorg/jetbrains/mps/openapi/module/SModuleReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSModuleReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModuleReference ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSModuleReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/model/SNode;)V
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConcept;)Lorg/modelix/model/api/INode;
+	public fun addNewChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/IConceptReference;)Lorg/modelix/model/api/INode;
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/model/SNode;
+	public final fun copy (Lorg/jetbrains/mps/openapi/model/SNode;)Lorg/modelix/model/mpsadapters/MPSNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSNode;Lorg/jetbrains/mps/openapi/model/SNode;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getConceptReference ()Lorg/modelix/model/api/ConceptReference;
+	public synthetic fun getConceptReference ()Lorg/modelix/model/api/IConceptReference;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getNode ()Lorg/jetbrains/mps/openapi/model/SNode;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyLinks ()Ljava/util/List;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceLinks ()Ljava/util/List;
+	public fun getReferenceTarget (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun isValid ()Z
+	public fun moveChild (Lorg/modelix/model/api/IChildLink;ILorg/modelix/model/api/INode;)V
+	public fun removeChild (Lorg/modelix/model/api/INode;)V
+	public fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INode;)V
+	public fun setReferenceTarget (Lorg/modelix/model/api/IReferenceLink;Lorg/modelix/model/api/INodeReference;)V
+	public fun toString ()Ljava/lang/String;
+	public fun tryGetConcept ()Lorg/modelix/model/api/IConcept;
+}
+
+public final class org/modelix/model/mpsadapters/MPSNodeReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSNodeReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/model/SNodeReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/model/SNodeReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/model/SNodeReference;)Lorg/modelix/model/mpsadapters/MPSNodeReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSNodeReference;Lorg/jetbrains/mps/openapi/model/SNodeReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSNodeReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRef ()Lorg/jetbrains/mps/openapi/model/SNodeReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSNodeReference$Companion {
+	public final fun tryConvert (Lorg/modelix/model/api/INodeReference;)Lorg/modelix/model/mpsadapters/MPSNodeReference;
+}
+
+public final class org/modelix/model/mpsadapters/MPSProjectAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Ljetbrains/mps/project/ProjectBase;)V
+	public final fun component1 ()Ljetbrains/mps/project/ProjectBase;
+	public final fun copy (Ljetbrains/mps/project/ProjectBase;)Lorg/modelix/model/mpsadapters/MPSProjectAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSProjectAsNode;Ljetbrains/mps/project/ProjectBase;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSProjectAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public final fun getProject ()Ljetbrains/mps/project/ProjectBase;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSProjectModuleAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Ljetbrains/mps/project/ProjectBase;Lorg/jetbrains/mps/openapi/module/SModule;)V
+	public final fun component1 ()Ljetbrains/mps/project/ProjectBase;
+	public final fun component2 ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun copy (Ljetbrains/mps/project/ProjectBase;Lorg/jetbrains/mps/openapi/module/SModule;)Lorg/modelix/model/mpsadapters/MPSProjectModuleAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSProjectModuleAsNode;Ljetbrains/mps/project/ProjectBase;Lorg/jetbrains/mps/openapi/module/SModule;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSProjectModuleAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getModule ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public final fun getProject ()Ljetbrains/mps/project/ProjectBase;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun getReferenceTarget (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INode;
+	public fun getReferenceTargetRef (Lorg/modelix/model/api/IReferenceLink;)Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun setPropertyValue (Lorg/modelix/model/api/IProperty;Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSProjectModuleReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSProjectModuleReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/modelix/model/mpsadapters/MPSProjectReference;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun component2 ()Lorg/modelix/model/mpsadapters/MPSProjectReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/modelix/model/mpsadapters/MPSProjectReference;)Lorg/modelix/model/mpsadapters/MPSProjectModuleReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSProjectModuleReference;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/modelix/model/mpsadapters/MPSProjectReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSProjectModuleReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModuleRef ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun getProjectRef ()Lorg/modelix/model/mpsadapters/MPSProjectReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSProjectModuleReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSProjectReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSProjectReference$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lorg/modelix/model/mpsadapters/MPSProjectReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSProjectReference;Ljava/lang/String;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSProjectReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProjectName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSProjectReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/MPSProperty : org/modelix/model/api/IProperty {
+	public fun <init> (Ljetbrains/mps/smodel/adapter/structure/property/SPropertyAdapter;)V
+	public fun <init> (Lorg/jetbrains/mps/openapi/language/SProperty;)V
+	public final fun component1 ()Ljetbrains/mps/smodel/adapter/structure/property/SPropertyAdapter;
+	public final fun copy (Ljetbrains/mps/smodel/adapter/structure/property/SPropertyAdapter;)Lorg/modelix/model/mpsadapters/MPSProperty;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSProperty;Ljetbrains/mps/smodel/adapter/structure/property/SPropertyAdapter;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getProperty ()Ljetbrains/mps/smodel/adapter/structure/property/SPropertyAdapter;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isOptional ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSReferenceLink : org/modelix/model/api/IReferenceLink {
+	public fun <init> (Ljetbrains/mps/smodel/adapter/structure/ref/SReferenceLinkAdapter;)V
+	public fun <init> (Lorg/jetbrains/mps/openapi/language/SReferenceLink;)V
+	public final fun component1 ()Ljetbrains/mps/smodel/adapter/structure/ref/SReferenceLinkAdapter;
+	public final fun copy (Ljetbrains/mps/smodel/adapter/structure/ref/SReferenceLinkAdapter;)Lorg/modelix/model/mpsadapters/MPSReferenceLink;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSReferenceLink;Ljetbrains/mps/smodel/adapter/structure/ref/SReferenceLinkAdapter;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSReferenceLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public final fun getLink ()Ljetbrains/mps/smodel/adapter/structure/ref/SReferenceLinkAdapter;
+	public fun getSimpleName ()Ljava/lang/String;
+	public fun getTargetConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getUID ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isOptional ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSRepositoryAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SRepository;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SRepository;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SRepository;)Lorg/modelix/model/mpsadapters/MPSRepositoryAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSRepositoryAsNode;Lorg/jetbrains/mps/openapi/module/SRepository;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSRepositoryAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAllChildren ()Ljava/lang/Iterable;
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getChildren (Lorg/modelix/model/api/IChildLink;)Ljava/lang/Iterable;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public final fun getRepository ()Lorg/jetbrains/mps/openapi/module/SRepository;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSRepositoryReference : org/modelix/model/api/INodeReference {
+	public static final field INSTANCE Lorg/modelix/model/mpsadapters/MPSRepositoryReference;
+	public fun serialize ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode : org/modelix/model/mpsadapters/IDefaultNodeAdapter {
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;ILorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;)V
+	public synthetic fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleReference;ILorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun component2 ()I
+	public final fun component3 ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun component4 ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleReference;ILorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;)Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode;Lorg/jetbrains/mps/openapi/module/SModuleReference;ILorg/jetbrains/mps/openapi/module/SModule;Lorg/jetbrains/mps/openapi/model/SModel;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getArea ()Lorg/modelix/model/area/IArea;
+	public fun getConcept ()Lorg/modelix/model/api/IConcept;
+	public fun getContainmentLink ()Lorg/modelix/model/api/IChildLink;
+	public final fun getLanguageVersion ()I
+	public final fun getModelImporter ()Lorg/jetbrains/mps/openapi/model/SModel;
+	public final fun getModuleImporter ()Lorg/jetbrains/mps/openapi/module/SModule;
+	public final fun getModuleReference ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun getParent ()Lorg/modelix/model/api/INode;
+	public fun getPropertyValue (Lorg/modelix/model/api/IProperty;)Ljava/lang/String;
+	public fun getReference ()Lorg/modelix/model/api/INodeReference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSSingleLanguageDependencyReference : org/modelix/model/api/INodeReference {
+	public static final field Companion Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyReference$Companion;
+	public fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;)V
+	public synthetic fun <init> (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lorg/jetbrains/mps/openapi/module/SModuleId;
+	public final fun component2 ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public final fun component3 ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun copy (Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;)Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyReference;
+	public static synthetic fun copy$default (Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyReference;Lorg/jetbrains/mps/openapi/module/SModuleId;Lorg/jetbrains/mps/openapi/module/SModuleReference;Lorg/jetbrains/mps/openapi/model/SModelReference;ILjava/lang/Object;)Lorg/modelix/model/mpsadapters/MPSSingleLanguageDependencyReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsedModuleId ()Lorg/jetbrains/mps/openapi/module/SModuleId;
+	public final fun getUserModel ()Lorg/jetbrains/mps/openapi/model/SModelReference;
+	public final fun getUserModule ()Lorg/jetbrains/mps/openapi/module/SModuleReference;
+	public fun hashCode ()I
+	public fun serialize ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/modelix/model/mpsadapters/MPSSingleLanguageDependencyReference$Companion {
+}
+
+public final class org/modelix/model/mpsadapters/Model : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/mpsadapters/Model;
+	public final fun getRootNodes ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/mpsadapters/Module : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/mpsadapters/Module;
+	public final fun getModels ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/mpsadapters/Repository : org/modelix/model/api/SimpleConcept {
+	public static final field INSTANCE Lorg/modelix/model/mpsadapters/Repository;
+	public final fun getModules ()Lorg/modelix/model/api/SimpleChildLink;
+}
+
+public final class org/modelix/model/mpsadapters/RepositoryLanguage : org/modelix/model/api/SimpleLanguage {
+	public static final field INSTANCE Lorg/modelix/model/mpsadapters/RepositoryLanguage;
+	public final fun getBaseConcept ()Lorg/modelix/model/mpsadapters/MPSConcept;
+	public final fun getINamedConcept ()Lorg/modelix/model/mpsadapters/MPSConcept;
+	public final fun getModel ()Lorg/modelix/model/mpsadapters/Model;
+	public final fun getModule ()Lorg/modelix/model/mpsadapters/Module;
+	public final fun getNamePropertyUID ()Ljava/lang/String;
+	public final fun getRepository ()Lorg/modelix/model/mpsadapters/Repository;
+	public final fun getVirtualPackagePropertyUID ()Ljava/lang/String;
+}
+

--- a/mps-model-server-plugin/api/mps-model-server-plugin.api
+++ b/mps-model-server-plugin/api/mps-model-server-plugin.api
@@ -1,0 +1,23 @@
+public final class org/modelix/model/server/mps/MPSModelServer : com/intellij/openapi/Disposable {
+	public fun <init> ()V
+	public fun dispose ()V
+	public final fun ensureStarted ()V
+	public final fun ensureStopped ()V
+	public final fun registerProject (Lcom/intellij/openapi/project/Project;)V
+	public final fun unregisterProject (Lcom/intellij/openapi/project/Project;)V
+}
+
+public final class org/modelix/model/server/mps/MPSModelServerForProject : com/intellij/openapi/Disposable {
+	public fun <init> (Lcom/intellij/openapi/project/Project;)V
+	public fun dispose ()V
+}
+
+public final class org/modelix/model/server/mps/MPSModelServerKt {
+	public static final field LOAD_MODELS_MODULE_PARAMETER_NAME Ljava/lang/String;
+}
+
+public final class org/modelix/model/server/mps/MPSModelServerStartupActivity : com/intellij/openapi/startup/StartupActivity$Background {
+	public fun <init> ()V
+	public fun runActivity (Lcom/intellij/openapi/project/Project;)V
+}
+


### PR DESCRIPTION
It's not always obvious if a change in the Kotlin code is a breaking change of the JVM API. Sometimes annotations such as `@JvmOverloads` are required to maintain binary compatibility.

Some changes are not breaking changes in the sense that they don't require changes in Kotlin code that uses the API, but if the JVM API is incompatible it can cause LinkageErrors at runtime, if the Kotlin code wasn't re-compiled against the new version.

See https://github.com/Kotlin/binary-compatibility-validator for details.