### PR TITLE
ci: fix permissions for sarif upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Cf. https://github.com/marketplace/actions/publish-test-results#permissions
     permissions:
+      # Cf. https://github.com/marketplace/actions/publish-test-results#permissions
       checks: write
       pull-requests: write
+      # For detekt
+      security-events: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
By explicitly stating permissions for the test comments action, we have dropped default permissions for detekt to upload the sarif file.