### PR TITLE
docs: fix typo in model-api-gen

### DIFF
--- a/docs/global/modules/core/pages/reference/component-model-api-gen.adoc
+++ b/docs/global/modules/core/pages/reference/component-model-api-gen.adoc
@@ -10,7 +10,7 @@ https://api.modelix.org/3.12.0/model-api-gen-gradle/index.html[API doc^] | https
 
 
 The *Model API Generator* (`model-api-gen`) is a Kotlin component which generates a domain-specific model API.
-Currently, the generator supports either Kotlin and TypeScipt as target languages.
+Currently, the generator supports either Kotlin and TypeScript as target languages.
 As a source for the generated API, `model-api-gen` consumes a given metamodel specified by JSON files.
 
 The Model API Generator is mainly used in the corresponding gradle plugin xref:core:reference/component-model-api-gen-gradle.adoc[model-api-gen-gradle].


### PR DESCRIPTION
Stumbled on a typo in the docs that bothered me waaaaaay too much.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
