### PR TITLE
feat(model-server): implement deleting branches via REST API and ModelClient

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -44,6 +44,14 @@ interface IModelClientV2 {
     suspend fun deleteRepository(repository: RepositoryId): Boolean
     suspend fun listBranches(repository: RepositoryId): List<BranchReference>
 
+    /**
+     * Deletes a branch from a repository if it exists.
+     *
+     * @param branch the branch to delete
+     * @return true if the branch existed and could be deleted, else false.
+     */
+    suspend fun deleteBranch(branch: BranchReference): Boolean
+
     @Deprecated("repository ID is required for permission checks")
     @DeprecationInfo("3.7.0", "May be removed with the next major release. Also remove the endpoint from the model-server.")
     suspend fun loadVersion(versionHash: String, baseVersion: IVersion?): IVersion

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -22,6 +22,7 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.prepareGet
@@ -166,6 +167,25 @@ class ModelClientV2(
                 appendPathSegmentsEncodingSlash("repositories", repository.id, "branches")
             }
         }.bodyAsText().lines().filter { it.isNotEmpty() }.map { repository.getBranchReference(it) }
+    }
+
+    override suspend fun deleteBranch(branch: BranchReference): Boolean {
+        try {
+            return httpClient.delete {
+                url {
+                    takeFrom(baseUrl)
+                    appendPathSegmentsEncodingSlash(
+                        "repositories",
+                        branch.repositoryId.id,
+                        "branches",
+                        branch.branchName,
+                    )
+                }
+            }.status == HttpStatusCode.NoContent
+        } catch (ex: Exception) {
+            LOG.error(ex) { ex.message }
+            return false
+        }
     }
 
     @Deprecated("repository ID is required for permission checks")

--- a/model-server-openapi/specifications/model-server.yaml
+++ b/model-server-openapi/specifications/model-server.yaml
@@ -85,6 +85,24 @@ paths:
         "200":
           $ref: '#/components/responses/200'
   /v2/repositories/{repository}/branches/{branch}:
+    delete:
+      operationId: deleteRepositoryBranch
+      parameters:
+        - name: repository
+          in: "path"
+          required: true
+          schema:
+            type: string
+        - name: branch
+          in: "path"
+          required: true
+          schema:
+            type: string
+      responses:
+        "404":
+          $ref: '#/components/responses/404'
+        "204":
+          description: "Branch successfully deleted"
     get:
       operationId: getRepositoryBranch
       parameters:


### PR DESCRIPTION
Adds a new DELETE endpoint to the REST API for deleting a branch from a repository. Moreover, the ModelClient is extended with the matching `deleteBranch` method.

Garbage collection of data potentially not referenced anymore is not handled here and will be part of a later feature implementation.