### PR TITLE
feat(model-api-gen): allow generating typescript barrels

### DIFF
--- a/docs/global/modules/core/pages/reference/component-model-api-gen-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-model-api-gen-gradle.adoc
@@ -101,6 +101,11 @@ Inside of the `metamodel` block the following settings can be configured.
 |File
 |Target TypeScript directory of the generator
 
+|`includeTypescriptBarrels`
+|Boolean
+|Add barrelling to the generated index file for convenience.
+Only enable when you are completely sure there are no naming conflicts among the concepts of all generated languages.
+
 |`registrationHelperName`
 |String
 |Fully qualified name of the generated language registration helper

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/GenerateMetaModelSources.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/GenerateMetaModelSources.kt
@@ -40,6 +40,9 @@ abstract class GenerateMetaModelSources @Inject constructor(of: ObjectFactory) :
     val typescriptOutputDir: DirectoryProperty = of.directoryProperty()
 
     @get:Input
+    val includeTypescriptBarrels: Property<Boolean> = of.property(Boolean::class.java)
+
+    @get:Input
     val includedNamespaces: ListProperty<String> = of.listProperty(String::class.java)
 
     @get:Input
@@ -114,7 +117,7 @@ abstract class GenerateMetaModelSources @Inject constructor(of: ObjectFactory) :
 
         val typescriptOutputDir = this.typescriptOutputDir.orNull?.asFile
         if (typescriptOutputDir != null) {
-            val tsGenerator = TypescriptMMGenerator(typescriptOutputDir.toPath(), nameConfig.get())
+            val tsGenerator = TypescriptMMGenerator(typescriptOutputDir.toPath(), nameConfig.get(), includeTypescriptBarrels.get())
             tsGenerator.generate(processedLanguages)
         }
     }

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
@@ -76,6 +76,7 @@ class MetaModelGradlePlugin @Inject constructor(val project: Project) : Plugin<P
                 settings.kotlinDir?.let { task.kotlinOutputDir.set(it) }
                 settings.modelqlKotlinDir?.let { task.modelqlKotlinOutputDir.set(it) }
                 settings.typescriptDir?.let { task.typescriptOutputDir.set(it) }
+                task.includeTypescriptBarrels.set(settings.includeTypescriptBarrels)
                 task.includedNamespaces.addAll(settings.includedLanguageNamespaces)
                 task.includedLanguages.addAll(settings.includedLanguages)
                 task.includedConcepts.addAll(settings.includedConcepts)

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradleSettings.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradleSettings.kt
@@ -29,6 +29,7 @@ open class MetaModelGradleSettings {
             field = value
         }
     var typescriptDir: File? = null
+    var includeTypescriptBarrels: Boolean = false
     var registrationHelperName: String? = null
     var conceptPropertiesInterfaceName: String? = null
     val taskDependencies: MutableList<Any> = ArrayList()

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
@@ -8,7 +8,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.writeText
 
-class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = NameConfig()) {
+class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = NameConfig(), private val includeTsBarrels: Boolean = false) {
 
     private fun LanguageData.packageDir(): Path {
         val packageName = name
@@ -33,7 +33,7 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                 .resolve(language.generatedClassName().simpleName + ".ts")
                 .fixFormatAndWriteText(generateLanguage(language))
 
-            generateRegistry(languages)
+            generateIndexTs(languages)
         }
     }
 
@@ -54,7 +54,7 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
 
     private fun Path.fixFormatAndWriteText(text: String) = writeText(fixFormat(text))
 
-    private fun generateRegistry(languages: ProcessedLanguageSet) {
+    private fun generateIndexTs(languages: ProcessedLanguageSet) {
         outputDir.resolve("index.ts").fixFormatAndWriteText(
             """
             import { LanguageRegistry } from "@modelix/ts-model-api";
@@ -68,6 +68,13 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
             """
             }}
             }
+            ${if (!includeTsBarrels) {
+                ""
+            } else {
+                languages.getLanguages().joinToString("\n") {
+                    """export * from "./${it.simpleClassName()}";"""
+                }
+            }}
             """,
         )
     }


### PR DESCRIPTION
This merge request adds a new optional property to the model api gen called `includeTypescriptBarrels `. When enabled it adds barrelling to the generated `index.ts` file as a convience feature. Example

```typescript
// index.ts (generated)
import { LanguageRegistry } from "@modelix/ts-model-api";
import { L_org_modelix_entities } from "./L_org_modelix_entities";
export function registerLanguages() {
  LanguageRegistry.INSTANCE.register(L_org_modelix_entities.INSTANCE);
}
export * from "./L_org_modelix_entities";

// test.ts
import {N_Entity} from './index.ts'

// instead of 
import {N_Entity} from './L_org_modelix_entities.ts'
```



## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
