### PR TITLE
build(deps): bump typescript from 4.9.5 to 5.4.2 in /ts-model-api

### DIFF
--- a/ts-model-api/.eslintrc.json
+++ b/ts-model-api/.eslintrc.json
@@ -17,5 +17,7 @@
         "@typescript-eslint"
     ],
     "rules": {
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/no-import-type-side-effects":"error"
     }
 }

--- a/ts-model-api/package-lock.json
+++ b/ts-model-api/package-lock.json
@@ -16,7 +16,7 @@
         "eslint": "^8.56.0",
         "husky": "^9.0.11",
         "shx": "^0.3.2",
-        "typescript": "^4.7.4"
+        "typescript": "^5.4.5"
       },
       "engines": {
         "node": ">= 10.18.1",
@@ -1717,16 +1717,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/ts-model-api/package.json
+++ b/ts-model-api/package.json
@@ -41,7 +41,7 @@
     "eslint": "^8.56.0",
     "husky": "^9.0.11",
     "shx": "^0.3.2",
-    "typescript": "^4.7.4"
+    "typescript": "^5.4.5"
   },
   "eslint-comment": "// IMPORTANT: keep ESLint version and versions of plugins in sync with the versions in .pre-commit-config.yaml",
   "engines": {

--- a/ts-model-api/src/LanguageRegistry.ts
+++ b/ts-model-api/src/LanguageRegistry.ts
@@ -1,6 +1,7 @@
 import type {GeneratedLanguage} from "./GeneratedLanguage.js";
 import type {INodeJS} from "./INodeJS.js";
-import {ITypedNode, TypedNode, UnknownTypedNode} from "./TypedNode.js";
+import type {ITypedNode} from "./TypedNode.js";
+import { TypedNode, UnknownTypedNode} from "./TypedNode.js";
 import type {IConceptJS} from "./IConceptJS.js";
 
 export class LanguageRegistry {

--- a/ts-model-api/tsconfig.json
+++ b/ts-model-api/tsconfig.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error",
     "inlineSources": true,
     "listEmittedFiles": true,
     "newLine": "LF",


### PR DESCRIPTION
Upgrade TypeScript to 5.4.2

Replace the deprecated compiler option `importsNotUsedAsValues` with linting rules.

The new suggested compiler option `verbatimModuleSyntax` does not allow writing ESM syntax in files that will emit as CommonJS.
That is what we do.
To not rewrite the code but disable the things disabled by `importsNotUsedAsValues` the new linting rules were added.

An in-depth explanation can be found at https://johnnyreilly.com/typescript-5-importsnotusedasvalues-error-eslint-consistent-type-imports

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
