### PR TITLE
fix(model-client): detect incomplete version delta streams

### DIFF
--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/ModelClientV2JvmTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/ModelClientV2JvmTest.kt
@@ -22,6 +22,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ModelClientV2JvmTest {
@@ -40,13 +41,15 @@ class ModelClientV2JvmTest {
         // Implementing `close` allow to use `.use` method.
         modelClient.use {
         }
-        assertFailsWith<CancellationException>("Parent job is Completed") {
+        val firstException = assertFailsWith<CancellationException> {
             modelClient.init()
         }
-        // `Closable` implies, that `.close` method is idempotent.
+        assertEquals("Parent job is Completed", firstException.message)
+        // `Closable` implies that `.close` method is idempotent.
         modelClient.close()
-        assertFailsWith<CancellationException>("Parent job is Completed") {
+        val secondException = assertFailsWith<CancellationException> {
             modelClient.init()
         }
+        assertEquals("Parent job is Completed", secondException.message)
     }
 }

--- a/model-server-api/build.gradle.kts
+++ b/model-server-api/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-//                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion")
+                implementation(libs.kotlin.coroutines.test)
                 implementation(kotlin("test"))
             }
         }

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server.api.v2
+
+import io.ktor.http.ContentType
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.readUTF8Line
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * In comparison to the previous format for version deltas,
+ * this format is structured so that incompletely sent data can be detected.
+ *
+ * Detecting incomplete data is a workaround for:
+ * - https://youtrack.jetbrains.com/issue/KTOR-6905/The-client-reads-incomplete-streamed-responses-without-failing
+ *   In this case partial data from a request might be read
+ *   without throwing an exception or indicating it with a correct return value
+ * - https://youtrack.jetbrains.com/issue/KTOR-4862/Ktor-hangs-if-exception-occurs-during-write-response-body
+ *   Because Ktor server does not close the connection when an exception occurs while writing a body
+ *   we always close the connection even if not all data was yet send (see [ByteWriteChannel.useClosingWithoutCause]).
+ *
+ *  The format sends redundant hashes because of previous bugs encountered with SHA1 calculation.
+ *  See https://github.com/modelix/modelix.core/pull/213/commits/a412bc97765426fcc81db0c55516c65b8679641b
+ */
+class VersionDeltaStreamV2(
+    val versionHash: String,
+    val hashesWithDeltaObject: Flow<Pair<String, String>>,
+) {
+    companion object {
+        class IncompleteData(message: String) : RuntimeException(message)
+
+        val CONTENT_TYPE = ContentType("application", "x-modelix-objects-v2")
+        private const val NEW_LINE_IN_VERSION_DELTA_STREAM_V2 = "\n"
+
+        /**
+         * Magic byte (as string) that indicates the end of one data line/all streaming data.
+         * Use `$`/`~` because it:
+         * (1) encodes as a single byte in UTF8 and therefore cannot be sent partially.
+         * (2) is not a first character in serialized value (see. [IKVValue.serialize]).
+         * (3) it is a char that would be URL-encoded in object data.
+         */
+        private const val MAGIC_BYTE_FOR_END_OF_DATA_LINE = "$"
+        private const val MAGIC_BYTE_FOR_END_OF_VERSION_DELTA = "~"
+
+        private suspend fun encodeLine(output: ByteWriteChannel, line: String) {
+            output.writeStringUtf8(line)
+            output.writeStringUtf8(NEW_LINE_IN_VERSION_DELTA_STREAM_V2)
+            output.writeStringUtf8(MAGIC_BYTE_FOR_END_OF_DATA_LINE)
+            output.writeStringUtf8(NEW_LINE_IN_VERSION_DELTA_STREAM_V2)
+        }
+
+        suspend fun encodeVersionDeltaStreamV2(
+            output: ByteWriteChannel,
+            versionHash: String,
+            hashesWithDeltaObject: Flow<Pair<String, String>>,
+        ) {
+            encodeLine(output, versionHash)
+            hashesWithDeltaObject.collect { (hash, deltaObject) ->
+                encodeLine(output, hash)
+                encodeLine(output, deltaObject)
+            }
+            output.writeStringUtf8(MAGIC_BYTE_FOR_END_OF_VERSION_DELTA)
+        }
+
+        private suspend fun decodeLine(input: ByteReadChannel): String? {
+            val dataLine = input.readUTF8Line()
+            when (dataLine) {
+                null -> throw IncompleteData("Missing data line")
+                MAGIC_BYTE_FOR_END_OF_VERSION_DELTA -> return null
+            }
+            val endOfDataLine = input.readUTF8Line()
+            if (endOfDataLine != MAGIC_BYTE_FOR_END_OF_DATA_LINE) {
+                throw IncompleteData("Missing end of data line [dataLine=`$dataLine`] [endOfDataLine=`$endOfDataLine`]")
+            }
+            return dataLine
+        }
+
+        /**
+         * @throws IncompleteData if data is detected to be incomplete
+         */
+        suspend fun decodeVersionDeltaStreamV2(input: ByteReadChannel): VersionDeltaStreamV2 {
+            val versionHash = decodeLine(input) ?: throw IncompleteData("Version hash missing.")
+            val hashesWithDeltaObject = flow {
+                while (true) {
+                    val hash = decodeLine(input) ?: break
+                    val deltaObject = decodeLine(input) ?: throw IncompleteData("Missing delta object.")
+                    emit(hash to deltaObject)
+                }
+            }
+            return VersionDeltaStreamV2(versionHash, hashesWithDeltaObject)
+        }
+    }
+}

