### PR TITLE
 perf(model-client): consistently process version streams while receiving data

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -168,7 +168,7 @@ class ModelClientV2(
     @Deprecated("repository ID is required for permission checks")
     @DeprecationInfo("3.7.0", "May be removed with the next major release. Also remove the endpoint from the model-server.")
     override suspend fun loadVersion(versionHash: String, baseVersion: IVersion?): IVersion {
-        val response = httpClient.post {
+        val response = httpClient.get {
             url {
                 takeFrom(baseUrl)
                 appendPathSegments("versions", versionHash)
@@ -186,7 +186,7 @@ class ModelClientV2(
         versionHash: String,
         baseVersion: IVersion?,
     ): IVersion {
-        val response = httpClient.post {
+        val response = httpClient.get {
             url {
                 takeFrom(baseUrl)
                 appendPathSegments("repositories", repositoryId.id, "versions", versionHash)


### PR DESCRIPTION
The optimization was previously only done to `ModelClientV2.poll`, `ModelClientV2.pullIfExists` and `ModelClientV2.pull`.