### PR TITLE
feat(model-server): report errors as application/problem+json

### DIFF
--- a/authorization/src/main/kotlin/org/modelix/authorization/KtorAuthUtils.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/KtorAuthUtils.kt
@@ -34,7 +34,6 @@ import io.ktor.server.auth.jwt.jwt
 import io.ktor.server.auth.parseAuthorizationHeader
 import io.ktor.server.auth.principal
 import io.ktor.server.plugins.forwardedheaders.XForwardedHeaders
-import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.request.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
@@ -81,28 +80,6 @@ fun Application.installAuthentication(unitTestMode: Boolean = false) {
                     } catch (e: Exception) {
                     }
                     null
-                }
-            }
-        }
-    }
-    install(StatusPages) {
-        exception<Throwable> { call, cause ->
-            when (cause) {
-                is NoPermissionException -> call.respondText(
-                    text = cause.message ?: "",
-                    status = HttpStatusCode.Forbidden,
-                )
-                is NotLoggedInException -> call.respondText(
-                    text = cause.message ?: "",
-                    status = HttpStatusCode.Unauthorized,
-                )
-                else -> {
-                    val text = """
-                        |500: $cause
-                        |
-                        |${cause.stackTraceToString()}
-                    """.trimMargin()
-                    call.respondText(text = text, status = HttpStatusCode.InternalServerError)
                 }
             }
         }

--- a/model-server-openapi/specifications/model-server.yaml
+++ b/model-server-openapi/specifications/model-server.yaml
@@ -22,38 +22,48 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/user-id:
     get:
       operationId: getUserId
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/generate-client-id:
     post:
       operationId: postGenerateClientId
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /headers:
     get:
       operationId: getHeaders
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /health:
     get:
       operationId: getHealth
       responses:
         "200":
           $ref: '#/components/responses/200'
-        "500":
-          $ref: '#/components/responses/500'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories:
     get:
       operationId: getRepositories
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/objects:
     put:
       operationId: putRepositoryObjects
@@ -68,10 +78,10 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/200json'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches:
     get:
       operationId: getRepositoryBranches
@@ -84,6 +94,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches/{branch}:
     delete:
       operationId: deleteRepositoryBranch
@@ -103,6 +115,8 @@ paths:
           $ref: '#/components/responses/404'
         "204":
           description: "Branch successfully deleted"
+        default:
+          $ref: '#/components/responses/GeneralError'
     get:
       operationId: getRepositoryBranch
       parameters:
@@ -130,6 +144,8 @@ paths:
 #            '*/*':
 #              schema:
 #                $ref: "#/components/schemas/VersionDelta"
+        default:
+          $ref: '#/components/responses/GeneralError'
     post:
       operationId: postRepositoryBranch
       parameters:
@@ -156,6 +172,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/versionDelta'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches/{branch}/hash:
     get:
       operationId: getRepositoryBranchHash
@@ -175,6 +193,8 @@ paths:
           $ref: '#/components/responses/404'
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches/{branch}/listen:
     get:
       operationId: listenRepositoryBranch
@@ -217,8 +237,6 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "101":
           description: "Switching Protocols"
           headers:
@@ -234,6 +252,8 @@ paths:
               required: true
               schema:
                 type: string
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches/{branch}/poll:
     get:
       operationId: pollRepositoryBranch
@@ -258,10 +278,10 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/versionDelta'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches/{branch}/pollHash:
     get:
       operationId: pollRepositoryBranchHash
@@ -286,10 +306,10 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/branches/{branch}/query:
     post:
       operationId: postRepositoryBranchQuery
@@ -307,8 +327,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200json'
-        "500":
-          $ref: '#/components/responses/500'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/init:
     post:
       operationId: initializeRepository
@@ -328,10 +348,10 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/versionDelta'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/delete:
     post:
       operationId: deleteRepository
@@ -374,12 +394,16 @@ paths:
             '*/*':
               schema:
                 type: object
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/repositories/{repository}/versions/{versionHash}/history/{oldestVersionHash}:
     get:
       operationId: getOldestVersionHash
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
       parameters:
         - name: repository
           in: "path"
@@ -413,8 +437,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200json'
-        "500":
-          $ref: '#/components/responses/500'
+        default:
+          $ref: '#/components/responses/GeneralError'
 
   /v2/versions/{versionHash}:
     get:
@@ -435,12 +459,16 @@ paths:
           $ref: '#/components/responses/404'
         "200":
           $ref: '#/components/responses/versionDelta'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /v2/versions/{versionHash}/history/{oldestVersionHash}:
     get:
       operationId: getOldestVersionHashForVersion
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
       parameters:
         - name: versionHash
           in: "path"
@@ -465,10 +493,10 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /get/{key}:
     get:
       parameters:
@@ -482,12 +510,12 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "404":
           $ref: '#/components/responses/404'
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /getAll:
     put:
       responses:
@@ -495,15 +523,17 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/200json'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /getEmail:
     get:
       responses:
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /getRecursively/{key}:
     get:
       parameters:
@@ -515,6 +545,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200json'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /poll/{key}:
     get:
       parameters:
@@ -533,12 +565,12 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "404":
           $ref: '#/components/responses/404'
         "200":
           $ref: '#/components/responses/200'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /put/{key}:
     put:
       parameters:
@@ -552,12 +584,12 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/200'
         "404":
           $ref: '#/components/responses/404'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /putAll:
     put:
       responses:
@@ -565,15 +597,21 @@ paths:
           $ref: '#/components/responses/403'
         "401":
           $ref: '#/components/responses/401'
-        "500":
-          $ref: '#/components/responses/500'
         "200":
           $ref: '#/components/responses/200'
         "404":
           $ref: '#/components/responses/404'
+        default:
+          $ref: '#/components/responses/GeneralError'
 components:
   responses:
     "200":
+      description: OK
+      content:
+        text/plain:
+          schema:
+            type: string
+    "204":
       description: OK
       content:
         text/plain:
@@ -585,36 +623,38 @@ components:
         application/json:
           schema:
             type: string
+
     "400":
       description: "Bad Request"
       content:
-        text/plain:
+        application/problem+json:
           schema:
-            type: string
+            $ref: '#/components/schemas/Problem'
     "401":
       description: "Unauthorized"
       content:
-        text/plain:
+        application/problem+json:
           schema:
-            type: string
-    403:
+            $ref: '#/components/schemas/Problem'
+    "403":
       description: "Forbidden"
       content:
-        text/plain:
+        application/problem+json:
           schema:
-            type: string
+            $ref: '#/components/schemas/Problem'
     "404":
       description: "Not Found"
       content:
-        text/plain:
+        application/problem+json:
           schema:
-            type: string
-    "500":
-      description: "Internal Server Error"
+            $ref: '#/components/schemas/Problem'
+    GeneralError:
+      description: Unexpected error
       content:
-        text/plain:
+        application/problem+json:
           schema:
-            type: string
+            $ref: '#/components/schemas/Problem'
+
     "versionDelta":
       description: OK
       content:
@@ -630,7 +670,55 @@ components:
         'text/plain':
           schema:
             type: string
+
   schemas:
+    # From https://opensource.zalando.com/restful-api-guidelines/models/problem-1.0.1.yaml
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri-reference
+          description: >
+            A URI reference that uniquely identifies the problem type only in the
+            context of the provided API. Opposed to the specification in RFC-9457,
+            it is neither recommended to be dereferenceable and point to a
+            human-readable documentation nor globally unique for the problem type.
+          default: 'about:blank'
+          example: '/some/uri-reference'
+        title:
+          type: string
+          description: >
+            A short summary of the problem type. Written in English and readable
+            for engineers, usually not suited for non technical stakeholders and
+            not localized.
+          example: some title for the error situation
+        status:
+          type: integer
+          format: int32
+          description: >
+            The HTTP status code generated by the origin server for this occurrence
+            of the problem.
+          minimum: 100
+          maximum: 600
+          exclusiveMaximum: true
+        detail:
+          type: string
+          description: >
+            A human readable explanation specific to this occurrence of the
+            problem that is helpful to locate the problem and give advice on how
+            to proceed. Written in English and readable for engineers, usually not
+            suited for non technical stakeholders and not localized.
+          example: some description for the error situation
+        instance:
+          type: string
+          format: uri-reference
+          description: >
+            A URI reference that identifies the specific occurrence of the problem,
+            e.g. by adding a fragment identifier or sub-path to the problem type.
+            May be used to locate the root of this problem in the source code.
+          example: '/some/uri-reference#specific-occurrence-context'
+
     VersionDelta:
       title: VersionDelta
       type: object

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/HttpException.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/HttpException.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server.handlers
+
+import io.ktor.http.HttpStatusCode
+import org.modelix.api.public.Problem
+import org.modelix.model.lazy.BranchReference
+
+/**
+ * A namespace for problems we use as the first part of every `type` in an application/problem+json response.
+ *
+ * Follows the ideas from https://opensource.zalando.com/restful-api-guidelines/#176.
+ */
+const val PROBLEM_NAMESPACE = "/problems"
+
+/**
+ * Constructs a namespaces problem type for application/problem+json in the format /<namespace>/<suffix>.
+ *
+ * The generated format follows the ideas from https://opensource.zalando.com/restful-api-guidelines/#176
+ *
+ * @param suffix kebab-case identifier for a certain type of problem
+ */
+fun problemType(suffix: String) = "$PROBLEM_NAMESPACE/$suffix"
+
+/**
+ * An exception used to indicate a problem serving an HTTP request. It includes details used to construct a proper
+ * response.
+ *
+ * @param problem the problem to use as the basis for this exception. In case the problem does not contain a status
+ *                code, an internal server error 500 is assumed.
+ * @param cause the exception that caused this problem or null if none.
+ */
+open class HttpException(problem: Problem, cause: Throwable? = null) : RuntimeException(problem.toString(), cause) {
+    /**
+     * A description of the problem this exception is reporting to the caller.
+     */
+    val problem = problem.copy(status = problem.status ?: HttpStatusCode.InternalServerError.value)
+
+    /**
+     * Creates a new instance of this exception based on a status code and other details contributing to a [Problem].
+     */
+    constructor(
+        statusCode: HttpStatusCode = HttpStatusCode.InternalServerError,
+        title: String? = null,
+        details: String? = null,
+        type: String? = null,
+        instance: String? = null,
+        cause: Throwable? = null,
+    ) : this(
+        Problem(status = statusCode.value, title = title, detail = details, type = type, instance = instance),
+        cause,
+    )
+}
+
+/**
+ * Indicates a bad request from the client with missing or invalid information provided.
+ *
+ * @param details the detailed message to expose to the caller
+ * @param typeSuffix A detailed type making this bad request instance uniquely identifiable. [PROBLEM_NAMESPACE] will
+ *                   automatically be prepended. This field should be written in kebab-case.
+ * @param cause The causing exception for the bad request or null if none.
+ */
+class BadRequestException(details: String, typeSuffix: String, cause: Throwable? = null) : HttpException(
+    HttpStatusCode.BadRequest,
+    title = "Bad request",
+    details = details,
+    type = problemType(typeSuffix),
+    cause = cause,
+)
+
+/**
+ * A [HttpException] indicating that a branch was not found in a repository.
+ *
+ * @param branch name of the missing branch
+ * @param repositoryId ID of the repository missing the branch
+ * @param cause The causing exception for the bad request or null if none.
+ */
+class BranchNotFoundException(branch: String, repositoryId: String, cause: Throwable? = null) : HttpException(
+    HttpStatusCode.NotFound,
+    title = "Branch not found",
+    details = "Branch '$branch' does not exist in repository '$repositoryId'",
+    type = "/problems/branch-not-found",
+    cause = cause,
+) {
+    constructor(branch: BranchReference, cause: Throwable? = null) : this(
+        branch.branchName,
+        branch.repositoryId.id,
+        cause,
+    )
+}
+
+/**
+ * A [HttpException] indicating that a version inside a repository or branch was not found.
+ *
+ * @param versionHash has of the missing version
+ * @param cause The causing exception for the bad request or null if none.
+ */
+class VersionNotFoundException(versionHash: String, cause: Throwable? = null) :
+    HttpException(
+        HttpStatusCode.NotFound,
+        title = "Version not found",
+        details = "Version '$versionHash' doesn't exist",
+        type = "/problems/version-not-found",
+        cause = cause,
+    )

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelServerTestUtil.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelServerTestUtil.kt
@@ -29,6 +29,7 @@ import io.ktor.server.websocket.WebSockets
 import kotlinx.coroutines.runBlocking
 import org.modelix.authorization.installAuthentication
 import org.modelix.model.client2.ModelClientV2
+import org.modelix.model.server.Main.installStatusPages
 
 suspend fun ApplicationTestBuilder.createModelClient(): ModelClientV2 {
     val url = "http://localhost/v2"
@@ -40,6 +41,7 @@ fun Application.installDefaultServerPlugins() {
     install(ContentNegotiation) { json() }
     install(Resources)
     install(IgnoreTrailingSlash)
+    installStatusPages()
 }
 
 /**


### PR DESCRIPTION
This commit modifies the v2 REST API to always report errors as application/problem+json instances following RFC 9475. We do not declare this as a breaking change as we never guaranteed a certain error format.

The OpenAPI specification has been extended with a default error response for all routes to avoid having to repeat the definition many times.

The installation of the StatusPages extension had to be moved to the model-server Main file as this extension is now used to map instances of the new HttpException class to suitable responses.

HttpException has been introduced due to the lack of a standard HTTP exception hierarchy in ktor. Throwing exceptions instead of call.respondXXX usually makes route implementations shorter and easier to read.