### PR TITLE
feat(bulk-model-sync): add a configuration option to load plugins

### DIFF
--- a/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-bulk-model-sync-gradle.adoc
@@ -112,6 +112,16 @@ mpsBuild {
 |`mpsDebugPort`
 |Int
 |If set, the headless MPS will suspend on startup and wait for a remote debugger on the specified port.
+|`mpsPlugin`
+| PluginSpec
+| Add a plugin to be loaded when running MPS.
+`jetbrains.mps.core`, `jetbrains.mps.testing`, `jetbrains.mps.ide.make` are always loaded.
+
+All other plugins, even bundled ones, must be configured explicitly.
+In general cases, the sync does not rely on concepts (and in turn on languages and plugins) of the synced nodes.
+
+Loading other plugins might become necessary when they provide custom persistence and in other, yet unknown cases.
+First, try if the sync works for your project without adding plugins.
 |===
 
 === ServerSource/-Target configuration


### PR DESCRIPTION
In simple cases, `MPSBulkSynchronizer` does not rely on concepts (and in turn of languages and plugins) of the synced nodes to be loaded. 
Plugins might become necessary when they provide custom persistence and in other, yet unknown cases.

Depends on https://github.com/modelix/modelix.mps-build-tools/pull/52. 
After it is merged and published `libs.versions.toml` needs to be updated. But the API in bulk-sync-plugin can be reviewed anyway.

I did not add tests.
The test would be complicated, long-running (starts MPS) and only test rather simple logic.
When someone deems test necessary I would add tests, that run one of the sync tasks and assert through the logs, that the specified plugins are loaded.
If someone has a better idea/different opinion on the tests here, please let me know.


## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
