### PR TITLE
fix(model-datastructure): make `MapBasedStore` thread safe

### DIFF
--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/DataStructures.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/DataStructures.kt
@@ -29,3 +29,5 @@ package org.modelix.kotlin.utils
  * Therefore, the memory efficient maps are used sparingly for only the very big maps.
  */
 expect fun <K, V> createMemoryEfficientMap(): MutableMap<K, V>
+
+expect fun <K, V> MutableMap<K, V>.toSynchronizedMap(): MutableMap<K, V>

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/DataStructures.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/DataStructures.js.kt
@@ -17,3 +17,8 @@
 package org.modelix.kotlin.utils
 
 actual fun <K, V> createMemoryEfficientMap(): MutableMap<K, V> = HashMap()
+
+actual fun <K, V> MutableMap<K, V>.toSynchronizedMap(): MutableMap<K, V> {
+    // Because JS is single-threaded, no extra measures are needed.
+    return this
+}

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/DataStructures.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/DataStructures.jvm.kt
@@ -17,5 +17,10 @@
 package org.modelix.kotlin.utils
 
 import gnu.trove.map.hash.THashMap
+import java.util.Collections
 
 actual fun <K, V> createMemoryEfficientMap(): MutableMap<K, V> = THashMap()
+
+actual fun <K, V> MutableMap<K, V>.toSynchronizedMap(): MutableMap<K, V> {
+    return Collections.synchronizedMap(this)
+}

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
@@ -16,6 +16,7 @@
 package org.modelix.model.persistent
 
 import org.modelix.kotlin.utils.createMemoryEfficientMap
+import org.modelix.kotlin.utils.toSynchronizedMap
 import org.modelix.model.IKeyListener
 import org.modelix.model.IKeyValueStore
 import org.modelix.model.lazy.IBulkQuery
@@ -26,7 +27,7 @@ import org.modelix.model.lazy.NonBulkQuery
 open class MapBaseStore : MapBasedStore()
 
 open class MapBasedStore : IKeyValueStore {
-    private val map: MutableMap<String?, String?> = createMemoryEfficientMap()
+    private val map = createMemoryEfficientMap<String?, String?>().toSynchronizedMap()
     override fun get(key: String): String? {
         return map[key]
     }


### PR DESCRIPTION
Make it thread safe by using a synchronized map.

Missing thread safety is the suspected issue for such error messages

```
2024-03-20 08:58:01,282 [  48184]  ERROR - #com.intellij.ide.plugins.PluginManager - Equal objects must have equal hashcodes. During rehashing, Trove discovered that the following two objects claim to be equal (as in java.lang.Object.equals()) but their hashCodes (or those calculated by your TObjectHashingStrategy) are not equal.This violates the general contract of java.lang.Object.hashCode().  See bullet point two in that method's documentation. object #1 =class java.lang.String id= 996201210 hashCode= -209607169 toString= sHB6r*02gLuXVEvI31E7v9ijDVL5VSdSO8F9OO-2z2CA; object #2 =class java.lang.String id= 1530156665 hashCode= -209607169 toString= sHB6r*02gLuXVEvI31E7v9ijDVL5VSdSO8F9OO-2z2CA
[Warning] apparent concurrent modification of the key set. Size before and after rehash() do not match 81 vs 83
java.lang.IllegalArgumentException: Equal objects must have equal hashcodes. During rehashing, Trove discovered that the following two objects claim to be equal (as in java.lang.Object.equals()) but their hashCodes (or those calculated by your TObjectHashingStrategy) are not equal.This violates the general contract of java.lang.Object.hashCode().  See bullet point two in that method's documentation. object #1 =class java.lang.String id= 996201210 hashCode= -209607169 toString= sHB6r*02gLuXVEvI31E7v9ijDVL5VSdSO8F9OO-2z2CA; object #2 =class java.lang.String id= 1530156665 hashCode= -209607169 toString= sHB6r*02gLuXVEvI31E7v9ijDVL5VSdSO8F9OO-2z2CA
[Warning] apparent concurrent modification of the key set. Size before and after rehash() do not match 81 vs 83
	at gnu.trove.impl.hash.TObjectHash.buildObjectContractViolation(TObjectHash.java:464)
	at gnu.trove.impl.hash.TObjectHash.throwObjectContractViolation(TObjectHash.java:448)
	at gnu.trove.map.hash.THashMap.rehash(THashMap.java:403)
	at gnu.trove.impl.hash.THash.ensureCapacity(THash.java:175)
	at gnu.trove.map.hash.THashMap.putAll(THashMap.java:551)
	at org.modelix.model.persistent.MapBasedStore.putAll(MapBasedStore.kt:54)
```