### PR TITLE
MODELIX-791: enable coverage reporting in PR pipelines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew --build-cache build detekt -PciBuild=true
+        run: ./gradlew --build-cache build detekt :koverHtmlReport :koverXmlReport -PciBuild=true
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         # Also report in case the build failed
@@ -49,6 +49,13 @@ jobs:
           path: |
             */build/test-results
             */build/reports
+      - name: Report test coverage
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: ${{ github.workspace }}/build/reports/kover/report.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: JVM coverage report
+          update-comment: true
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.node) apply false
     alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.kotlinx.kover)
 }
 
 group = "org.modelix"
@@ -69,6 +70,11 @@ fun computeVersion(): Any {
 
 dependencies {
     dokkaPlugin(libs.dokka.versioning)
+
+    // Generate a combined coverage report
+    project.subprojects.forEach {
+        kover(it)
+    }
 }
 
 val parentProject = project
@@ -78,6 +84,7 @@ subprojects {
     apply(plugin = "maven-publish")
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "org.jetbrains.kotlinx.kover")
 
     version = rootProject.version
     group = rootProject.group

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ test-logger = { id = "com.adarshr.test-logger", version = "4.0.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 intellij = { id = "org.jetbrains.intellij", version = "1.17.2" }
 openapi-generator = {id = "org.openapi.generator", version.ref = "openapi"}
+kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.7.5" }
 
 [versions]
 kotlin = "1.9.23"

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/HistoryHandler.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/HistoryHandler.kt
@@ -107,7 +107,7 @@ class HistoryHandler(val client: IModelClient, private val repositoriesManager: 
         }
     }
 
-    suspend fun revert(repositoryAndBranch: BranchReference, from: String?, to: String?, author: String?) {
+    private suspend fun revert(repositoryAndBranch: BranchReference, from: String?, to: String?, author: String?) {
         val version = repositoriesManager.getVersion(repositoryAndBranch) ?: throw RuntimeException("Branch doesn't exist: $repositoryAndBranch")
         val branch = OTBranch(PBranch(version.tree, client.idGenerator), client.idGenerator, client.storeCache!!)
         branch.runWriteT { t ->

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
@@ -31,7 +31,10 @@ private val LOG = KotlinLogging.logger { }
 
 class IgniteStoreClient(jdbcConfFile: File? = null, inmemory: Boolean = false) : IStoreClient, AutoCloseable {
 
-    private val ENTRY_CHANGED_TOPIC = "entryChanged"
+    companion object {
+        private const val ENTRY_CHANGED_TOPIC = "entryChanged"
+    }
+
     private lateinit var ignite: Ignite
     private val cache: IgniteCache<String, String?>
     private val changeNotifier = ChangeNotifier(this)


### PR DESCRIPTION
Adds code coverage reporting via a PR comment. A hopefully uncontroversial change is included to demonstrate the per-file reporting in this PR.

JS reporting is unfortunately not too easy and excluded here.

The PR job artifacts include the full HTML coverage report.

Feel free to merge if the PR is ok as is.

Fixes: MODELIX-791