--- a/model-server-api/src/commonTest/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2Test.kt
+++ b/model-server-api/src/commonTest/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2Test.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server.api.v2
+
+import io.ktor.util.cio.use
+import io.ktor.util.toByteArray
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.writeFully
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.modelix.model.server.api.v2.VersionDeltaStreamV2.Companion.IncompleteData
+import org.modelix.model.server.api.v2.VersionDeltaStreamV2.Companion.decodeVersionDeltaStreamV2
+import org.modelix.model.server.api.v2.VersionDeltaStreamV2.Companion.encodeVersionDeltaStreamV2
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class VersionDeltaStreamV2Test {
+
+    @Test
+    fun parsesStreamWithoutObjects() = runTest {
+        val channel = ByteChannel()
+        channel.use {
+            encodeVersionDeltaStreamV2(channel, "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A", emptyFlow())
+        }
+        val versionDeltaStream = decodeVersionDeltaStreamV2(channel)
+
+        assertEquals("CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A", versionDeltaStream.versionHash)
+        assertEquals(emptyList(), versionDeltaStream.hashesWithDeltaObject.toList())
+    }
+
+    @Test
+    fun parsesStreamWithObjects() = runTest {
+        val channel = ByteChannel()
+        channel.use {
+            encodeVersionDeltaStreamV2(
+                channel,
+                "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A",
+                flowOf(
+                    "r7k0y*p0mmIhhD46RvqLsmTEGuBQvAf9hw7aN0IzihLc" to "L/100000017/xioDt*mnraICBf48DpWkvvtl2KuPixWn1p7yteYQ3XSg",
+                    "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A" to "1/%00/0/%00///",
+                ),
+            )
+        }
+
+        val versionDeltaStream = decodeVersionDeltaStreamV2(channel)
+
+        assertEquals("CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A", versionDeltaStream.versionHash)
+        val expectedObjects = listOf(
+            "r7k0y*p0mmIhhD46RvqLsmTEGuBQvAf9hw7aN0IzihLc" to "L/100000017/xioDt*mnraICBf48DpWkvvtl2KuPixWn1p7yteYQ3XSg",
+            "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A" to "1/%00/0/%00///",
+        )
+        assertEquals(expectedObjects, versionDeltaStream.hashesWithDeltaObject.toList())
+    }
+
+    @Test
+    fun failsToParseEmptyStream() = runTest {
+        val data = ""
+        val channel = ByteChannel()
+        channel.use {
+            writeStringUtf8(data)
+        }
+
+        val exception = assertFailsWith<IncompleteData> {
+            decodeVersionDeltaStreamV2(channel).hashesWithDeltaObject.toList()
+        }
+        assertEquals("Missing data line", exception.message)
+    }
+
+    @Test
+    fun failsToParseIncompleteLine() = runTest {
+        val data = "CTVRw*a6KXJ4o7uzGlp"
+        val channel = ByteChannel()
+        channel.use {
+            writeStringUtf8(data)
+        }
+
+        val exception = assertFailsWith<IncompleteData> {
+            decodeVersionDeltaStreamV2(channel).hashesWithDeltaObject.toList()
+        }
+        assertEquals(
+            "Missing end of data line [dataLine=`CTVRw*a6KXJ4o7uzGlp`] [endOfDataLine=`null`]",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun failsToParseStreamWithWrongEndOfDataLine() = runTest {
+        val data = "CTVRw*a6KXJ4o7uzGlp\n%"
+        val channel = ByteChannel()
+        channel.use {
+            writeStringUtf8(data)
+        }
+
+        val exception = assertFailsWith<IncompleteData> {
+            decodeVersionDeltaStreamV2(channel).hashesWithDeltaObject.toList()
+        }
+        assertEquals(
+            "Missing end of data line [dataLine=`CTVRw*a6KXJ4o7uzGlp`] [endOfDataLine=`%`]",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun failsToParseStreamWithoutVersionHash() = runTest {
+        val data = "~"
+        val channel = ByteChannel()
+        channel.use {
+            writeStringUtf8(data)
+        }
+
+        val exception = assertFailsWith<IncompleteData> {
+            decodeVersionDeltaStreamV2(channel).hashesWithDeltaObject.toList()
+        }
+        assertEquals("Version hash missing.", exception.message)
+    }
+
+    @Test
+    fun failsParsingStreamWithMissingDataAfterVersionHash() = runTest {
+        val data = "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A\n$\n"
+        val channel = ByteChannel()
+        channel.use {
+            writeStringUtf8(data)
+        }
+
+        val exception = assertFailsWith<IncompleteData> {
+            decodeVersionDeltaStreamV2(channel).hashesWithDeltaObject.toList()
+        }
+        assertEquals("Missing data line", exception.message)
+    }
+
+    @Test
+    fun failsParsingStreamWithMissingObject() = runTest {
+        val data = "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A\n$\n" +
+            "r7k0y*p0mmIhhD46RvqLsmTEGuBQvAf9hw7aN0IzihLc\n$\n" +
+            "L/100000017/xioDt*mnraICBf48DpWkvvtl2KuPixWn1p7yteYQ3XSg\n$\n" +
+            "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A\n$\n" +
+            "~"
+
+        val channel = ByteChannel()
+        channel.use {
+            writeStringUtf8(data)
+        }
+
+        val emittedObjects = mutableListOf<Pair<String, String>>()
+        val exception = assertFailsWith<IncompleteData> {
+            decodeVersionDeltaStreamV2(channel).hashesWithDeltaObject.collect(emittedObjects::add)
+        }
+        assertEquals("Missing delta object.", exception.message)
+        assertEquals(
+            listOf("r7k0y*p0mmIhhD46RvqLsmTEGuBQvAf9hw7aN0IzihLc" to "L/100000017/xioDt*mnraICBf48DpWkvvtl2KuPixWn1p7yteYQ3XSg"),
+            emittedObjects,
+        )
+    }
+
+    @Test
+    fun failsToParseAnySubstringOfAValidEncoding() = runTest {
+        val channel = ByteChannel()
+        channel.use {
+            encodeVersionDeltaStreamV2(
+                channel,
+                "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A",
+                flowOf(
+                    "r7k0y*p0mmIhhD46RvqLsmTEGuBQvAf9hw7aN0IzihLc" to "L/100000017/xioDt*mnraICBf48DpWkvvtl2KuPixWn1p7yteYQ3XSg",
+                    "CTVRw*a6KXJ4o7uzGlp-kUosxpyRf4fUpHnLokG9T86A" to "1/%00/0/%00///",
+                ),
+            )
+        }
+        val fullByteArray = channel.toByteArray()
+
+        for (newSize in fullByteArray.indices) {
+            val subByteArray = fullByteArray.copyOf(newSize)
+            val subChannel = ByteChannel()
+            subChannel.use {
+                subChannel.writeFully(subByteArray)
+            }
+
+            assertFailsWith<IncompleteData> {
+                decodeVersionDeltaStreamV2(subChannel).hashesWithDeltaObject.toList()
+            }
+        }
+    }
+}

--- a/model-server-openapi/specifications/model-server.yaml
+++ b/model-server-openapi/specifications/model-server.yaml
@@ -603,6 +603,9 @@ components:
         'application/x-modelix-objects':
           schema:
             type: string
+        'application/x-modelix-objects-v2':
+          schema:
+            type: string
         'application/json':
           schema:
             type: object


### PR DESCRIPTION
Introduce a new version delta stream format that enables the client to properly detect incomplete delta version streams.

Old clients can still use the old format, but they might not detect incomplete streams.