### PR TITLE
fix(model-client): fix usage of concept references `MetaModelBranch`

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelBranch.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelBranch.kt
@@ -168,6 +168,10 @@ class MetaModelBranch(val branch: IBranch) : IBranch by branch {
         override fun getConcept(nodeId: Long): IConcept? {
             return transaction.getConceptReference(nodeId)?.let { resolveConcept(it, transaction.tree) }
         }
+
+        override fun getConceptReference(nodeId: Long): IConceptReference? {
+            return getConcept(nodeId)?.getReference()
+        }
     }
 
     inner class MMWriteTransaction(val transaction: IWriteTransaction) : IWriteTransaction by transaction, ITransactionWrapper {
@@ -184,6 +188,11 @@ class MetaModelBranch(val branch: IBranch) : IBranch by branch {
         override fun getConcept(nodeId: Long): IConcept? {
             return transaction.getConceptReference(nodeId)?.let { resolveConcept(it, transaction.tree) }
         }
+
+        override fun getConceptReference(nodeId: Long): IConceptReference? {
+            return getConcept(nodeId)?.getReference()
+        }
+
         override fun addNewChild(parentId: Long, role: String?, index: Int, childId: Long, concept: IConcept?) {
             transaction.addNewChild(parentId, role, index, childId, concept?.let { toLocalConcept(it) })
         }

--- a/model-client/src/commonTest/kotlin/org/modelix/model/metameta/MetaModelBranchTest.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/metameta/MetaModelBranchTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.metameta
+
+import org.modelix.model.api.BuiltinLanguages
+import org.modelix.model.api.IConceptReference
+import org.modelix.model.api.ITree
+import org.modelix.model.api.PBranch
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.persistent.MapBaseStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MetaModelBranchTest {
+
+    @Test
+    fun conceptReferenceIsResolvedInMetaModel() {
+        // Arrange
+        val modelConcept = BuiltinLanguages.MPSRepositoryConcepts.Model
+        val store = MapBaseStore()
+        val storeCache = ObjectStoreCache(store)
+        val idGenerator = IdGenerator.newInstance(1)
+        val emptyTree = CLTree(storeCache)
+
+        val rawBranch = PBranch(emptyTree, idGenerator)
+        val metaModelBranch = MetaModelBranch(rawBranch)
+        metaModelBranch.disabled = false
+        metaModelBranch.runWrite {
+            metaModelBranch.getRootNode().addNewChild("aChild", -1, modelConcept)
+        }
+
+        // Act
+        var resolvedConceptReferenceInRead: IConceptReference? = null
+        metaModelBranch.runRead {
+            val onlyChild = metaModelBranch
+                .getRootNode()
+                .getChildren("aChild")
+                .single()
+            resolvedConceptReferenceInRead = onlyChild.getConceptReference()
+        }
+        var resolvedConceptReferenceInWrite: IConceptReference? = null
+        metaModelBranch.runWriteT {
+            val onlyChildId = it.getChildren(ITree.ROOT_ID, "aChild").single()
+            resolvedConceptReferenceInWrite = it.getConceptReference(onlyChildId)
+        }
+
+        // Assert
+        assertEquals(modelConcept.getReference(), resolvedConceptReferenceInRead)
+        assertEquals(modelConcept.getReference(), resolvedConceptReferenceInWrite)
+    }
+}


### PR DESCRIPTION
Though `MetaModelBranch` is deprecated, some customers have old data they access through it. Without this fix, `INode.concept.getReference()` and `INode.getConceptReference()` returned different results. `INode.getConceptReference()` was not correctly resolved by `MetaModelBranch` which broke the generated typed API which was using it.