### PR TITLE
feat(bulk-model-sync): workaround removed and outdated resolveInfo after import into MPS

### DIFF
--- a/bulk-model-sync-lib/mps-test/build.gradle.kts
+++ b/bulk-model-sync-lib/mps-test/build.gradle.kts
@@ -30,8 +30,10 @@ plugins {
 
 dependencies {
     testImplementation(project(":bulk-model-sync-lib"))
+    testImplementation(project(":bulk-model-sync-mps"))
     testImplementation(project(":mps-model-adapters"))
     testImplementation(libs.kotlin.serialization.json)
+    testImplementation(libs.xmlunit.matchers)
 }
 
 intellij {

--- a/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ResolveInfoUpdateTest.kt
+++ b/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ResolveInfoUpdateTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.sync.bulk.lib.test
+import kotlinx.serialization.json.Json
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.modelix.model.api.BuiltinLanguages
+import org.modelix.model.api.INode
+import org.modelix.model.data.ModelData
+import org.modelix.model.mpsadapters.MPSRepositoryAsNode
+import org.modelix.model.sync.bulk.ExistingAndExpectedNode
+import org.modelix.model.sync.bulk.asExported
+import org.modelix.mps.model.sync.bulk.MPSBulkSynchronizer
+import org.xmlunit.builder.Input
+import org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath
+
+class ResolveInfoUpdateTest : MPSTestBase() {
+
+    fun `test resolve info is updated with name from INamedConcept (testdata ResolveInfoUpdateTest)`() {
+        val exportedModuleJson = exportModuleJson()
+        val modifiedModuleJson = exportedModuleJson.replace("referencedNodeA", "referencedNodeANewName")
+        val modifiedModule: ModelData = Json.decodeFromString(modifiedModuleJson)
+
+        val getModulesToImport = { sequenceOf(ExistingAndExpectedNode(getTestModule(), modifiedModule)) }
+        MPSBulkSynchronizer.importModelsIntoRepository(mpsProject.repository, getTestModule(), false, getModulesToImport)
+
+        assertReferenceHasResolveInfo("3vHUMVfa0RY", "referencedNodeANewName")
+    }
+
+    fun `test resolve info is updated with resolveInfo from IResolveInfo (testdata ResolveInfoUpdateTest)`() {
+        val exportedModuleJson = exportModuleJson()
+        val modifiedModuleJson = exportedModuleJson.replace("referencedNodeC", "referencedNodeCNewName")
+        val modifiedModule: ModelData = Json.decodeFromString(modifiedModuleJson)
+
+        val getModulesToImport = { sequenceOf(ExistingAndExpectedNode(getTestModule(), modifiedModule)) }
+        MPSBulkSynchronizer.importModelsIntoRepository(mpsProject.repository, getTestModule(), false, getModulesToImport)
+
+        assertReferenceHasResolveInfo("3vHUMVfa0RZ", "referencedNodeCNewName")
+    }
+
+    private fun assertReferenceHasResolveInfo(referencedNode: String, expectedResolveInfo: String) {
+        val testModelPath = projectDir.resolve("solutions/NewSolution/models/NewSolution.a_model.mps")
+        val testModelXml = Input.fromPath(testModelPath).build()
+        assertThat(testModelXml, hasXPath("model/node/node/ref[@node='$referencedNode']/@resolve", equalTo(expectedResolveInfo)))
+    }
+
+    private fun getTestModule(): INode {
+        var result: INode? = null
+        mpsProject.repository.modelAccess.runReadAction {
+            val repository = mpsProject.repository
+            val repositoryNode = MPSRepositoryAsNode(repository)
+            result = repositoryNode.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Repository.modules)
+                .single { it.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name) == "NewSolution" }
+        }
+        return checkNotNull(result)
+    }
+
+    private fun exportModuleJson(): String {
+        var result: String? = null
+        mpsProject.repository.modelAccess.runReadAction {
+            val module = getTestModule()
+            val modelData = ModelData(root = module.asExported())
+            result = modelData.toJson()
+        }
+        return checkNotNull(result)
+    }
+}

--- a/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/.mps/.gitignore
+++ b/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/.mps/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/.mps/migration.xml
+++ b/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/.mps/migration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="project.baseline.version" value="211" />
+  </component>
+</project>

--- a/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/.mps/modules.xml
+++ b/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/.mps/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules>
+      <modulePath path="$PROJECT_DIR$/solutions/NewSolution/NewSolution.msd" folder="" />
+    </projectModules>
+  </component>
+</project>

