### PR TITLE
fix(model-server): Escape slashes in path segments in repository overview

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoryOverview.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoryOverview.kt
@@ -83,18 +83,10 @@ class RepositoryOverview(private val repoManager: RepositoriesManager) {
                                         buildHistoryLink(branch.repositoryId.id, branch.branchName)
                                     }
                                     td {
-                                        a("../content/$repository/${branch.branchName}/latest/") {
-                                            +"Explore Latest Version"
-                                        }
+                                        buildExploreLatestLink(branch.repositoryId.id, branch.branchName)
                                     }
                                     td {
-                                        form {
-                                            postButton {
-                                                name = "delete"
-                                                formAction = "../v2/repositories/${branch.repositoryId.id}/delete"
-                                                +"Delete Repository"
-                                            }
-                                        }
+                                        buildDeleteForm(branch.repositoryId.id)
                                     }
                                 }
                             }
@@ -109,5 +101,21 @@ class RepositoryOverview(private val repoManager: RepositoriesManager) {
 fun FlowOrInteractiveOrPhrasingContent.buildHistoryLink(repositoryId: String, branchName: String) {
     a("../history/${repositoryId.encodeURLPathPart()}/${branchName.encodeURLPathPart()}/") {
         +"Show History"
+    }
+}
+
+fun FlowOrInteractiveOrPhrasingContent.buildExploreLatestLink(repositoryId: String, branchName: String) {
+    a("../content/${repositoryId.encodeURLPathPart()}/${branchName.encodeURLPathPart()}/latest/") {
+        +"Explore Latest Version"
+    }
+}
+
+fun FlowContent.buildDeleteForm(repositoryId: String) {
+    form {
+        postButton {
+            name = "delete"
+            formAction = "../v2/repositories/${repositoryId.encodeURLPathPart()}/delete"
+            +"Delete Repository"
+        }
     }
 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/RepositoryOverviewTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/RepositoryOverviewTest.kt
@@ -25,9 +25,22 @@ class RepositoryOverviewTest {
 
     @Test
     fun testSlashesInPathSegmentsFromRepositoryIdAndBranchId() {
-        val html = createHTML().span {
+        val html = createHTML(prettyPrint = false).span {
             buildHistoryLink("repository/v1", "branch/v2")
+            buildExploreLatestLink("repository/v1", "branch/v2")
+            buildDeleteForm("repository/v1")
         }
-        assertEquals("<span><a href=\"../history/repository%2Fv1/branch%2Fv2/\">Show History</a></span>", html)
+        assertEquals(
+            """
+                <span>
+                    <a href="../history/repository%2Fv1/branch%2Fv2/">Show History</a>
+                    <a href="../content/repository%2Fv1/branch%2Fv2/latest/">Explore Latest Version</a>
+                    <form>
+                        <button formmethod="post" name="delete" formaction="../v2/repositories/repository%2Fv1/delete">Delete Repository</button>
+                    </form>
+                </span>
+            """.lines().joinToString("") { it.trim() },
+            html,
+        )
     }
 }


### PR DESCRIPTION
While the "Show History" link was already escaped properly to support slashes in both the repository id and branch name, it was not supported for the other links.