### PR TITLE
build(model-server): raise timeout for Ignite test

### DIFF
--- a/model-server/src/test/kotlin/org/modelix/model/server/IgniteStoreClientParallelTransactionsTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/IgniteStoreClientParallelTransactionsTest.kt
@@ -110,7 +110,7 @@ class ThreadBlocker {
 
 fun sleepUntil(
     checkIntervalMilliseconds: Long = 10,
-    timeoutMilliseconds: Long = 1000,
+    timeoutMilliseconds: Long = 5_000,
     condition: () -> Boolean,
 ) {
     check(checkIntervalMilliseconds > 0) {


### PR DESCRIPTION
`IgniteStoreClientParallelTransactionsTest` kept failing in CI with a timeout.

See https://github.com/modelix/modelix.core/actions/runs/9447363808/job/26021069325?pr=800#step:6:3371

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
