### PR TITLE
feat(model-client): let the user set useRoleIds in the initRepository call

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -39,7 +39,7 @@ interface IModelClientV2 {
     fun getIdGenerator(): IIdGenerator
     fun getUserId(): String?
 
-    suspend fun initRepository(repository: RepositoryId): IVersion
+    suspend fun initRepository(repository: RepositoryId, useRoleIds: Boolean = true): IVersion
     suspend fun listRepositories(): List<RepositoryId>
     suspend fun deleteRepository(repository: RepositoryId): Boolean
     suspend fun listBranches(repository: RepositoryId): List<BranchReference>

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -24,6 +24,7 @@ import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.prepareGet
 import io.ktor.client.request.preparePost
@@ -125,9 +126,10 @@ class ModelClientV2(
 
     override fun getUserId(): String? = clientProvidedUserId ?: serverProvidedUserId
 
-    override suspend fun initRepository(repository: RepositoryId): IVersion {
+    override suspend fun initRepository(repository: RepositoryId, useRoleIds: Boolean): IVersion {
         return httpClient.preparePost {
             url {
+                parameter("useRoleIds", useRoleIds)
                 takeFrom(baseUrl)
                 appendPathSegmentsEncodingSlash("repositories", repository.id, "init")
             }

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -276,4 +276,22 @@ class ModelClientV2Test {
 
         assertEquals(initialVersion.getContentHash(), loadedVersion.getContentHash())
     }
+
+    @Test
+    fun `create repository with useRoleIds true`() = runTest {
+        val modelClient = createModelClient()
+        val repositoryId = RepositoryId("useRoleIdsTrue")
+        val initialVersion = modelClient.initRepository(repositoryId)
+
+        assertTrue(initialVersion.getTree().usesRoleIds())
+    }
+
+    @Test
+    fun `create repository with useRoleIds false`() = runTest {
+        val modelClient = createModelClient()
+        val repositoryId = RepositoryId("useRoleIdsFalse")
+        val initialVersion = modelClient.initRepository(repositoryId, useRoleIds = false)
+
+        assertFalse(initialVersion.getTree().usesRoleIds())
+    }
 }


### PR DESCRIPTION
The `initRepository` endpoint of the model server has an optional useRoleIds parameter. Its default value is true on the server.

ModelClientV2 has an initRepository method that does not accept the useRoleIds parameter, so it sends the request without it. It may cause problem for the user, if they create a repository via the modelClient V2, and then load/read the model assuming it has role names instead of role IDs.

This PR adds the (optional) useRoleIds parameter to that method. The default value is true. 