### PR TITLE
chore(model-server): use non-blocking method to send version delta

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -48,6 +48,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.ignite.Ignition
 import org.modelix.authorization.KeycloakUtils
 import org.modelix.authorization.installAuthentication
+import org.modelix.model.InMemoryModels
 import org.modelix.model.server.handlers.ContentExplorer
 import org.modelix.model.server.handlers.DeprecatedLightModelServer
 import org.modelix.model.server.handlers.HistoryHandler
@@ -150,8 +151,9 @@ object Main {
                 i += 2
             }
             val localModelClient = LocalModelClient(storeClient)
+            val inMemoryModels = InMemoryModels()
             val repositoriesManager = RepositoriesManager(localModelClient)
-            val modelServer = KeyValueLikeModelServer(repositoriesManager)
+            val modelServer = KeyValueLikeModelServer(repositoriesManager, storeClient, inMemoryModels)
             val sharedSecretFile = cmdLineArgs.secretFile
             if (sharedSecretFile.exists()) {
                 modelServer.setSharedSecret(
@@ -162,7 +164,7 @@ object Main {
             val repositoryOverview = RepositoryOverview(repositoriesManager)
             val historyHandler = HistoryHandler(localModelClient, repositoriesManager)
             val contentExplorer = ContentExplorer(localModelClient, repositoriesManager)
-            val modelReplicationServer = ModelReplicationServer(repositoriesManager)
+            val modelReplicationServer = ModelReplicationServer(repositoriesManager, localModelClient, inMemoryModels)
             val metricsHandler = MetricsHandler()
 
             val configureNetty: NettyApplicationEngine.Configuration.() -> Unit = {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ContentExplorer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ContentExplorer.kt
@@ -50,7 +50,7 @@ import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.server.templates.PageWithMenuBar
 import kotlin.collections.set
 
-class ContentExplorer(private val client: IModelClient, private val repoManager: RepositoriesManager) {
+class ContentExplorer(private val client: IModelClient, private val repoManager: IRepositoriesManager) {
 
     fun init(application: Application) {
         application.routing {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/HistoryHandler.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/HistoryHandler.kt
@@ -55,7 +55,7 @@ import org.modelix.model.server.templates.PageWithMenuBar
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class HistoryHandler(val client: IModelClient, private val repositoriesManager: RepositoriesManager) {
+class HistoryHandler(val client: IModelClient, private val repositoriesManager: IRepositoriesManager) {
 
     fun init(application: Application) {
         application.routing {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/IRepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/IRepositoriesManager.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server.handlers
+
+import org.modelix.model.lazy.BranchReference
+import org.modelix.model.lazy.CLVersion
+import org.modelix.model.lazy.RepositoryId
+
+interface IRepositoriesManager {
+    /**
+     * Used to retrieve the server ID. If needed, the server ID is created and stored.
+     *
+     * If a server ID was not created yet, it is generated and saved in the database.
+     * It gets stored under the current and all legacy database keys.
+     *
+     * If the server ID was created previously but is only stored under a legacy database key,
+     * it also gets stored under the current and all legacy database keys.
+     */
+    suspend fun maybeInitAndGetSeverId(): String
+    fun getRepositories(): Set<RepositoryId>
+    suspend fun createRepository(repositoryId: RepositoryId, userName: String?, useRoleIds: Boolean = true): CLVersion
+    suspend fun removeRepository(repository: RepositoryId): Boolean
+
+    fun getBranches(repositoryId: RepositoryId): Set<BranchReference>
+
+    suspend fun removeBranches(repository: RepositoryId, branchNames: Set<String>)
+
+    /**
+     * Same as [removeBranches] but blocking.
+     * Caller is expected to execute it outside the request thread.
+     */
+    fun removeBranchesBlocking(repository: RepositoryId, branchNames: Set<String>)
+    suspend fun getVersion(branch: BranchReference): CLVersion?
+    suspend fun getVersionHash(branch: BranchReference): String?
+    suspend fun pollVersionHash(branch: BranchReference, lastKnown: String?): String
+    suspend fun mergeChanges(branch: BranchReference, newVersionHash: String): String
+
+    /**
+     * Same as [mergeChanges] but blocking.
+     * Caller is expected to execute it outside the request thread.
+     */
+    fun mergeChangesBlocking(branch: BranchReference, newVersionHash: String): String
+    suspend fun computeDelta(versionHash: String, baseVersionHash: String?): ObjectData
+}
+
+fun IRepositoriesManager.getBranchNames(repositoryId: RepositoryId): Set<String> {
+    return getBranches(repositoryId).map { it.branchName }.toSet()
+}

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import org.apache.commons.collections4.map.LRUMap
-import org.modelix.model.InMemoryModels
 import org.modelix.model.ModelMigrations
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IBranch
@@ -51,7 +50,7 @@ import org.slf4j.LoggerFactory
 import java.lang.ref.SoftReference
 import java.util.UUID
 
-class RepositoriesManager(val client: LocalModelClient) {
+class RepositoriesManager(val client: LocalModelClient) : IRepositoriesManager {
 
     init {
         fun migrateLegacyRepositoriesList(infoBranch: IBranch) {
@@ -82,13 +81,6 @@ class RepositoriesManager(val client: LocalModelClient) {
 
     private val store: IStoreClient get() = client.store
     private val objectStore: IDeserializingKeyValueStore get() = client.storeCache
-    val inMemoryModels = InMemoryModels()
-
-    fun dispose() {
-        // TODO find instance creations and add a dispose() call if needed. Whoever creates an instance is responsible
-        //      for its lifecycle.
-        inMemoryModels.dispose()
-    }
 
     fun generateClientId(repositoryId: RepositoryId): Long {
         return client.store.generateId("$KEY_PREFIX:${repositoryId.id}:clientId")
@@ -103,7 +95,7 @@ class RepositoriesManager(val client: LocalModelClient) {
      * If the server ID was created previously but is only stored under a legacy database key,
      * it also gets stored under the current and all legacy database keys.
      */
-    suspend fun maybeInitAndGetSeverId(): String {
+    override suspend fun maybeInitAndGetSeverId(): String {
         return store.runTransactionSuspendable {
             var serverId = store[SERVER_ID_KEY]
             if (serverId == null) {
@@ -118,7 +110,7 @@ class RepositoriesManager(val client: LocalModelClient) {
         }
     }
 
-    fun getRepositories(): Set<RepositoryId> {
+    override fun getRepositories(): Set<RepositoryId> {
         val repositoriesList = store[REPOSITORIES_LIST_KEY]
         val emptyRepositoriesList = repositoriesList.isNullOrBlank()
         return if (emptyRepositoriesList) {
@@ -130,7 +122,7 @@ class RepositoriesManager(val client: LocalModelClient) {
 
     private fun repositoryExists(repositoryId: RepositoryId) = getRepositories().contains(repositoryId)
 
-    suspend fun createRepository(repositoryId: RepositoryId, userName: String?, useRoleIds: Boolean = true): CLVersion {
+    override suspend fun createRepository(repositoryId: RepositoryId, userName: String?, useRoleIds: Boolean): CLVersion {
         var initialVersion: CLVersion? = null
         store.runTransactionSuspendable {
             val masterBranch = repositoryId.getBranchReference()
@@ -155,7 +147,7 @@ class RepositoriesManager(val client: LocalModelClient) {
         return store[branchListKey(repositoryId)]?.lines()?.toSet() ?: emptySet()
     }
 
-    fun getBranches(repositoryId: RepositoryId): Set<BranchReference> {
+    override fun getBranches(repositoryId: RepositoryId): Set<BranchReference> {
         return getBranchNames(repositoryId)
             .map { repositoryId.getBranchReference(it) }
             .sortedBy { it.branchName }
@@ -188,7 +180,7 @@ class RepositoriesManager(val client: LocalModelClient) {
         }
     }
 
-    suspend fun removeRepository(repository: RepositoryId): Boolean {
+    override suspend fun removeRepository(repository: RepositoryId): Boolean {
         return store.runTransactionSuspendable {
             if (!repositoryExists(repository)) {
                 return@runTransactionSuspendable false
@@ -206,7 +198,7 @@ class RepositoriesManager(val client: LocalModelClient) {
         }
     }
 
-    suspend fun removeBranches(repository: RepositoryId, branchNames: Set<String>) {
+    override suspend fun removeBranches(repository: RepositoryId, branchNames: Set<String>) {
         return store.runTransactionSuspendable {
             removeBranchesBlocking(repository, branchNames)
         }
@@ -216,7 +208,7 @@ class RepositoriesManager(val client: LocalModelClient) {
      * Same as [removeBranches] but blocking.
      * Caller is expected to execute it outside the request thread.
      */
-    fun removeBranchesBlocking(repository: RepositoryId, branchNames: Set<String>) {
+    override fun removeBranchesBlocking(repository: RepositoryId, branchNames: Set<String>) {
         if (branchNames.isEmpty()) return
         store.runTransaction {
             val key = branchListKey(repository)
@@ -229,7 +221,7 @@ class RepositoriesManager(val client: LocalModelClient) {
         }
     }
 
-    suspend fun mergeChanges(branch: BranchReference, newVersionHash: String): String {
+    override suspend fun mergeChanges(branch: BranchReference, newVersionHash: String): String {
         return store.runTransactionSuspendable {
             mergeChangesBlocking(branch, newVersionHash)
         }
@@ -239,7 +231,7 @@ class RepositoriesManager(val client: LocalModelClient) {
      * Same as [mergeChanges] but blocking.
      * Caller is expected to execute it outside the request thread.
      */
-    fun mergeChangesBlocking(branch: BranchReference, newVersionHash: String): String {
+    override fun mergeChangesBlocking(branch: BranchReference, newVersionHash: String): String {
         return store.runTransaction {
             val headHash = getVersionHashBlocking(branch)
             val mergedHash = if (headHash == null) {
@@ -262,11 +254,11 @@ class RepositoriesManager(val client: LocalModelClient) {
         }
     }
 
-    suspend fun getVersion(branch: BranchReference): CLVersion? {
+    override suspend fun getVersion(branch: BranchReference): CLVersion? {
         return getVersionHash(branch)?.let { CLVersion.loadFromHash(it, client.storeCache) }
     }
 
-    suspend fun getVersionHash(branch: BranchReference): String? {
+    override suspend fun getVersionHash(branch: BranchReference): String? {
         return store.runTransactionSuspendable {
             getVersionHashBlocking(branch)
         }
@@ -293,13 +285,13 @@ class RepositoriesManager(val client: LocalModelClient) {
         store.put(legacyBranchKey(branch), hash, false)
     }
 
-    suspend fun pollVersionHash(branch: BranchReference, lastKnown: String?): String {
+    override suspend fun pollVersionHash(branch: BranchReference, lastKnown: String?): String {
         return pollEntry(client.store, branchKey(branch), lastKnown)
             ?: throw IllegalStateException("No version found for branch '${branch.branchName}' in repository '${branch.repositoryId}'")
     }
 
     private val versionDeltaCache = VersionDeltaCache(client.storeCache)
-    suspend fun computeDelta(versionHash: String, baseVersionHash: String?): ObjectData {
+    override suspend fun computeDelta(versionHash: String, baseVersionHash: String?): ObjectData {
         if (versionHash == baseVersionHash) return ObjectData.empty
         if (baseVersionHash == null) {
             // no need to cache anything if there is no delta computation happening

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -50,6 +50,8 @@ import org.slf4j.LoggerFactory
 import java.lang.ref.SoftReference
 import java.util.UUID
 
+// The methods in this class are almost cohesive, so the number of functions is fine.
+@Suppress("complexity.TooManyFunctions")
 class RepositoriesManager(val client: LocalModelClient) : IRepositoriesManager {
 
     init {

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoryOverview.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoryOverview.kt
@@ -25,7 +25,7 @@ import kotlinx.html.tr
 import org.modelix.api.html.Paths
 import org.modelix.model.server.templates.PageWithMenuBar
 
-class RepositoryOverview(private val repoManager: RepositoriesManager) {
+class RepositoryOverview(private val repoManager: IRepositoriesManager) {
 
     fun init(application: Application) {
         application.routing {

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelServerTestUtil.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelServerTestUtil.kt
@@ -19,11 +19,15 @@ package org.modelix.model.server
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.netty.Netty
+import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.resources.Resources
 import io.ktor.server.routing.IgnoreTrailingSlash
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.websocket.WebSockets
+import kotlinx.coroutines.runBlocking
+import org.modelix.authorization.installAuthentication
 import org.modelix.model.client2.ModelClientV2
 
 suspend fun ApplicationTestBuilder.createModelClient(): ModelClientV2 {
@@ -36,4 +40,34 @@ fun Application.installDefaultServerPlugins() {
     install(ContentNegotiation) { json() }
     install(Resources)
     install(IgnoreTrailingSlash)
+}
+
+/**
+ * Allow running a model server for test with Netty.
+ *
+ * This allows testing properties that would not be testable with [io.ktor.server.testing.testApplication]
+ * because the requests run on proper request threads.
+ *
+ * Examples for such properties are
+ * (1) errors while writing responses and
+ * (2) effects of blocking code on request threads.
+ */
+fun runWithNettyServer(
+    setupBlock: (application: Application) -> Unit,
+    testBlock: suspend (server: NettyApplicationEngine) -> Unit,
+) {
+    val nettyServer: NettyApplicationEngine = io.ktor.server.engine.embeddedServer(Netty, port = 0) {
+        installAuthentication(unitTestMode = true)
+        installDefaultServerPlugins()
+        setupBlock(this)
+    }
+
+    try {
+        nettyServer.start(wait = false)
+        runBlocking {
+            testBlock(nettyServer)
+        }
+    } finally {
+        nettyServer.stop()
+    }
 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/PullPerformanceTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/PullPerformanceTest.kt
@@ -20,6 +20,7 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.coroutineScope
 import org.modelix.authorization.installAuthentication
+import org.modelix.model.InMemoryModels
 import org.modelix.model.api.IChildLink
 import org.modelix.model.api.IConceptReference
 import org.modelix.model.api.INode
@@ -40,11 +41,12 @@ class PullPerformanceTest {
     private fun runTest(block: suspend ApplicationTestBuilder.(storeClientWithStatistics: StoreClientWithStatistics) -> Unit) = testApplication {
         val storeClientWithStatistics = StoreClientWithStatistics(InMemoryStoreClient())
         val repositoriesManager = RepositoriesManager(LocalModelClient(storeClientWithStatistics))
+        val inMemoryModels = InMemoryModels()
         application {
             installAuthentication(unitTestMode = true)
             installDefaultServerPlugins()
-            ModelReplicationServer(repositoriesManager).init(this)
-            KeyValueLikeModelServer(repositoriesManager).init(this)
+            ModelReplicationServer(repositoriesManager, LocalModelClient(storeClientWithStatistics), inMemoryModels).init(this)
+            KeyValueLikeModelServer(repositoriesManager, storeClientWithStatistics, inMemoryModels).init(this)
         }
 
         coroutineScope {

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.RepetitionInfo
 import org.modelix.authorization.installAuthentication
+import org.modelix.model.InMemoryModels
 import org.modelix.model.ModelFacade
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IBranch
@@ -68,9 +69,12 @@ class ReplicatedRepositoryTest {
         application {
             installAuthentication(unitTestMode = true)
             installDefaultServerPlugins()
-            val repositoriesManager = RepositoriesManager(LocalModelClient(InMemoryStoreClient()))
-            ModelReplicationServer(repositoriesManager).init(this)
-            KeyValueLikeModelServer(repositoriesManager).init(this)
+            val storeClient = InMemoryStoreClient()
+            val modelClient = LocalModelClient(storeClient)
+            val repositoriesManager = RepositoriesManager(modelClient)
+            val inMemoryModels = InMemoryModels()
+            ModelReplicationServer(repositoriesManager, modelClient, inMemoryModels).init(this)
+            KeyValueLikeModelServer(repositoriesManager, storeClient, inMemoryModels).init(this)
         }
 
         coroutineScope {

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
@@ -23,6 +23,7 @@ import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import org.modelix.authorization.installAuthentication
+import org.modelix.model.InMemoryModels
 import org.modelix.model.api.IConceptReference
 import org.modelix.model.client2.ModelClientV2
 import org.modelix.model.client2.readVersionDelta
@@ -41,9 +42,12 @@ class ModelReplicationServerTest {
         application {
             installAuthentication(unitTestMode = true)
             installDefaultServerPlugins()
-            val repositoriesManager = RepositoriesManager(LocalModelClient(InMemoryStoreClient()))
-            ModelReplicationServer(repositoriesManager).init(this)
-            KeyValueLikeModelServer(repositoriesManager).init(this)
+            val storeClient = InMemoryStoreClient()
+            val modelClient = LocalModelClient(storeClient)
+            val repositoriesManager = RepositoriesManager(modelClient)
+            val inMemoryModels = InMemoryModels()
+            ModelReplicationServer(repositoriesManager, modelClient, inMemoryModels).init(this)
+            KeyValueLikeModelServer(repositoriesManager, storeClient, inMemoryModels).init(this)
         }
 
         coroutineScope {

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
@@ -15,14 +15,25 @@
 
 package org.modelix.model.server.handlers
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.appendPathSegments
 import io.ktor.http.takeFrom
+import io.ktor.server.application.Application
+import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.modelix.authorization.installAuthentication
 import org.modelix.model.InMemoryModels
 import org.modelix.model.api.IConceptReference
@@ -32,11 +43,13 @@ import org.modelix.model.client2.runWrite
 import org.modelix.model.client2.useVersionStreamFormat
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.server.installDefaultServerPlugins
+import org.modelix.model.server.runWithNettyServer
 import org.modelix.model.server.store.InMemoryStoreClient
 import org.modelix.model.server.store.LocalModelClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
+import kotlin.time.Duration.Companion.seconds
 
 class ModelReplicationServerTest {
 
@@ -47,7 +60,7 @@ class ModelReplicationServerTest {
         return ModelReplicationServer(repositoriesManager, modelClient, InMemoryModels())
     }
 
-    private fun runTest(
+    private fun runWithTestModelServer(
         modelReplicationServer: ModelReplicationServer = getDefaultModelReplicationServer(),
         block: suspend ApplicationTestBuilder.(scope: CoroutineScope) -> Unit,
     ) = testApplication {
@@ -63,7 +76,7 @@ class ModelReplicationServerTest {
     }
 
     @Test
-    fun `pulling delta does not return objects twice`() = runTest {
+    fun `pulling delta does not return objects twice`() = runWithTestModelServer {
         // Arrange
         val url = "http://localhost/v2"
         val modelClient = ModelClientV2.builder().url(url).client(client).build().also { it.init() }
@@ -117,7 +130,7 @@ class ModelReplicationServerTest {
         val repositoryId = RepositoryId("repo1")
         val branchRef = repositoryId.getBranchReference()
 
-        runTest(modelReplicationServer) {
+        runWithTestModelServer(modelReplicationServer) {
             repositoriesManager.createRepository(repositoryId, null)
 
             // Act
@@ -132,5 +145,64 @@ class ModelReplicationServerTest {
             // Assert
             assertEquals(HttpStatusCode.InternalServerError, response.status)
         }
+    }
+
+    @Test
+    fun `server closes connection when failing to compute delta after starting to respond`() = runTest {
+        // Arrange
+        val repositoryId = RepositoryId("repo1")
+        val branchRef = repositoryId.getBranchReference()
+        val storeClient = InMemoryStoreClient()
+        val modelClient = LocalModelClient(storeClient)
+        val repositoriesManager = RepositoriesManager(modelClient)
+        val faultyRepositoriesManager = object :
+            IRepositoriesManager by repositoriesManager {
+            override suspend fun computeDelta(versionHash: String, baseVersionHash: String?): ObjectData {
+                val originalFlow = repositoriesManager.computeDelta(versionHash, baseVersionHash).asFlow()
+                val brokenFlow = channelFlow<Pair<String, String>> {
+                    error("Unexpected error.")
+                }
+                return ObjectDataFlow(
+                    flow {
+                        emitAll(originalFlow)
+                        emitAll(brokenFlow)
+                    },
+                )
+            }
+        }
+        repositoriesManager.createRepository(repositoryId, null)
+
+        suspend fun createClient(server: NettyApplicationEngine): HttpClient {
+            val port = server.resolvedConnectors().first().port
+            return HttpClient(CIO) {
+                defaultRequest {
+                    url("http://localhost:$port")
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 5_000
+                }
+            }
+        }
+
+        val modelReplicationServer = ModelReplicationServer(faultyRepositoriesManager, modelClient, InMemoryModels())
+        val setupBlock = { application: Application -> modelReplicationServer.init(application) }
+        val testBlock: suspend (server: NettyApplicationEngine) -> Unit = { server ->
+            withTimeout(10.seconds) {
+                val client = createClient(server)
+                // Act
+                val response = client.get {
+                    url {
+                        takeFrom(url)
+                        appendPathSegments("v2", "repositories", repositoryId.id, "branches", branchRef.branchName)
+                    }
+                    useVersionStreamFormat()
+                }
+
+                // Assert
+                // The response should be delivered even if an exception is thrown inside the flow.
+                assertEquals(HttpStatusCode.OK, response.status)
+            }
+        }
+        runWithNettyServer(setupBlock, testBlock)
     }
 }


### PR DESCRIPTION
Use `respondBytesWriter` because it has a non-blocking `writeStringUtf8` method. `respondTextWriter` has only blocking methods to write data.

Using a `Writer` is just an indirection without purpose.