### PR TITLE
build: enable parallel gradle task execution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1024m "-XX:MaxMetaspaceSize=2g"
+org.gradle.parallel=true
 systemProp.org.gradle.internal.http.socketTimeout=120000
 kotlin.daemon.jvmargs=-Xmx2G

--- a/model-api-gen-gradle-test/gradle.properties
+++ b/model-api-gen-gradle-test/gradle.properties
@@ -1,1 +1,2 @@
+org.gradle.parallel=true
 kotlin.daemon.jvmargs=-Xmx3g


### PR DESCRIPTION
This is something I stumbled upon [here](https://docs.gradle.org/current/userguide/performance.html#parallel_execution).

On my local machine this reduces the the time for a clean `./gradlew build` by about 40%.