### PR TITLE
fix(model-api): fix typo that breaks backwards compatibility

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -215,7 +215,7 @@ interface INode {
      * @return the serialized reference of the source node, if this one was created during an import
      */
     fun getOriginalReference(): String? = getPropertyValue(IProperty.fromName(NodeData.ID_PROPERTY_KEY))
-        ?: getPropertyValue(IProperty.fromName("#mpsNodeID#")) // for backwards compatibility
+        ?: getPropertyValue(IProperty.fromName("#mpsNodeId#")) // for backwards compatibility
 
     // <editor-fold desc="non-string based API">
     fun usesRoleIds(): Boolean = false


### PR DESCRIPTION
There was a typo in https://github.com/modelix/modelix.core/commit/61ebd1df6cb819404aa12d8838265b004de61614, that flew under the radar and made it into production.

However, I just realized that due to this typo all of my Node IDs are wrong in the modelix sync plugin. Therefore this PR fixes the typo.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
