### PR TITLE
fix(bulk-model-sync): update previously unresolvable references if they can be resolved

### DIFF
--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -80,9 +80,9 @@ class ModelImporter(
         }
     }
 
-    data class PostponedReference(
+    private data class PostponedReference(
         val expectedTargetId: String,
-        val mpsNode: INode,
+        val node: INode,
         val role: String,
     )
 
@@ -91,9 +91,9 @@ class ModelImporter(
         if (expectedRefTarget == null) {
             // The target node is not part of the model. Assuming it exists in some other model we can
             // store the reference and try to resolve it dynamically on access.
-            mpsNode.setReferenceTarget(role, SerializedNodeReference(expectedTargetId))
+            node.setReferenceTarget(role, SerializedNodeReference(expectedTargetId))
         } else {
-            mpsNode.setReferenceTarget(role, expectedRefTarget)
+            node.setReferenceTarget(role, expectedRefTarget)
         }
     }
 


### PR DESCRIPTION
For unresolvable references we store the serialized expected reference, as we assume the node is not part of the model but the reference might still be useful for dynamic resolution on access. 
If the target node became part of the model later on, we did not update it because the originalIds still matched. Now we check, if it was previously unresolvable and update the reference to the INode accordingly.