### PR TITLE
ci: group com.google.oauth-client updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      google-oauth:
+        patterns:
+          - "com.google.oauth-client*"
   - package-ecosystem: "docker"
     open-pull-requests-limit: 20
     directory: "/model-server"


### PR DESCRIPTION
Avoids separate PRs for client and client-jetty.

#742 #741 will be grouped after this hopefully.