### PR TITLE
MODELIX-792: enable test result reporting in PR pipelines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Cf. https://github.com/marketplace/actions/publish-test-results#permissions
+    permissions:
+      checks: write
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11
@@ -26,8 +31,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew --build-cache build detekt -PciBuild=true
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        # Also report in case the build failed
+        if: always()
+        with:
+          files: |
+            **/test-results/**/*.xml
       - name: Archive test report
         uses: actions/upload-artifact@v4
+        # Archive test reports for introspection even if the build failed. They are most useful in this situation.
         if: always()
         with:
           name: test-report

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -114,9 +114,18 @@ val cucumber = task("cucumber") {
         javaexec {
             mainClass.set("io.cucumber.core.cli.Main")
             classpath = cucumberRuntime + sourceSets.main.get().output + sourceSets.test.get().output
-            // Change glue for your project package where the step definitions are.
-            // And where the feature files are.
-            args = listOf("--plugin", "pretty", "--glue", "org.modelix.model.server.functionaltests", "src/test/resources/functionaltests")
+            args = listOf(
+                "--plugin",
+                "pretty",
+                // Enable junit reporting so that GitHub actions can report on these tests, too
+                "--plugin",
+                "junit:${project.layout.buildDirectory.dir("test-results/cucumber.xml").get()}",
+                // Change glue for your project package where the step definitions are.
+                "--glue",
+                "org.modelix.model.server.functionaltests",
+                // Specify where the feature files are.
+                "src/test/resources/functionaltests",
+            )
         }
     }
 }


### PR DESCRIPTION
This PR adds reporting for test results via a PR comment as can be seen below.

Due to the current setup with additional test projects for the bulk sync and the generator, test results from these test projects are not included in the reporting. The reporting setup would be more complicated with multiple dependent jobs being needed. I don't think it's worth the effort, especially, given the ongoing work to change to a composite build for these tests.

FYI: the :zzz: is the number of skipped tests. Not an entirely intuitive emoji choice...

Fixes: MODELIX-792