### PR TITLE
build: remove plugin com.dorongold.task-tree

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.gitVersion)
     alias(libs.plugins.spotless) apply false
-    alias(libs.plugins.tasktree)
     alias(libs.plugins.dokka)
     alias(libs.plugins.node) apply false
     alias(libs.plugins.detekt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 gitVersion = { id = "com.palantir.git-version", version = "3.0.0" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.0" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
-tasktree = { id = "com.dorongold.task-tree", version = "2.1.1" }
 modelix-mps-buildtools = { id = "org.modelix.mps.build-tools", version.ref = "modelixBuildtools" }
 dokka = {id = "org.jetbrains.dokka", version.ref = "dokka"}
 node = {id = "com.github.node-gradle.node", version = "7.0.2"}


### PR DESCRIPTION
It only adds debugging functionality that can be added to the build temporarily when needed.