### PR TITLE
perf(model-server): inefficient SQL query was generated for getAll

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/store/PostgresDialect.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/PostgresDialect.kt
@@ -53,4 +53,47 @@ class PostgresDialect : BasicJdbcDialect() {
             updPart,
         )
     }
+
+    override fun loadQuery(
+        fullTblName: String,
+        keyCols: Collection<String>,
+        cols: Iterable<String>,
+        keyCnt: Int,
+    ): String {
+        assert(!keyCols.isEmpty())
+        if (keyCols.size == 1 || keyCnt == 1) return super.loadQuery(fullTblName, keyCols, cols, keyCnt)
+
+        /*
+            The default implementation generates a query that looks like this:
+
+                SELECT "repository","key","value"
+                    FROM "modelix"."model"
+                    WHERE
+                        (repository=? AND key=?) OR
+                        (repository=? AND key=?)
+
+            Postgres creates a query plan that still uses the index, but is not optimal.
+
+            For single column primary keys a query using the IN operator would be generated and that leads to a more
+            efficient query plan.
+
+            For the following query a plan is created that is comparable in performance to the IN operator.
+
+                SELECT repository, key, value
+                FROM modelix.model
+                JOIN (
+                    VALUES
+                        (?, ?),
+                        (?, ?)
+                ) as t (k0,k1)
+                ON k0 = repository AND k1 = key
+         */
+
+        val valuesList = (1..keyCnt).joinToString(", ") { "(?, ?)" }
+        val subSelectColumns = keyCols.withIndex().joinToString(",") { "k${it.index}" }
+        val joinCondition = keyCols.withIndex().joinToString(" AND ") { "k${it.index} = ${it.value}" }
+        val joinPart = """JOIN (VALUES $valuesList) as t ($subSelectColumns) ON $joinCondition"""
+        val result = """SELECT ${cols.joinToString(", ")} FROM $fullTblName $joinPart"""
+        return result
+    }
 }


### PR DESCRIPTION
After adding the repository column to the primary key, a different SQL query was generated that is less efficient. Adjusted the PostgresDialect to generate a query with comparable performance to the one for single column primary keys.