--- a/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/solutions/NewSolution/NewSolution.msd
+++ b/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/solutions/NewSolution/NewSolution.msd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="NewSolution" uuid="471b29cb-3253-460b-9743-1e1443884a6b" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <languageVersions />
+  <dependencyVersions>
+    <module reference="471b29cb-3253-460b-9743-1e1443884a6b(NewSolution)" version="0" />
+  </dependencyVersions>
+</solution>

--- a/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/solutions/NewSolution/models/NewSolution.a_model.mps
+++ b/bulk-model-sync-lib/mps-test/testdata/ResolveInfoUpdateTest/solutions/NewSolution/models/NewSolution.a_model.mps
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:cd78e6ac-0e34-490a-9b49-e5643f948d6d(NewSolution.a_model)">
+ <persistence version="9" />
+  <languages>
+    <use id="e2840528-cf1a-4707-9968-32c55e0e5b6c" name="NewLanguage" version="0" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1196978630214" name="jetbrains.mps.lang.core.structure.IResolveInfo" flags="ng" index="2Lv6Xg">
+        <property id="1196978656277" name="resolveInfo" index="2Lvdk3" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="e2840528-cf1a-4707-9968-32c55e0e5b6c" name="NewLanguage">
+      <concept id="4030135827843012252" name="NewLanguage.structure.RootNode" flags="ng" index="3SLrQM">
+        <child id="4030135827843012255" name="referencedNode" index="3SLrQL" />
+        <child id="4030135827843012253" name="referencingNodes" index="3SLrQN" />
+      </concept>
+      <concept id="4030135827842946229" name="NewLanguage.structure.ReferencingNode" flags="ng" index="3SMFYr">
+        <reference id="4030135827843004992" name="aReference" index="3SLt5I" />
+      </concept>
+      <concept id="4030135827842946260" name="NewLanguage.structure.ReferencedNodeWithResolveInfo" flags="ng" index="3SMFZU" />
+      <concept id="4030135827842946256" name="NewLanguage.structure.ReferencedNodeWithName" flags="ng" index="3SMFZY" />
+    </language>
+  </registry>
+  <node concept="3SLrQM" id="3vHUMVfa5C_">
+    <node concept="3SMFYr" id="3vHUMVfa0RX" role="3SLrQN" >
+      <ref role="3SLt5I" node="3vHUMVfa0RY" resolve="referencedNodeA" />
+    </node>
+    <node concept="3SMFZY" id="3vHUMVfa0RY" role="3SLrQL">
+      <property role="TrG5h" value="referencedNodeA" />
+    </node>
+    <node concept="3SMFZU" id="3vHUMVfa0RZ" role="3SLrQL">
+      <property role="2Lvdk3" value="referencedNodeC" />
+    </node>
+    <node concept="3SMFYr" id="3vHUMVfa4pM" role="3SLrQN">
+      <ref role="3SLt5I" node="3vHUMVfa0RZ" resolve="referencedNodeC" />
+    </node>
+  </node>
+</model>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ openapi = "7.6.0"
 micrometer = "1.13.1"
 dokka = "1.9.20"
 detekt = "1.23.6"
+xmlunit = "2.10.0"
 
 [libraries]
 
@@ -104,7 +105,8 @@ postgresql = { group = "org.postgresql", name = "postgresql", version = "42.7.3"
 jcommander = { group = "com.beust", name = "jcommander", version = "1.82" }
 cucumber-java = { group = "io.cucumber", name = "cucumber-java", version = "7.18.0" }
 junit = { group = "junit", name = "junit", version = "4.13.2" }
-xmlunit-core = { group = "org.xmlunit", name = "xmlunit-core", version = "2.10.0"}
+xmlunit-core = { group = "org.xmlunit", name = "xmlunit-core", version.ref="xmlunit"}
+xmlunit-matchers = { group = "org.xmlunit", name = "xmlunit-matchers", version.ref="xmlunit"}
 jsoup = { group = "org.jsoup", name = "jsoup", version = "1.17.2" }
 
 apache-cxf-sse = { group = "org.apache.cxf", name = "cxf-rt-rs-sse", version.ref = "apacheCxf" }


### PR DESCRIPTION
In projects, loading all libraries and plugins can take significant time. This workaround enables to sync projects better that do not want to load all libraries and plugins. With this workaround, the `name` or `resolveInfo` property of a target is used as the `resoleInfo` property on a reference even if the concept of the target could not be fully loaded.

## To be verified by reviewers

* [x] Relevant public API members have been documented
* [x] Documentation related to this PR is complete
  * [x] Boundary conditions are documented
  * [x] Exceptions are documented
  * [x] Nullability is documented if used
* [x] Touched existing code has been extended with documentation if missing
* [x] Code is readable
* [x] New features and fixed bugs are covered by tests
