### PR TITLE
chore: configure the detekt IntelliJ plugin

### DIFF
--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DetektPluginSettings">
+    <option name="configurationFiles">
+      <list>
+        <option value="$PROJECT_DIR$/.detekt.yml" />
+      </list>
+    </option>
+    <option name="enableDetekt" value="true" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ added 72 packages, removed 98 packages, changed 203 packages, and audited 654 pa
 ...
 ```
 
+### detekt
+
+We use [detekt](https://detekt.dev/) as a Kotlin linter.
+detekt is integrated in the Gradle build process.
+Manually, it can be triggered with:
+
+```console
+$ ./gradlew detektMain detektTest detektJsMain detektJsTest detektJvmMain detektJvmTest
+...
+```
+
+The project contains a configuration for the [IntelliJ detekt plugin](https://plugins.jetbrains.com/plugin/10761-detekt).
+If you install this plugin, you should get detekt annotations inline in IntelliJ.
+Unfortunately, the plugin [does not support detekt rules requiring type resolution](https://github.com/detekt/detekt-intellij-plugin/issues/499).
+Therefore, some annotations can only be obtained by running detekt through Gradle.
+
+detekt results are also reported on the GitHub project using GitHub's code scanning feature.
+In PRs, detekt finding will be provided as annotations on the PR.
+
 # Authors
 
 Development of modelix is supported by [itemis](https://itemis.com)


### PR DESCRIPTION
Adds the required configuration file for the IntelliJ plugin.

Fixes: MODELIX-793