### PR TITLE
MODELIX-832: MPSLanguageRepository returns "unknown" Concept for unknown concepts

### DIFF
--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -252,7 +252,7 @@ class ModelImporter(
                 } else {
                     nodeAtIndex
                 }
-                check(childNode.getConceptReference() == expectedConcept) { "Unexpected concept change" }
+                check(childNode.getConceptReference() == expectedConcept) { "Unexpected concept change from $expectedConcept to ${childNode.getConceptReference()}" }
 
                 syncNode(childNode, expected, progressReporter)
             }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -124,6 +124,10 @@ interface INode {
         return concepts.map { addNewChild(role, index, it) }
     }
 
+    fun addNewChildren(link: IChildLink, index: Int, concepts: List<IConceptReference?>): List<INode> {
+        return concepts.map { addNewChild(link, index, it) }
+    }
+
     /**
      * Removes the given node from this node's children.
      *

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -121,11 +121,11 @@ interface INode {
     }
 
     fun addNewChildren(role: String?, index: Int, concepts: List<IConceptReference?>): List<INode> {
-        return concepts.map { addNewChild(role, index, it) }
+        return concepts.mapIndexed { i, it -> addNewChild(role, if (index >= 0) index + i else index, it) }
     }
 
     fun addNewChildren(link: IChildLink, index: Int, concepts: List<IConceptReference?>): List<INode> {
-        return concepts.map { addNewChild(link, index, it) }
+        return concepts.mapIndexed { i, it -> addNewChild(link, if (index >= 0) index + i else index, it) }
     }
 
     /**

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ConceptResolutionTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ConceptResolutionTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.mpsadapters
+
+import org.modelix.model.api.BuiltinLanguages
+import org.modelix.model.api.ConceptReference
+import org.modelix.model.api.ILanguageRepository
+
+class ConceptResolutionTest : MpsAdaptersTestBase("SimpleProject") {
+
+    fun `test resolution of Module concept`() {
+        val conceptUID = BuiltinLanguages.MPSRepositoryConcepts.Module.getReference().getUID()
+        val moduleConcept = ILanguageRepository.resolveConcept(ConceptReference(conceptUID))
+
+        // There was an issue where MPSLanguageRepository resolved a concept even though it wasn't loaded and no
+        // metamodel information was available. If a concept can be resolved then it should provide more information
+        // than just the ID that it extracted from the concept reference.
+        assertEquals("Module", moduleConcept.getShortName())
+        assertContainsElements(moduleConcept.getOwnChildLinks().map { it.getSimpleName() }, "models")
+    }
+
+    fun `test MPSLanguageRepository cannot resolve the Module concept`() {
+        val conceptUID = BuiltinLanguages.MPSRepositoryConcepts.Module.getReference().getUID()
+        val moduleConcept = MPSLanguageRepository(mpsProject.repository).resolveConcept(conceptUID)
+
+        // After making the repository language part of this plugin, this assertion will fail and this test can just be removed.
+        assertNull(moduleConcept)
+    }
+}

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
@@ -42,7 +42,7 @@ data class MPSConcept(val concept: SAbstractConceptAdapter) : IConcept {
             is SInterfaceConceptAdapterById -> concept.id
             else -> error("Unknown concept type: $concept")
         }
-        return "mps:" + id.serialize()
+        return UID_PREFIX + id.serialize()
     }
 
     override fun getShortName(): String {
@@ -116,6 +116,20 @@ data class MPSConcept(val concept: SAbstractConceptAdapter) : IConcept {
         return when (name) {
             "alias" -> concept.conceptAlias
             else -> null
+        }
+    }
+
+    companion object {
+        private const val UID_PREFIX = "mps:"
+
+        fun tryParseUID(uid: String): MPSConcept? {
+            if (!uid.startsWith(UID_PREFIX)) return null
+            val conceptId = SConceptId.deserialize(uid.substringAfter(UID_PREFIX))
+
+            // For interface concepts `SInterfaceConceptAdapterById(conceptId, "")` would be correct, but we don't have
+            // that information. Assuming that this concept is used to create new nodes SConceptAdapterById is the
+            // better default.
+            return MPSConcept(SConceptAdapterById(conceptId, ""))
         }
     }
 }

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSLanguageRepository.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSLanguageRepository.kt
@@ -20,6 +20,7 @@ import jetbrains.mps.smodel.adapter.ids.SConceptId
 import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory
 import jetbrains.mps.smodel.language.ConceptRegistry
 import jetbrains.mps.smodel.language.LanguageRegistry
+import jetbrains.mps.smodel.runtime.illegal.IllegalConceptDescriptor
 import org.jetbrains.mps.openapi.language.SAbstractConcept
 import org.jetbrains.mps.openapi.module.SRepository
 import org.modelix.model.api.IConcept
@@ -37,6 +38,8 @@ data class MPSLanguageRepository(private val repository: SRepository) : ILanguag
         } catch (e: NumberFormatException) { return null } ?: return null // in case the id cannot be parsed
 
         val conceptDescriptor = ConceptRegistry.getInstance().getConceptDescriptor(conceptId)
+
+        if (conceptDescriptor is IllegalConceptDescriptor) return null
 
         return MPSConcept(MetaAdapterFactory.getAbstractConcept(conceptDescriptor))
     }


### PR DESCRIPTION
I took the courage to revert the commit, because it makes the new sync plugin fail. A workaround for the new new sync plugin is in [this PR](https://github.com/modelix/modelix.mps-plugins/pull/70).

Since I'm not familiar with the bulk-sync at all, I would leave the following task for someone with more experience.

# TODO from the issue comments

- [ ] find a differnt solution for the bulk-sync