### PR TITLE
fix(model-server): fix `IgniteStoreClient.getAll` not returning values for existing entries

### DIFF
--- a/model-server-test/src/test/kotlin/IgnitePostgresTest.kt
+++ b/model-server-test/src/test/kotlin/IgnitePostgresTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class IgnitePostgresTest {
     lateinit var store: IgniteStoreClient
@@ -33,6 +34,18 @@ class IgnitePostgresTest {
     @AfterTest
     fun afterTest() {
         store.dispose()
+    }
+
+    @Test
+    fun `can get values for multiple keys when Ignite has not cached the keys yet`() {
+        // The actual keys are irrelevant for this test.
+        // A fresh client will have no keys cached.
+        val keys = listOf("zK4Y2*xIEWlYlQGJL2Va4Z0ESgpWgnSQcOmnPeqt34PA", "zxgZN*oLuudxsu42ppSEGnCib8LkrSvauQk2B6T7AW6o")
+            .map { ObjectInRepository.global(it) }
+
+        val values = store.getAll(keys)
+
+        assertTrue(values.filterNotNull().isNotEmpty())
     }
 
     @Test

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/ObjectInRepository.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/ObjectInRepository.kt
@@ -16,6 +16,14 @@
 
 package org.modelix.model.server.store
 
+/**
+ * A composed key used in the key-value stores to persist model data.
+ * The key is composed of a [key] and an optional [repositoryId].
+ * The [repositoryId] is set when an entry is scoped to the repository.
+ *
+ * This class is directly used with the Ignite cache (see [IgniteStoreClient]).
+ * Therefore, the order of fields must be consistent with the configuration of `JdbcType` in ignite.xml.
+ */
 data class ObjectInRepository(private val repositoryId: String, val key: String) : Comparable<ObjectInRepository> {
     fun isGlobal() = repositoryId == ""
     fun getRepositoryId() = repositoryId.takeIf { it != "" }

--- a/model-server/src/main/resources/org/modelix/model/server/store/ignite.xml
+++ b/model-server/src/main/resources/org/modelix/model/server/store/ignite.xml
@@ -77,15 +77,8 @@
                                         <property name="keyType" value="org.modelix.model.server.store.ObjectInRepository"/>
                                         <property name="valueType" value="java.lang.String"/>
                                         <property name="keyFields">
+                                            <!-- Order of fields must be consistent with ObjectInRepository -->
                                             <list>
-                                                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
-                                                    <property name="databaseFieldType">
-                                                        <util:constant static-field="java.sql.Types.VARCHAR"/>
-                                                    </property>
-                                                    <property name="databaseFieldName" value="key"/>
-                                                    <property name="javaFieldType" value="java.lang.String"/>
-                                                    <property name="javaFieldName" value="key"/>
-                                                </bean>
                                                 <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
                                                     <property name="databaseFieldType">
                                                         <util:constant static-field="java.sql.Types.VARCHAR"/>
@@ -93,6 +86,14 @@
                                                     <property name="databaseFieldName" value="repository"/>
                                                     <property name="javaFieldType" value="java.lang.String"/>
                                                     <property name="javaFieldName" value="repositoryId"/>
+                                                </bean>
+                                                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                                                    <property name="databaseFieldType">
+                                                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                                                    </property>
+                                                    <property name="databaseFieldName" value="key"/>
+                                                    <property name="javaFieldType" value="java.lang.String"/>
+                                                    <property name="javaFieldName" value="key"/>
                                                 </bean>
                                             </list>
                                         </property>


### PR DESCRIPTION
With different field order in Ignite configuration and key type `ObjectInRepository`, `IgniteCache.getAll` returned null values because keys were serialized differently. 
This only happened when `IgniteCache.getAll` was called with more than one key and the keys were not loaded into the cache. 
The serialization of a key return from a read-through operation was different from the serialization of a key created from an `ObjectInRepository` object.

## To be verified by reviewers

* [x] Relevant public API members have been documented
* [x] Documentation related to this PR is complete
  * [x] Boundary conditions are documented
  * [x] Exceptions are documented
  * [x] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [x] Code is readable
* [x] New features and fixed bugs are covered by tests
