### PR TITLE
test(bulk-model-sync): increase timeout of JS tests

### DIFF
--- a/bulk-model-sync-lib/build.gradle.kts
+++ b/bulk-model-sync-lib/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
         browser {
             testTask {
                 useMocha {
-                    timeout = "30s"
+                    timeout = "60s"
                 }
             }
         }


### PR DESCRIPTION
The test `can handle random changes` was often failing due to timeouts.

It fails because one test checks a hundred random cases.

`kotlin.test` does not support parametrized tests. Kotest would support it, but the `Annotation Spec` does not support Kotlin multiplatform.

Not wanting to decide on another testing style and rewrite the test, I just increased the timeout.

e.g. https://github.com/modelix/modelix.core/runs/23384531208