### PR TITLE
MODELIX-911 Efficient lazy loading (JVM)

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -314,6 +314,10 @@ interface IReplaceableNode : INode {
 @Deprecated("Use .key(INode), .key(IBranch), .key(ITransaction) or .key(ITree)")
 fun IRole.key(): String = RoleAccessContext.getKey(this)
 fun IRole.key(node: INode): String = if (node.usesRoleIds()) getUID() else getSimpleName()
+fun IChildLink.key(node: INode): String? = when (this) {
+    is NullChildLink -> null
+    else -> (this as IRole).key(node)
+}
 fun INode.usesRoleIds(): Boolean = if (this is INodeEx) this.usesRoleIds() else false
 fun INode.getChildren(link: IChildLink): Iterable<INode> = if (this is INodeEx) getChildren(link) else getChildren(link.key(this))
 fun INode.moveChild(role: IChildLink, index: Int, child: INode): Unit = if (this is INodeEx) moveChild(role, index, child) else moveChild(role.key(this), index, child)
@@ -433,3 +437,5 @@ fun INode.getContainmentLink() = if (this is INodeEx) {
 fun INode.getRoot(): INode = parent?.getRoot() ?: this
 fun INode.isInstanceOf(superConcept: IConcept?): Boolean = concept.let { it != null && it.isSubConceptOf(superConcept) }
 fun INode.isInstanceOfSafe(superConcept: IConcept): Boolean = tryGetConcept()?.isSubConceptOf(superConcept) ?: false
+
+fun INode.addNewChild(role: IChildLink, index: Int) = addNewChild(role, index, null as IConceptReference?)

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -21,6 +21,7 @@ val ktorVersion: String by rootProject
 val kotlinxSerializationVersion: String by rootProject
 
 kotlin {
+    jvmToolchain(11)
     jvm()
     js(IR) {
         browser {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client/GarbageFilteringStore.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client/GarbageFilteringStore.kt
@@ -29,6 +29,10 @@ class GarbageFilteringStore(private val store: IKeyValueStore) : IKeyValueStoreW
         return if (pendingEntries.containsKey(key)) pendingEntries[key] else store[key]
     }
 
+    override fun getIfCached(key: String): String? {
+        return if (pendingEntries.containsKey(key)) pendingEntries[key] else store.getIfCached(key)
+    }
+
     override fun getPendingSize(): Int = store.getPendingSize() + pendingEntries.size
 
     override fun getWrapped(): IKeyValueStore = store

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -86,8 +86,4 @@ interface IModelClientV2 {
     suspend fun <R> query(branch: BranchReference, body: (IMonoStep<INode>) -> IMonoStep<R>): R
 
     suspend fun <R> query(repositoryId: RepositoryId, versionHash: String, body: (IMonoStep<INode>) -> IMonoStep<R>): R
-
-    suspend fun getObjects(repository: RepositoryId, keys: Sequence<String>): Map<String, String>
-
-    suspend fun pushObjects(repository: RepositoryId, objects: Sequence<Pair<String, String>>)
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -86,4 +86,8 @@ interface IModelClientV2 {
     suspend fun <R> query(branch: BranchReference, body: (IMonoStep<INode>) -> IMonoStep<R>): R
 
     suspend fun <R> query(repositoryId: RepositoryId, versionHash: String, body: (IMonoStep<INode>) -> IMonoStep<R>): R
+
+    suspend fun getObjects(repository: RepositoryId, keys: Sequence<String>): Map<String, String>
+
+    suspend fun pushObjects(repository: RepositoryId, objects: Sequence<Pair<String, String>>)
 }

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2Internal.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2Internal.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.client2
+
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.server.api.v2.ObjectHash
+import org.modelix.model.server.api.v2.ObjectHashAndSerializedObject
+import org.modelix.model.server.api.v2.SerializedObject
+
+/**
+ * Should only be used by Modelix components.
+ */
+interface IModelClientV2Internal : IModelClientV2 {
+    /**
+     * Required for lazy loading.
+     * Use [IModelClientV2.lazyLoadVersion]
+     */
+    suspend fun getObjects(repository: RepositoryId, keys: Sequence<ObjectHash>): Map<ObjectHash, SerializedObject>
+
+    /**
+     * Required for lazy loading.
+     * Use [IModelClientV2.lazyLoadVersion]
+     */
+    suspend fun pushObjects(repository: RepositoryId, objects: Sequence<ObjectHashAndSerializedObject>)
+}

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -68,6 +68,10 @@ import org.modelix.model.lazy.computeDelta
 import org.modelix.model.operations.OTBranch
 import org.modelix.model.persistent.HashUtil
 import org.modelix.model.persistent.MapBasedStore
+import org.modelix.model.server.api.v2.ImmutableObjectsStream
+import org.modelix.model.server.api.v2.ObjectHash
+import org.modelix.model.server.api.v2.ObjectHashAndSerializedObject
+import org.modelix.model.server.api.v2.SerializedObject
 import org.modelix.model.server.api.v2.VersionDelta
 import org.modelix.model.server.api.v2.VersionDeltaStream
 import org.modelix.model.server.api.v2.VersionDeltaStreamV2
@@ -83,7 +87,7 @@ class ModelClientV2(
     private val httpClient: HttpClient,
     val baseUrl: String,
     private var clientProvidedUserId: String?,
-) : IModelClientV2, Closable {
+) : IModelClientV2, IModelClientV2Internal, Closable {
     private var clientId: Int = 0
     private var idGenerator: IIdGenerator = IdGeneratorDummy()
     private var serverProvidedUserId: String? = null
@@ -265,27 +269,16 @@ class ModelClientV2(
         }
     }
 
-    override suspend fun getObjects(repository: RepositoryId, keys: Sequence<String>): Map<String, String> {
-        val response = httpClient.post {
+    override suspend fun getObjects(repository: RepositoryId, keys: Sequence<ObjectHash>): Map<ObjectHash, SerializedObject> {
+        return httpClient.preparePost {
             url {
                 takeFrom(baseUrl)
                 appendPathSegments("repositories", repository.id, "objects", "getAll")
             }
             setBody(keys.joinToString("\n"))
+        }.execute { response ->
+            ImmutableObjectsStream.decode(response.bodyAsChannel())
         }
-
-        val content = response.bodyAsChannel()
-        val objects = HashMap<String, String>()
-        while (true) {
-            val key = checkNotNull(content.readUTF8Line()) { "Empty line expected at the end of the stream" }
-            if (key == "") {
-                check(content.readUTF8Line() == null) { "Empty line is only allowed at the end of the stream" }
-                break
-            }
-            val value = checkNotNull(content.readUTF8Line()) { "Object missing for hash $key" }
-            objects[key] = value
-        }
-        return objects
     }
 
     override suspend fun push(branch: BranchReference, version: IVersion, baseVersion: IVersion?): IVersion {
@@ -315,7 +308,7 @@ class ModelClientV2(
         }
     }
 
-    override suspend fun pushObjects(repository: RepositoryId, objects: Sequence<Pair<String, String>>) {
+    override suspend fun pushObjects(repository: RepositoryId, objects: Sequence<ObjectHashAndSerializedObject>) {
         LOG.debug { "${clientId.toString(16)}.pushObjects($repository)" }
         objects.chunked(100_000).forEach { unsortedChunk ->
             // Entries are sorted to avoid deadlocks on the server side between transactions.

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/KeyValueStoreCache.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/KeyValueStoreCache.kt
@@ -61,6 +61,10 @@ class KeyValueStoreCache(private val store: IKeyValueStore) : IKeyValueStoreWrap
         return getAll(setOf(key))[key]
     }
 
+    override fun getIfCached(key: String): String? {
+        return cache[key] ?: store.getIfCached(key)
+    }
+
     override fun getAll(keys: Iterable<String>): Map<String, String?> {
         val remainingKeys = toStream(keys).collect(Collectors.toList())
         val result: MutableMap<String, String?> = LinkedHashMap(16, 0.75.toFloat(), false)

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/AsyncStore.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/AsyncStore.kt
@@ -33,6 +33,12 @@ class AsyncStore(private val store: IKeyValueStore) : IKeyValueStoreWrapper {
         return store[key]
     }
 
+    override fun getIfCached(key: String): String? {
+        return synchronized(pendingWrites) {
+            pendingWrites[key]
+        } ?: store.getIfCached(key)
+    }
+
     override fun getWrapped(): IKeyValueStore = store
 
     override fun getPendingSize(): Int = store.getPendingSize() + pendingWrites.size

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
@@ -371,6 +371,10 @@ class RestWebModelClient @JvmOverloads constructor(
         return runBlocking { getA(key) }
     }
 
+    override fun getIfCached(key: String): String? {
+        return null // doesn't contain any caches
+    }
+
     override suspend fun getA(key: String): String? {
         val isHash = HashUtil.isSha256(key)
         if (isHash) {

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client2/LazyLoading.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client2/LazyLoading.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.client2
+
+import kotlinx.coroutines.runBlocking
+import org.modelix.model.IKeyListener
+import org.modelix.model.IKeyValueStore
+import org.modelix.model.IVersion
+import org.modelix.model.lazy.BranchReference
+import org.modelix.model.lazy.CLVersion
+import org.modelix.model.lazy.ObjectStoreCache
+import org.modelix.model.lazy.RepositoryId
+
+fun IModelClientV2.lazyLoadVersion(repositoryId: RepositoryId, versionHash: String, cacheSize: Int = 100_000): IVersion {
+    val store = ObjectStoreCache(ModelClientAsStore(this, repositoryId), cacheSize)
+    return CLVersion.loadFromHash(versionHash, store)
+}
+
+suspend fun IModelClientV2.lazyLoadVersion(branchRef: BranchReference, cacheSize: Int = 100_000): IVersion {
+    return lazyLoadVersion(branchRef.repositoryId, pullHash(branchRef), cacheSize)
+}
+
+class ModelClientAsStore(val client: IModelClientV2, val repositoryId: RepositoryId) : IKeyValueStore {
+    override fun get(key: String): String? {
+        return getAll(listOf(key))[key]
+    }
+
+    override fun put(key: String, value: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAll(keys: Iterable<String>): Map<String, String?> {
+        return runBlocking {
+            client.getObjects(repositoryId, keys.asSequence())
+        }
+    }
+
+    override fun putAll(entries: Map<String, String?>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun prefetch(key: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun listen(key: String, listener: IKeyListener) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeListener(key: String, listener: IKeyListener) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPendingSize(): Int {
+        TODO("Not yet implemented")
+    }
+}

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client2/LazyLoading.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client2/LazyLoading.kt
@@ -22,25 +22,48 @@ import org.modelix.model.IKeyValueStore
 import org.modelix.model.IVersion
 import org.modelix.model.lazy.BranchReference
 import org.modelix.model.lazy.CLVersion
+import org.modelix.model.lazy.CacheConfiguration
 import org.modelix.model.lazy.ObjectStoreCache
 import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.persistent.HashUtil
 
-fun IModelClientV2.lazyLoadVersion(repositoryId: RepositoryId, versionHash: String, cacheSize: Int = 100_000): IVersion {
-    val store = ObjectStoreCache(ModelClientAsStore(this, repositoryId), cacheSize)
+/**
+ * This function loads parts of the model lazily while it is iterated and limits the amount of data that is cached on
+ * the client side.
+ *
+ * IModelClientV2#loadVersion eagerly loads the whole model. For large models this can be slow and requires lots of
+ * memory.
+ * To reduce the relative overhead of requests to the server, the lazy loading algorithm tries to predict which nodes
+ * are required next and fill a "prefetch cache" by using "free capacity" of the regular requests. That means,
+ * the number of requests doesn't change by this prefetching, but small requests are filled to up to their limit with
+ * additional prefetch requests.
+ */
+fun IModelClientV2.lazyLoadVersion(repositoryId: RepositoryId, versionHash: String, config: CacheConfiguration = CacheConfiguration()): IVersion {
+    val store = ObjectStoreCache(ModelClientAsStore(this, repositoryId), config)
     return CLVersion.loadFromHash(versionHash, store)
 }
 
-suspend fun IModelClientV2.lazyLoadVersion(branchRef: BranchReference, cacheSize: Int = 100_000): IVersion {
-    return lazyLoadVersion(branchRef.repositoryId, pullHash(branchRef), cacheSize)
+/**
+ * An overload of [IModelClientV2.lazyLoadVersion] that reads the current version hash of the branch from the server and
+ * then loads that version with lazy loading support.
+ */
+suspend fun IModelClientV2.lazyLoadVersion(branchRef: BranchReference, config: CacheConfiguration = CacheConfiguration()): IVersion {
+    return lazyLoadVersion(branchRef.repositoryId, pullHash(branchRef), config)
 }
 
-class ModelClientAsStore(val client: IModelClientV2, val repositoryId: RepositoryId) : IKeyValueStore {
+private class ModelClientAsStore(client: IModelClientV2, val repositoryId: RepositoryId) : IKeyValueStore {
+    private val client: IModelClientV2Internal = client as IModelClientV2Internal
+
     override fun get(key: String): String? {
         return getAll(listOf(key))[key]
     }
 
+    override fun getIfCached(key: String): String? {
+        return null
+    }
+
     override fun put(key: String, value: String?) {
-        TODO("Not yet implemented")
+        putAll(mapOf(key to value))
     }
 
     override fun getAll(keys: Iterable<String>): Map<String, String?> {
@@ -50,22 +73,30 @@ class ModelClientAsStore(val client: IModelClientV2, val repositoryId: Repositor
     }
 
     override fun putAll(entries: Map<String, String?>) {
-        TODO("Not yet implemented")
+        runBlocking {
+            client.pushObjects(
+                repositoryId,
+                entries.asSequence().map { (key, value) ->
+                    require(HashUtil.isSha256(key) && value != null) { "Only immutable objects are allowed: $key -> $value" }
+                    key to value
+                },
+            )
+        }
     }
 
     override fun prefetch(key: String) {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException()
     }
 
     override fun listen(key: String, listener: IKeyListener) {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException()
     }
 
     override fun removeListener(key: String, listener: IKeyListener) {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException()
     }
 
     override fun getPendingSize(): Int {
-        TODO("Not yet implemented")
+        return 0
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyValueStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyValueStore.kt
@@ -16,12 +16,14 @@
 package org.modelix.model
 
 import org.modelix.model.lazy.BulkQuery
+import org.modelix.model.lazy.BulkQueryConfiguration
 import org.modelix.model.lazy.IBulkQuery
 import org.modelix.model.lazy.IDeserializingKeyValueStore
 
 interface IKeyValueStore {
-    fun newBulkQuery(deserializingCache: IDeserializingKeyValueStore): IBulkQuery = BulkQuery(deserializingCache)
+    fun newBulkQuery(deserializingCache: IDeserializingKeyValueStore, config: BulkQueryConfiguration): IBulkQuery = BulkQuery(deserializingCache, config)
     operator fun get(key: String): String?
+    fun getIfCached(key: String): String?
     suspend fun getA(key: String): String? = get(key)
     fun put(key: String, value: String?)
     fun getAll(keys: Iterable<String>): Map<String, String?>

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLNode.kt
@@ -82,9 +82,9 @@ class CLNode(private val tree: CLTree, private val data: CPNode) {
             getDescendants(bulkQuery, false)
                 .map { descendants -> (sequenceOf(this) + descendants).asIterable() }
         } else {
-            getChildren(bulkQuery).mapBulk { children: Iterable<CLNode> ->
+            getChildren(bulkQuery).flatMap { children: Iterable<CLNode> ->
                 val d: IBulkQuery.Value<Iterable<CLNode>> = bulkQuery
-                    .map(children) { child: CLNode -> child.getDescendants(bulkQuery, true) }
+                    .flatMap(children) { child: CLNode -> child.getDescendants(bulkQuery, true) }
                     .map { it.flatten() }
                 d
             }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
@@ -349,7 +349,7 @@ private fun computeDelta(keyValueStore: IKeyValueStore, versionHash: String, bas
                     override fun visitChangesOnly(): Boolean = false
                     override fun entryAdded(key: Long, value: KVEntryReference<CPNode>) {
                         changedNodeIds += key
-                        if (value != null) bulkQuery.get(value)
+                        if (value != null) bulkQuery.query(value)
                     }
 
                     override fun entryRemoved(key: Long, value: KVEntryReference<CPNode>) {
@@ -362,14 +362,14 @@ private fun computeDelta(keyValueStore: IKeyValueStore, versionHash: String, bas
                         newValue: KVEntryReference<CPNode>,
                     ) {
                         changedNodeIds += key
-                        if (newValue != null) bulkQuery.get(newValue)
+                        if (newValue != null) bulkQuery.query(newValue)
                     }
                 },
                 bulkQuery,
             )
             v1 = v2
         }
-        (bulkQuery as? BulkQuery)?.process()
+        (bulkQuery as? BulkQuery)?.executeQuery()
     }
     val oldEntries: Map<String, String?> = trackAccessedEntries(keyValueStore) { store ->
         if (baseVersionHash == null) return@trackAccessedEntries
@@ -386,12 +386,12 @@ private fun computeDelta(keyValueStore: IKeyValueStore, versionHash: String, bas
 
         val nodesMap = oldTree.nodesMap!!
         changedNodeIds.forEach { changedNodeId ->
-            nodesMap.get(changedNodeId, 0, bulkQuery).onSuccess { nodeRef: KVEntryReference<CPNode>? ->
-                if (nodeRef != null) bulkQuery.get(nodeRef)
+            nodesMap.get(changedNodeId, 0, bulkQuery).onReceive { nodeRef: KVEntryReference<CPNode>? ->
+                if (nodeRef != null) bulkQuery.query(nodeRef)
             }
         }
 
-        (bulkQuery as? BulkQuery)?.process()
+        (bulkQuery as? BulkQuery)?.executeQuery()
     }
     return oldAndNewEntries - oldEntries.keys
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
@@ -18,14 +18,14 @@ package org.modelix.model.lazy
 import org.modelix.model.persistent.IKVValue
 
 interface IBulkQuery {
-    fun process()
-    fun <I, O> map(input_: Iterable<I>, f: (I) -> Value<O>): Value<List<O>>
+    fun executeQuery()
+    fun <I, O> flatMap(input: Iterable<I>, f: (I) -> Value<O>): Value<List<O>>
     fun <T> constant(value: T): Value<T>
-    operator fun <T : IKVValue> get(hash: KVEntryReference<T>): Value<T?>
+    fun <T : IKVValue> query(hash: KVEntryReference<T>): Value<T?>
     interface Value<out T> {
-        fun execute(): T
-        fun <R> mapBulk(handler: (T) -> Value<R>): Value<R>
+        fun executeQuery(): T
+        fun <R> flatMap(handler: (T) -> Value<R>): Value<R>
         fun <R> map(handler: (T) -> R): Value<R>
-        fun onSuccess(handler: (T) -> Unit)
+        fun onReceive(handler: (T) -> Unit)
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
@@ -18,6 +18,7 @@ package org.modelix.model.lazy
 import org.modelix.model.persistent.IKVValue
 
 interface IBulkQuery {
+    fun offerPrefetch(key: IPrefetchGoal)
     fun executeQuery()
     fun <I, O> flatMap(input: Iterable<I>, f: (I) -> Value<O>): Value<List<O>>
     fun <T> constant(value: T): Value<T>
@@ -27,5 +28,23 @@ interface IBulkQuery {
         fun <R> flatMap(handler: (T) -> Value<R>): Value<R>
         fun <R> map(handler: (T) -> R): Value<R>
         fun onReceive(handler: (T) -> Unit)
+    }
+}
+
+open class BulkQueryConfiguration {
+    /**
+     * The maximum number of objects that is requested in one request.
+     */
+    var requestBatchSize: Int = defaultRequestBatchSize
+
+    /**
+     * If a request contains fewer objects than [prefetchBatchSize], it is filled up with additional objects that are
+     * predicted to be required in the future.
+     */
+    var prefetchBatchSize: Int? = defaultPrefetchBatchSize
+
+    companion object {
+        var defaultRequestBatchSize: Int = 5_000
+        var defaultPrefetchBatchSize: Int? = null
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IDeserializingKeyValueStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IDeserializingKeyValueStore.kt
@@ -16,13 +16,18 @@
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore
+import org.modelix.model.persistent.IKVValue
 
 interface IDeserializingKeyValueStore {
     fun newBulkQuery(): IBulkQuery = newBulkQuery(this)
-    fun newBulkQuery(wrapper: IDeserializingKeyValueStore): IBulkQuery = keyValueStore.newBulkQuery(wrapper)
+    fun newBulkQuery(wrapper: IDeserializingKeyValueStore, config: BulkQueryConfiguration? = null): IBulkQuery = keyValueStore.newBulkQuery(wrapper, config ?: BulkQueryConfiguration())
     val keyValueStore: IKeyValueStore
     operator fun <T> get(hash: String, deserializer: (String) -> T): T?
+    fun <T> getIfCached(hash: String, deserializer: (String) -> T, isPrefetch: Boolean): T?
     fun <T> getAll(hash: Iterable<String>, deserializer: (String, String) -> T): Iterable<T>
+    fun <T : IKVValue> getAll(regular: List<IKVEntryReference<T>>, prefetch: List<IKVEntryReference<T>>): Map<String, T?> = throw UnsupportedOperationException()
     fun put(hash: String, deserialized: Any, serialized: String)
+
+    @Deprecated("BulkQuery is now responsible for prefetching")
     fun prefetch(hash: String)
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IndirectObjectStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IndirectObjectStore.kt
@@ -26,6 +26,10 @@ abstract class IndirectObjectStore : IDeserializingKeyValueStore {
         return getStore().get(hash, deserializer)
     }
 
+    override fun <T> getIfCached(hash: String, deserializer: (String) -> T, isPrefetch: Boolean): T? {
+        return getStore().getIfCached(hash, deserializer, isPrefetch)
+    }
+
     override fun <T> getAll(hash: Iterable<String>, deserializer: (String, String) -> T): Iterable<T> {
         return getStore().getAll(hash, deserializer)
     }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonBulkQuery.kt
@@ -27,6 +27,10 @@ class NonBulkQuery(private val store: IDeserializingKeyValueStore) : IBulkQuery 
         return Value(value)
     }
 
+    override fun offerPrefetch(key: IPrefetchGoal) {
+        // Since no real bulk queries are executed, prefetching doesn't provide any benefit.
+    }
+
     override fun <T : IKVValue> query(hash: KVEntryReference<T>): IBulkQuery.Value<T?> {
         return constant(hash.getValue(store))
     }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ObjectStoreCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ObjectStoreCache.kt
@@ -16,18 +16,53 @@
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore
-import org.modelix.model.createLRUMap
+import org.modelix.model.persistent.IKVValue
 import kotlin.jvm.JvmOverloads
+import kotlin.jvm.Synchronized
 
-class ObjectStoreCache @JvmOverloads constructor(override val keyValueStore: IKeyValueStore, cacheSize: Int = 100_000) : IDeserializingKeyValueStore {
-    private val cache: MutableMap<String?, Any> = createLRUMap(cacheSize)
+class CacheConfiguration : BulkQueryConfiguration() {
+    /**
+     * Size of the cache for regularly requested objects.
+     */
+    var cacheSize: Int = defaultCacheSize
 
+    /**
+     * Size of the separate cache for prefetched objects.
+     * Objects are prefetched based on a prediction of what data might be needed next, but they may not be actually
+     * used at all. To avoid eviction of regular objects, there are two separate caches.
+     */
+    var prefetchCacheSize: Int? = defaultPrefetchCacheSize
+    fun getPrefetchCacheSize() = prefetchCacheSize ?: cacheSize
+
+    companion object {
+        var defaultCacheSize: Int = 100_000
+        var defaultPrefetchCacheSize: Int? = null
+    }
+}
+
+class ObjectStoreCache @JvmOverloads constructor(
+    override val keyValueStore: IKeyValueStore,
+    val config: CacheConfiguration = CacheConfiguration(),
+) : IDeserializingKeyValueStore {
+    private val regularCache = LRUCache<String, Any>(config.cacheSize)
+    private val prefetchCache = LRUCache<String, Any>(config.getPrefetchCacheSize())
+    private var bulkQuery: Pair<IBulkQuery, IDeserializingKeyValueStore>? = null
+
+    @Synchronized
+    override fun newBulkQuery(wrapper: IDeserializingKeyValueStore, config: BulkQueryConfiguration?): IBulkQuery {
+        if (bulkQuery?.takeIf { it.second == wrapper } == null) {
+            bulkQuery = keyValueStore.newBulkQuery(wrapper, config ?: this.config).asSynchronized() to wrapper
+        }
+        return bulkQuery!!.first
+    }
+
+    @Synchronized
     override fun <T> getAll(hashes_: Iterable<String>, deserializer: (String, String) -> T): Iterable<T> {
         val hashes = hashes_.toList()
-        val result: MutableMap<String?, T?> = HashMap()
+        val result: MutableMap<String?, T?> = LinkedHashMap()
         val nonCachedHashes: MutableList<String> = ArrayList(hashes.size)
         for (hash in hashes) {
-            val deserialized = cache[hash] as T?
+            val deserialized = (regularCache[hash] ?: prefetchCache[hash]) as T?
             if (deserialized == null) {
                 nonCachedHashes.add(hash)
             } else {
@@ -40,7 +75,7 @@ class ObjectStoreCache @JvmOverloads constructor(override val keyValueStore: IKe
                     result[hash] = null
                 } else {
                     val deserialized: T? = deserializer(hash, serialized)
-                    cache[hash] = deserialized ?: NULL
+                    regularCache[hash] = deserialized ?: NULL
                     result[hash] = deserialized
                 }
             }
@@ -48,23 +83,70 @@ class ObjectStoreCache @JvmOverloads constructor(override val keyValueStore: IKe
         return hashes.map { key: String? -> result[key] as T }.asIterable()
     }
 
+    @Synchronized
+    override fun <T : IKVValue> getAll(
+        regular: List<IKVEntryReference<T>>,
+        prefetch: List<IKVEntryReference<T>>,
+    ): Map<String, T?> {
+        val regularHashes = regular.asSequence().map { it.getHash() }.toSet()
+        val allRequests = regular.asSequence().plus(prefetch.asSequence())
+        val deserializers = allRequests.associate { it.getHash() to it.getDeserializer() }
+        val hashes = allRequests.map { it.getHash() }.toList()
+        val result: MutableMap<String, T?> = LinkedHashMap()
+        val nonCachedHashes: MutableList<String> = ArrayList(hashes.size)
+        for (hash in hashes) {
+            val deserialized = regularCache.get(hash, updatePosition = regularHashes.contains(hash)) ?: prefetchCache.get(hash)
+            if (deserialized == null) {
+                nonCachedHashes.add(hash)
+            } else {
+                result[hash] = if (deserialized === NULL) null else deserialized as T?
+            }
+        }
+        if (nonCachedHashes.isNotEmpty()) {
+            for ((hash, serialized) in keyValueStore.getAll(nonCachedHashes)) {
+                if (serialized == null) {
+                    result[hash] = null
+                } else {
+                    val deserialized = deserializers[hash]!!(serialized)
+                    (if (regularHashes.contains(hash)) regularCache else prefetchCache)[hash] = deserialized ?: NULL
+                    result[hash] = deserialized
+                }
+            }
+        }
+        return result
+    }
+
+    @Synchronized
     override fun <T> get(hash: String, deserializer: (String) -> T): T? {
-        var deserialized = cache[hash] as T?
+        return get(hash, deserializer, false, false)
+    }
+
+    private fun <T> get(hash: String, deserializer: (String) -> T, ifCached: Boolean, isPrefetch: Boolean): T? {
+        var deserialized = (regularCache.get(hash, updatePosition = !isPrefetch) ?: prefetchCache.get(hash)) as T?
         if (deserialized == null) {
-            val serialized = keyValueStore[hash] ?: return null
+            val serialized = (if (ifCached) keyValueStore.getIfCached(hash) else keyValueStore[hash]) ?: return null
             deserialized = deserializer(serialized)
-            cache[hash] = deserialized ?: NULL
+            (if (isPrefetch) prefetchCache else regularCache)[hash] = deserialized ?: NULL
         }
         return if (deserialized === NULL) null else deserialized
     }
 
-    override fun put(hash: String, deserialized: Any, serialized: String) {
-        keyValueStore.put(hash, serialized)
-        cache[hash] = deserialized ?: NULL
+    @Synchronized
+    override fun <T> getIfCached(hash: String, deserializer: (String) -> T, isPrefetch: Boolean): T? {
+        return get(hash, deserializer, true, isPrefetch)
     }
 
+    @Synchronized
+    override fun put(hash: String, deserialized: Any, serialized: String) {
+        keyValueStore.put(hash, serialized)
+        regularCache[hash] = deserialized ?: NULL
+        prefetchCache.remove(hash)
+    }
+
+    @Synchronized
     fun clearCache() {
-        cache.clear()
+        regularCache.clear()
+        prefetchCache.clear()
     }
 
     override fun prefetch(hash: String) {
@@ -73,5 +155,32 @@ class ObjectStoreCache @JvmOverloads constructor(override val keyValueStore: IKe
 
     companion object {
         private val NULL = Any()
+    }
+}
+
+private class LRUCache<K : Any, V>(val maxSize: Int) {
+    private val map: MutableMap<K, V> = LinkedHashMap()
+
+    operator fun set(key: K, value: V) {
+        map.remove(key)
+        map[key] = value
+        while (map.size > maxSize) map.remove(map.iterator().next().key)
+    }
+
+    operator fun get(key: K, updatePosition: Boolean = true): V? {
+        return map[key]?.also { value ->
+            if (updatePosition) {
+                map.remove(key)
+                map[key] = value as V
+            }
+        }
+    }
+
+    fun remove(key: K) {
+        map.remove(key)
+    }
+
+    fun clear() {
+        map.clear()
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ObjectStoreCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ObjectStoreCache.kt
@@ -17,9 +17,10 @@ package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore
 import org.modelix.model.createLRUMap
+import kotlin.jvm.JvmOverloads
 
-class ObjectStoreCache(override val keyValueStore: IKeyValueStore) : IDeserializingKeyValueStore {
-    private val cache: MutableMap<String?, Any> = createLRUMap(100000)
+class ObjectStoreCache @JvmOverloads constructor(override val keyValueStore: IKeyValueStore, cacheSize: Int = 100_000) : IDeserializingKeyValueStore {
+    private val cache: MutableMap<String?, Any> = createLRUMap(cacheSize)
 
     override fun <T> getAll(hashes_: Iterable<String>, deserializer: (String, String) -> T): Iterable<T> {
         val hashes = hashes_.toList()

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
@@ -22,6 +22,7 @@ import org.modelix.model.api.ITree
  * This guarantees that after a prefetch there are no more request required.
  * Not thread safe.
  */
+@Deprecated("BulkQuery is now responsible for prefetching")
 class PrefetchCache(private val store: IDeserializingKeyValueStore) : IDeserializingKeyValueStore {
     init {
         if (store is ContextIndirectCache) throw IllegalArgumentException()
@@ -33,13 +34,21 @@ class PrefetchCache(private val store: IDeserializingKeyValueStore) : IDeseriali
     override val keyValueStore: IKeyValueStore = store.keyValueStore
 
     override fun <T> get(hash: String, deserializer: (String) -> T): T? {
+        return get(hash, deserializer, false, false)
+    }
+
+    private fun <T> get(hash: String, deserializer: (String) -> T, ifCached: Boolean, isPrefetch: Boolean): T? {
         return if (entries.containsKey(hash)) {
             entries[hash] as T?
         } else {
-            val value = store.get(hash, deserializer)
+            val value = if (ifCached) store.getIfCached(hash, deserializer, isPrefetch) else store.get(hash, deserializer)
             entries[hash] = value
             value
         }
+    }
+
+    override fun <T> getIfCached(hash: String, deserializer: (String) -> T, isPrefetch: Boolean): T? {
+        return get(hash, deserializer, true, isPrefetch)
     }
 
     override fun <T> getAll(hashes: Iterable<String>, deserializer: (String, String) -> T): Iterable<T> {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/SynchronizedBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/SynchronizedBulkQuery.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.lazy
+
+import org.modelix.model.api.runSynchronized
+import org.modelix.model.persistent.IKVValue
+import kotlin.jvm.Synchronized
+
+class SynchronizedBulkQuery(val nonThreadSafeQuery: IBulkQuery) : IBulkQuery {
+    @Synchronized
+    override fun <T> constant(value: T): IBulkQuery.Value<T> {
+        return nonThreadSafeQuery.constant(value)
+    }
+
+    @Synchronized
+    override fun offerPrefetch(key: IPrefetchGoal) {
+        return nonThreadSafeQuery.offerPrefetch(key)
+    }
+
+    @Synchronized
+    override fun executeQuery() {
+        return nonThreadSafeQuery.executeQuery()
+    }
+
+    @Synchronized
+    override fun <I, O> flatMap(input: Iterable<I>, f: (I) -> IBulkQuery.Value<O>): IBulkQuery.Value<List<O>> {
+        return nonThreadSafeQuery.flatMap(input, f)
+    }
+
+    @Synchronized
+    override fun <T : IKVValue> query(hash: KVEntryReference<T>): IBulkQuery.Value<T?> {
+        return nonThreadSafeQuery.query(hash)
+    }
+
+    inner class Value<E>(val nonThreadSafeValue: IBulkQuery.Value<E>) : IBulkQuery.Value<E> {
+        override fun executeQuery(): E {
+            runSynchronized(this@SynchronizedBulkQuery) {
+                return nonThreadSafeValue.executeQuery()
+            }
+        }
+
+        override fun <R> flatMap(handler: (E) -> IBulkQuery.Value<R>): IBulkQuery.Value<R> {
+            runSynchronized(this@SynchronizedBulkQuery) {
+                return nonThreadSafeValue.flatMap(handler)
+            }
+        }
+
+        override fun <R> map(handler: (E) -> R): IBulkQuery.Value<R> {
+            runSynchronized(this@SynchronizedBulkQuery) {
+                return nonThreadSafeValue.map(handler)
+            }
+        }
+
+        override fun onReceive(handler: (E) -> Unit) {
+            runSynchronized(this@SynchronizedBulkQuery) {
+                return nonThreadSafeValue.onReceive(handler)
+            }
+        }
+    }
+}
+
+fun IBulkQuery.asSynchronized(): IBulkQuery {
+    return if (this is SynchronizedBulkQuery) this else SynchronizedBulkQuery(this)
+}

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtLeaf.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtLeaf.kt
@@ -90,7 +90,7 @@ class CPHamtLeaf(
                     visitor.entryRemoved(k, v)
                 }
             }
-            oldNode!!.visitEntries(bulkQuery, bp).onSuccess {
+            oldNode!!.visitEntries(bulkQuery, bp).onReceive {
                 val oldValue = oldValue
                 if (oldValue == null) {
                     visitor.entryAdded(key, value)

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
@@ -41,11 +41,11 @@ abstract class CPHamtNode : IKVValue {
 
     fun get(key: Long, store: IDeserializingKeyValueStore): KVEntryReference<CPNode>? {
         val bulkQuery: IBulkQuery = NonBulkQuery(store)
-        return get(key, 0, bulkQuery).execute()
+        return get(key, 0, bulkQuery).executeQuery()
     }
 
     fun getAll(keys: Iterable<Long>, bulkQuery: IBulkQuery): IBulkQuery.Value<List<KVEntryReference<CPNode>?>> {
-        return bulkQuery.map(keys) { key: Long -> get(key, 0, bulkQuery) }
+        return bulkQuery.flatMap(keys) { key: Long -> get(key, 0, bulkQuery) }
     }
 
     fun put(key: Long, value: KVEntryReference<CPNode>?, store: IDeserializingKeyValueStore): CPHamtNode? {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtSingle.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtSingle.kt
@@ -109,7 +109,7 @@ class CPHamtSingle(
     }
 
     fun getChild(bulkQuery: IBulkQuery): IBulkQuery.Value<CPHamtNode> {
-        return bulkQuery.query(child).map { childData -> childData!! }
+        return bulkQuery.query(child).map { childData -> checkNotNull(childData) { "Entry not found: $child" } }
     }
 
     override fun visitEntries(bulkQuery: IBulkQuery, visitor: (Long, KVEntryReference<CPNode>) -> Unit): IBulkQuery.Value<Unit> {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
@@ -19,6 +19,7 @@ import org.modelix.kotlin.utils.createMemoryEfficientMap
 import org.modelix.kotlin.utils.toSynchronizedMap
 import org.modelix.model.IKeyListener
 import org.modelix.model.IKeyValueStore
+import org.modelix.model.lazy.BulkQueryConfiguration
 import org.modelix.model.lazy.IBulkQuery
 import org.modelix.model.lazy.IDeserializingKeyValueStore
 import org.modelix.model.lazy.NonBulkQuery
@@ -32,7 +33,11 @@ open class MapBasedStore : IKeyValueStore {
         return map[key]
     }
 
-    override fun newBulkQuery(deserializingCache: IDeserializingKeyValueStore): IBulkQuery {
+    override fun getIfCached(key: String): String? {
+        return get(key)
+    }
+
+    override fun newBulkQuery(deserializingCache: IDeserializingKeyValueStore, config: BulkQueryConfiguration): IBulkQuery {
         // This implementation doesn't benefit from bulk queries. The NonBulkQuery has a lower performance overhead.
         return NonBulkQuery(deserializingCache)
     }

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/ImmutableObjectsStream.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/ImmutableObjectsStream.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server.api.v2
+
+import io.ktor.http.ContentType
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readUTF8Line
+
+object ImmutableObjectsStream {
+    val CONTENT_TYPE = ContentType("application", "x-modelix-immutable-objects")
+
+    fun encode(out: Appendable, objects: Map<String, String>) {
+        encode(out, objects.asSequence())
+    }
+
+    fun encode(out: Appendable, objects: Sequence<Map.Entry<String, String>>) {
+        objects.forEach {
+            out.append(it.key)
+            out.append("\n")
+            out.append(it.value)
+            out.append("\n")
+        }
+        // additional empty line indicates end of stream and can be used to verify completeness of data transfer
+        out.append("\n")
+    }
+
+    suspend fun decode(input: ByteReadChannel): Map<String, String> {
+        val objects = LinkedHashMap<String, String>()
+        while (true) {
+            val key = checkNotNull(input.readUTF8Line()) { "Empty line expected at the end of the stream" }
+            if (key == "") {
+                check(input.readUTF8Line() == null) { "Empty line is only allowed at the end of the stream" }
+                break
+            }
+            val value = checkNotNull(input.readUTF8Line()) { "Object missing for hash $key" }
+            objects[key] = value
+        }
+        return objects
+    }
+}
+
+typealias ObjectHash = String
+typealias SerializedObject = String
+typealias ObjectHashAndSerializedObject = Pair<ObjectHash, SerializedObject>

--- a/model-server-openapi/specifications/model-server-v2.yaml
+++ b/model-server-openapi/specifications/model-server-v2.yaml
@@ -75,6 +75,18 @@ paths:
           $ref: '#/components/responses/200json'
         default:
           $ref: '#/components/responses/GeneralError'
+  /repositories/{repository}/objects/getAll:
+    post:
+      operationId: postRepositoryObjectsGetAll
+      parameters:
+        - name: repository
+          in: "path"
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: '#/components/responses/200'
   /repositories/{repository}/branches:
     get:
       operationId: getRepositoryBranches

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -54,6 +54,7 @@ import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.operations.OTBranch
 import org.modelix.model.persistent.HashUtil
+import org.modelix.model.server.api.v2.ImmutableObjectsStream
 import org.modelix.model.server.api.v2.VersionDelta
 import org.modelix.model.server.api.v2.VersionDeltaStream
 import org.modelix.model.server.api.v2.VersionDeltaStreamV2
@@ -202,19 +203,16 @@ class ModelReplicationServer(
     }
 
     override suspend fun PipelineContext<Unit, ApplicationCall>.postRepositoryObjectsGetAll(repository: String) {
-        val keys = call.receiveStream().bufferedReader().use { reader ->
-            reader.lineSequence().toHashSet()
-        }
-        val objects = withContext(Dispatchers.IO) { modelClient.store.getAll(keys) }
-        call.respondTextWriter(contentType = VersionDeltaStream.CONTENT_TYPE) {
-            objects.forEach {
-                append(it.key)
-                append("\n")
-                append(it.value)
-                append("\n")
+        runWithRepository(repository) {
+            val keys = call.receiveStream().bufferedReader().use { reader ->
+                reader.lineSequence().toHashSet()
             }
-            // additional empty line indicates end of stream and can be used to verify completeness of data transfer
-            append("\n")
+            val objects = withContext(Dispatchers.IO) { modelClient.store.getAll(keys) }.checkValuesNotNull {
+                "Object not found: $it"
+            }
+            call.respondTextWriter(contentType = ImmutableObjectsStream.CONTENT_TYPE) {
+                ImmutableObjectsStream.encode(this, objects)
+            }
         }
     }
 
@@ -433,3 +431,10 @@ private fun Flow<String>.withSeparator(separator: String) = flow {
         emit(it)
     }
 }
+
+@Suppress("UNCHECKED_CAST")
+private fun <K, V> Map<K, V?>.checkValuesNotNull(lazyMessage: (K) -> Any): Map<K, V> = apply {
+    for (entry in this) {
+        checkNotNull(entry.value) { lazyMessage(entry.key) }
+    }
+} as Map<K, V>

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -372,7 +372,7 @@ class RepositoriesManager(val client: LocalModelClient) : IRepositoriesManager {
                 fun emitObjects(entry: KVEntryReference<*>) {
                     if (seenHashes.contains(entry.getHash())) return
                     seenHashes.add(entry.getHash())
-                    bulkQuery.get(entry).onSuccess {
+                    bulkQuery.query(entry).onReceive {
                         val value = checkNotNull(it) { "No value received for ${entry.getHash()}" }
                         // Use `send` instead of `trySend`,
                         // because `trySend` fails if the channel capacity is full.
@@ -391,7 +391,7 @@ class RepositoriesManager(val client: LocalModelClient) : IRepositoriesManager {
                 }
                 emitObjects(KVEntryReference(versionHash, CPVersion.DESERIALIZER))
                 LOG.debug("Starting to bulk query all objects.")
-                bulkQuery.process()
+                bulkQuery.executeQuery()
             }
         }
         val checkedHashObjectFlow = hashObjectFlow.checkObjectHashes()

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/LocalModelClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/LocalModelClient.kt
@@ -33,6 +33,10 @@ class LocalModelClient(val store: IStoreClient) : IModelClient {
         return store[key]
     }
 
+    override fun getIfCached(key: String): String? {
+        return null
+    }
+
     override fun put(key: String, value: String?) {
         store.put(key, value)
     }

--- a/model-server/src/test/kotlin/org/modelix/model/server/LazyLoadingTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/LazyLoadingTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.server
+
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import org.modelix.authorization.installAuthentication
+import org.modelix.model.api.INode
+import org.modelix.model.api.NullChildLink
+import org.modelix.model.api.TreePointer
+import org.modelix.model.api.addNewChild
+import org.modelix.model.api.getDescendants
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client2.lazyLoadVersion
+import org.modelix.model.client2.runWrite
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.persistent.MapBasedStore
+import org.modelix.model.server.api.v2.ObjectHash
+import org.modelix.model.server.api.v2.SerializedObject
+import org.modelix.model.server.handlers.IdsApiImpl
+import org.modelix.model.server.handlers.ModelReplicationServer
+import org.modelix.model.server.store.InMemoryStoreClient
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class LazyLoadingTest {
+
+    private lateinit var statistics: StoreClientWithStatistics
+
+    private fun runTest(block: suspend ApplicationTestBuilder.() -> Unit) = testApplication {
+        application {
+            installAuthentication(unitTestMode = true)
+            installDefaultServerPlugins()
+            statistics = StoreClientWithStatistics(InMemoryStoreClient())
+            ModelReplicationServer(statistics).init(this)
+            IdsApiImpl(statistics).init(this)
+        }
+        block()
+    }
+
+    private fun assertRequestCount(atLeast: Long, body: () -> Unit): Long {
+        val requestCount = measureRequests(body)
+        assertTrue(requestCount >= atLeast, "At least $atLeast requests expected, but was $requestCount")
+        return requestCount
+    }
+
+    private fun measureRequests(body: () -> Unit): Long {
+        val before = statistics.getTotalRequests()
+        body()
+        val after = statistics.getTotalRequests()
+        val requestCount = after - before
+        println("Requests: $requestCount")
+        return requestCount
+    }
+
+    @Test
+    fun `model data is loaded on demand`() = runTest {
+        // After optimizing the lazy loading to send less (but bigger) requests, this test might fail.
+        // Just update the model size, cache size and expected request count to fix it.
+
+        val client = createModelClient()
+        val branchRef = RepositoryId("my-repo").getBranchReference()
+        client.runWrite(branchRef) {
+            fun createNodes(parentNode: INode, numberOfNodes: Int) {
+                if (numberOfNodes == 0) return
+                if (numberOfNodes == 1) {
+                    parentNode.addNewChild(NullChildLink, 0)
+                    return
+                }
+                val subtreeSize1 = numberOfNodes / 2
+                val subtreeSize2 = numberOfNodes - subtreeSize1
+                createNodes(parentNode.addNewChild(NullChildLink, 0), subtreeSize1 - 1)
+                createNodes(parentNode.addNewChild(NullChildLink, 1), subtreeSize2 - 1)
+            }
+
+            createNodes(it, 5_000)
+        }
+        val version = client.lazyLoadVersion(branchRef, cacheSize = 500)
+
+        val rootNode = TreePointer(version.getTree()).getRootNode()
+
+        // Traverse to the first leaf node. This should load some data, but not the whole model.
+        assertRequestCount(1) {
+            generateSequence(rootNode) { it.allChildren.firstOrNull() }.count()
+        }
+
+        // Traverse the whole model.
+        val requestCountFirstTraversal = assertRequestCount(10) {
+            rootNode.getDescendants(true).count()
+        }
+
+        // Traverse the whole model a second time. The model doesn't fit into the cache and some parts are already
+        // unloaded during the first traversal. The unloaded parts need to be requested again.
+        // But the navigation to the first leaf is like a warmup of the cache for the whole model traversal.
+        // The previous traversal can benefit from that, but the next one cannot and is expected to need more requests.
+        assertRequestCount(requestCountFirstTraversal + 1) {
+            rootNode.getDescendants(true).count()
+        }
+    }
+}

--- a/model-server/src/test/kotlin/org/modelix/model/server/LazyLoadingTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/LazyLoadingTest.kt
@@ -21,12 +21,20 @@ import io.ktor.server.testing.testApplication
 import org.modelix.authorization.installAuthentication
 import org.modelix.model.api.INode
 import org.modelix.model.api.NullChildLink
+import org.modelix.model.api.PBranch
 import org.modelix.model.api.TreePointer
 import org.modelix.model.api.addNewChild
 import org.modelix.model.api.getDescendants
 import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.client2.IModelClientV2
+import org.modelix.model.client2.IModelClientV2Internal
 import org.modelix.model.client2.lazyLoadVersion
-import org.modelix.model.client2.runWrite
+import org.modelix.model.lazy.BranchReference
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.CLVersion
+import org.modelix.model.lazy.CacheConfiguration
+import org.modelix.model.lazy.ObjectStoreCache
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.persistent.MapBasedStore
 import org.modelix.model.server.api.v2.ObjectHash
@@ -34,81 +42,203 @@ import org.modelix.model.server.api.v2.SerializedObject
 import org.modelix.model.server.handlers.IdsApiImpl
 import org.modelix.model.server.handlers.ModelReplicationServer
 import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.model.server.store.forContextRepository
+import kotlin.random.Random
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
+@Suppress("ktlint:standard:annotation", "ktlint:standard:spacing-between-declarations-with-annotations")
 class LazyLoadingTest {
-
-    private lateinit var statistics: StoreClientWithStatistics
+    private var totalRequests: Long = 0
+    private var totalObjects: Long = 0
+    private var maxRequestSize: Int = 0
 
     private fun runTest(block: suspend ApplicationTestBuilder.() -> Unit) = testApplication {
         application {
             installAuthentication(unitTestMode = true)
             installDefaultServerPlugins()
-            statistics = StoreClientWithStatistics(InMemoryStoreClient())
-            ModelReplicationServer(statistics).init(this)
-            IdsApiImpl(statistics).init(this)
+            val store = InMemoryStoreClient().forContextRepository()
+            ModelReplicationServer(store).init(this)
+            IdsApiImpl(store).init(this)
         }
         block()
     }
 
-    private fun assertRequestCount(atLeast: Long, body: () -> Unit): Long {
-        val requestCount = measureRequests(body)
-        assertTrue(requestCount >= atLeast, "At least $atLeast requests expected, but was $requestCount")
-        return requestCount
-    }
-
-    private fun measureRequests(body: () -> Unit): Long {
-        val before = statistics.getTotalRequests()
+    private fun measureRequests(body: () -> Unit): Pair<Int, Int> {
+        maxRequestSize = 0
+        val before = totalRequests
+        val objectsBefore = totalObjects
         body()
-        val after = statistics.getTotalRequests()
-        val requestCount = after - before
+        val after = totalRequests
+        val objectsAfter = totalObjects
+        val requestCount = (after - before).toInt()
+        val requestedObjectsCount = (objectsAfter - objectsBefore).toInt()
         println("Requests: $requestCount")
-        return requestCount
+        println("Requested Objects: $requestedObjectsCount")
+        println("Max Request Size: $maxRequestSize")
+        return Pair(requestCount, requestedObjectsCount)
     }
 
-    @Test
-    fun `model data is loaded on demand`() = runTest {
-        // After optimizing the lazy loading to send less (but bigger) requests, this test might fail.
-        // Just update the model size, cache size and expected request count to fix it.
+    @Test fun compare_batch_size_10() = compare_batch_size(10, 22, 201, 187, 137, 1996, 1863)
+    @Test fun compare_batch_size_25() = compare_batch_size(25, 22, 103, 82, 285, 2575, 2050)
+    @Test fun compare_batch_size_50() = compare_batch_size(50, 22, 87, 72, 510, 4350, 3600)
+    @Test fun compare_batch_size_100() = compare_batch_size(100, 22, 60, 49, 905, 6000, 4900)
+    @Test fun compare_batch_size_200() = compare_batch_size(200, 22, 142, 160, 1605, 28400, 32000)
+    @Test fun compare_batch_size_400() = compare_batch_size(400, 22, 743, 138, 2627, 216698, 18369)
+    @Test fun compare_batch_size_800() = compare_batch_size(800, 22, 717, 185, 2700, 205909, 23806)
+    @Test fun compare_batch_size_1600() = compare_batch_size(1600, 22, 717, 185, 2700, 205909, 23806)
+    fun compare_batch_size(batchSize: Int, vararg expected: Int) = runLazyLoadingTest(DepthFirstSearchPattern, 1_000, 1_000, batchSize, batchSize, *expected)
 
-        val client = createModelClient()
+    @Test fun compare_cache_size_100() = compare_cache_size(100, 22, 861, 891, 510, 43050, 44550)
+    @Test fun compare_cache_size_200() = compare_cache_size(200, 22, 539, 490, 510, 26950, 24500)
+    @Test fun compare_cache_size_400() = compare_cache_size(400, 22, 217, 139, 510, 10850, 6950)
+    @Test fun compare_cache_size_800() = compare_cache_size(800, 22, 57, 73, 510, 2850, 3650)
+    @Test fun compare_cache_size_1600() = compare_cache_size(1600, 22, 44, 41, 510, 2200, 2050)
+    @Test fun compare_cache_size_3200() = compare_cache_size(3200, 22, 34, 0, 510, 1561, 0)
+    private fun compare_cache_size(cacheSize: Int, vararg expected: Int) = runLazyLoadingTest(DepthFirstSearchPattern, 1_000, cacheSize, 50, 50, *expected)
+
+    @Test fun compare_prefetch_size_0() = compare_prefetch_size(0, 22, 2055, 2073, 22, 2055, 2073)
+    @Test fun compare_prefetch_size_2() = compare_prefetch_size(2, 22, 1043, 1046, 38, 2086, 2092)
+    @Test fun compare_prefetch_size_4() = compare_prefetch_size(3, 22, 693, 708, 53, 2079, 2124)
+    @Test fun compare_prefetch_size_10() = compare_prefetch_size(10, 22, 288, 333, 137, 2880, 3330)
+    @Test fun compare_prefetch_size_25() = compare_prefetch_size(25, 22, 339, 296, 285, 8475, 7400)
+    @Test fun compare_prefetch_size_50() = compare_prefetch_size(50, 22, 539, 490, 510, 26950, 24500)
+    private fun compare_prefetch_size(prefetchSize: Int, vararg expected: Int) = runLazyLoadingTest(DepthFirstSearchPattern, 1_000, 200, 50, prefetchSize, *expected)
+
+    @Test fun compare_access_pattern_dfs() = compare_access_pattern(DepthFirstSearchPattern, 22, 123, 133, 510, 6150, 6650)
+    @Test fun compare_access_pattern_pdfs() = compare_access_pattern(ParallelDepthFirstSearchPattern, 22, 325, 174, 510, 16250, 8700)
+    @Test fun compare_access_pattern_bfs() = compare_access_pattern(BreathFirstSearchPattern, 22, 320, 278, 510, 16000, 13900)
+    @Test fun compare_access_pattern_random() = compare_access_pattern(RandomPattern(1_000, Random(987)), 22, 194, 154, 510, 5388, 3878)
+    private fun compare_access_pattern(pattern: AccessPattern, vararg expected: Int) = runLazyLoadingTest(pattern, 1_000, 500, 50, 50, *expected)
+
+    private fun runLazyLoadingTest(accessPattern: AccessPattern, numberOfNodes: Int, cacheSize: Int, batchSize: Int, prefetchSize: Int, vararg expectedRequests: Int) {
+        runLazyLoadingTest(accessPattern, numberOfNodes, cacheSize, batchSize, prefetchSize, expectedRequests.toList())
+    }
+
+    private fun runLazyLoadingTest(accessPattern: AccessPattern, numberOfNodes: Int, cacheSize: Int, batchSize: Int, prefetchSize: Int, expectedRequests: List<Int>) = runTest {
+        val client = ModelClientWithStatistics(createModelClient())
         val branchRef = RepositoryId("my-repo").getBranchReference()
-        client.runWrite(branchRef) {
-            fun createNodes(parentNode: INode, numberOfNodes: Int) {
-                if (numberOfNodes == 0) return
-                if (numberOfNodes == 1) {
-                    parentNode.addNewChild(NullChildLink, 0)
-                    return
-                }
-                val subtreeSize1 = numberOfNodes / 2
-                val subtreeSize2 = numberOfNodes - subtreeSize1
-                createNodes(parentNode.addNewChild(NullChildLink, 0), subtreeSize1 - 1)
-                createNodes(parentNode.addNewChild(NullChildLink, 1), subtreeSize2 - 1)
-            }
+        createModel(client, branchRef, numberOfNodes)
 
-            createNodes(it, 5_000)
-        }
-        val version = client.lazyLoadVersion(branchRef, cacheSize = 500)
-
+        val version = client.lazyLoadVersion(
+            branchRef,
+            CacheConfiguration().also {
+                it.cacheSize = cacheSize
+                it.requestBatchSize = batchSize
+                it.prefetchBatchSize = prefetchSize
+            },
+        )
         val rootNode = TreePointer(version.getTree()).getRootNode()
 
+        val actualRequestCount = ArrayList<Int>()
+
         // Traverse to the first leaf node. This should load some data, but not the whole model.
-        assertRequestCount(1) {
+        actualRequestCount += measureRequests {
             generateSequence(rootNode) { it.allChildren.firstOrNull() }.count()
-        }
+        }.toList()
 
         // Traverse the whole model.
-        val requestCountFirstTraversal = assertRequestCount(10) {
-            rootNode.getDescendants(true).count()
-        }
+        actualRequestCount += measureRequests {
+            accessPattern.runPattern(rootNode)
+        }.toList()
 
         // Traverse the whole model a second time. The model doesn't fit into the cache and some parts are already
         // unloaded during the first traversal. The unloaded parts need to be requested again.
         // But the navigation to the first leaf is like a warmup of the cache for the whole model traversal.
         // The previous traversal can benefit from that, but the next one cannot and is expected to need more requests.
-        assertRequestCount(requestCountFirstTraversal + 1) {
-            rootNode.getDescendants(true).count()
+        actualRequestCount += measureRequests {
+            accessPattern.runPattern(rootNode)
+        }.toList()
+
+        // move request count before object count
+        val reorderedActualRequests = actualRequestCount.withIndex().sortedBy { it.index % 2 }.map { it.value }
+
+        assertEquals(expectedRequests, reorderedActualRequests)
+    }
+
+    /**
+     * Creates a CLTree with fixed ID and a version without timestamp.
+     * This ensures that exactly the same data is created for each test run which avoids non-deterministic test results.
+     */
+    private suspend fun createModel(client: IModelClientV2, branchRef: BranchReference, numberOfNodes: Int) {
+        val initialTree = CLTree.builder(ObjectStoreCache(MapBasedStore())).repositoryId(RepositoryId("xxx")).build()
+        val branch = PBranch(initialTree, IdGenerator.newInstance(100))
+        val rootNode = branch.getRootNode()
+        branch.runWrite {
+            fun createNodes(parentNode: INode, numberOfNodes: Int, rand: Random) {
+                if (numberOfNodes == 0) return
+                if (numberOfNodes == 1) {
+                    parentNode.addNewChild(NullChildLink, 0)
+                    return
+                }
+                val numChildren = rand.nextInt(2, 10.coerceAtMost(numberOfNodes) + 1)
+                val subtreeSize = numberOfNodes / numChildren
+                val remainder = numberOfNodes % numChildren
+                for (i in 1..numChildren) {
+                    createNodes(parentNode.addNewChild(NullChildLink, 0), subtreeSize - 1 + (if (i == 1) remainder else 0), rand)
+                }
+            }
+
+            createNodes(rootNode, numberOfNodes, Random(10001))
+        }
+        val initialVersion = CLVersion.createRegularVersion(
+            id = 1000L,
+            time = null,
+            author = null,
+            tree = branch.computeReadT { it.tree } as CLTree,
+            baseVersion = null,
+            operations = emptyArray(),
+        )
+        client.push(branchRef, initialVersion, null)
+    }
+
+    private inner class ModelClientWithStatistics(val client: IModelClientV2Internal) : IModelClientV2Internal by client {
+        override suspend fun getObjects(repository: RepositoryId, keys: Sequence<String>): Map<ObjectHash, SerializedObject> {
+            totalRequests++
+            totalObjects += keys.count()
+            return client.getObjects(repository, keys)
+        }
+    }
+}
+
+private interface AccessPattern {
+    fun runPattern(rootNode: INode)
+}
+
+private object DepthFirstSearchPattern : AccessPattern {
+    override fun runPattern(rootNode: INode) {
+        rootNode.getDescendants(true).count()
+    }
+}
+
+private object ParallelDepthFirstSearchPattern : AccessPattern {
+    override fun runPattern(rootNode: INode) {
+        rootNode.getDescendants(true).zip(rootNode.getDescendants(true).drop(100)).count()
+    }
+}
+
+private object BreathFirstSearchPattern : AccessPattern {
+    override fun runPattern(rootNode: INode) {
+        val queue = ArrayDeque<INode>()
+        queue.addLast(rootNode)
+        while (queue.isNotEmpty()) {
+            queue.addAll(queue.removeFirst().allChildren)
+        }
+    }
+}
+
+private class RandomPattern(val maxAccessOperations: Int, val random: kotlin.random.Random) : AccessPattern {
+    override fun runPattern(rootNode: INode) {
+        var currentNode = rootNode
+
+        for (i in 1..maxAccessOperations) {
+            val nextNode = when (random.nextInt(2)) {
+                0 -> currentNode.parent ?: currentNode.allChildren.toList().random(random)
+                else -> currentNode.allChildren.toList().let {
+                    if (it.isEmpty()) currentNode.parent!! else it.random(random)
+                }
+            }
+            currentNode = nextNode
         }
     }
 }


### PR DESCRIPTION
This is an attempt to support lazy loading of model data in the ModelClientV2. Something similar exists in the old client implementation. This new feature should help migrating away from the old client.

Compared to the lazy loading implementation in the V1 client, this new implementation tries to reduce the number of requests (and by that the relative overhead) by predicting what data is needed next and prefetching it. The algorithm for this prefetching might need some fine tuning in the future to further improve the performance, but the tests show that it's already way better than without prefetching.

The new feature is only available on the JVM because requests are executed blocking, which is not allowed in a single threaded JS environment. For JS, solutions similar to the one I prototyped in #396 are required.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
