### PR TITLE
build: remove action wagoid/commitlint-github-action

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -3,15 +3,6 @@ on:
   pull_request:
 
 jobs:
-  lint-commits:
-    name: Lint PR commits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
-
   test-release:
     name: Dry-run semantic-release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ If you are looking for MPS-related modelix components,
 see https://github.com/modelix/modelix.mps and https://github.com/modelix/modelix.mps-plugins.
 
 
+test
+
 ## Development
 
 ### Commit convention


### PR DESCRIPTION
Commitlint is executed by pre-commit and checked in the `linting.yml` workflow.