### PR TITLE
feat(ts-model-api): add method to easily wrap untyped node

### DIFF
--- a/model-api-gen-gradle-test/typescript-generation/src/node.test.ts
+++ b/model-api-gen-gradle-test/typescript-generation/src/node.test.ts
@@ -1,3 +1,4 @@
+import { isOfConcept_PropertyAttribute } from "../build/typescript_src/L_jetbrains_mps_lang_core";
 import { useFakeNode } from "./test-helpers";
 
 test("typed nodes can be removed", () => {
@@ -6,4 +7,18 @@ test("typed nodes can be removed", () => {
 
   typedNode.remove();
   expect(rootNode.getChildren("children1")).toHaveLength(0);
+});
+
+test("untyped nodes can be easily wrapped", () => {
+  const { untypedNode } = useFakeNode();
+  const typedNode = untypedNode.wrap();
+  expect(isOfConcept_PropertyAttribute(typedNode)).toBeTruthy();
+});
+
+test("typed nodes can be easily unwrapped", () => {
+  const { typedNode } = useFakeNode();
+  const untypedNode = typedNode.unwrap();
+  expect(untypedNode.getConceptUID()).toEqual(
+    "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/3364660638048049750"
+  );
 });

--- a/model-api-gen-gradle-test/typescript-generation/src/test-helpers.ts
+++ b/model-api-gen-gradle-test/typescript-generation/src/test-helpers.ts
@@ -1,5 +1,4 @@
 import { org } from "@modelix/model-client";
-import { LanguageRegistry } from "@modelix/ts-model-api";
 import { registerLanguages } from "../build/typescript_src";
 
 const DEFAULT_NODE_DATA = {
@@ -32,7 +31,7 @@ export function useFakeRootNode(nodeData: object = DEFAULT_NODE_DATA) {
   }
 
   function getTypedNode(role?: string) {
-    return LanguageRegistry.INSTANCE.wrapNode(getUntypedNode(role));
+    return getUntypedNode(role).wrap();
   }
 
   return {

--- a/model-api/src/jsMain/kotlin/org/modelix/model/api/NodeAdapterJS.kt
+++ b/model-api/src/jsMain/kotlin/org/modelix/model/api/NodeAdapterJS.kt
@@ -3,6 +3,7 @@ package org.modelix.model.api
 import IConceptJS
 import INodeJS
 import INodeReferenceJS
+import ITypedNode
 import LanguageRegistry
 import TypedNode
 
@@ -95,6 +96,10 @@ class NodeAdapterJS(val node: INode) : INodeJS_ {
 
     override fun remove() {
         node.remove()
+    }
+
+    override fun wrap(): ITypedNode {
+        return LanguageRegistry.INSTANCE.wrapNode(this)
     }
 
     override fun getReferenceRoles(): Array<String> {

--- a/ts-model-api/src/INodeJS.ts
+++ b/ts-model-api/src/INodeJS.ts
@@ -1,4 +1,5 @@
 import type {IConceptJS} from "./IConceptJS.js";
+import type {ITypedNode} from "./TypedNode.js";
 
 export interface INodeJS {
   getConcept(): IConceptJS | undefined
@@ -9,6 +10,7 @@ export interface INodeJS {
   getParent(): INodeJS | undefined
 
   remove(): void
+  wrap(): ITypedNode;
 
   getChildren(role: string | undefined): Array<INodeJS>
   getAllChildren(): Array<INodeJS>

--- a/vue-model-api/src/internal/ReactiveINodeJS.ts
+++ b/vue-model-api/src/internal/ReactiveINodeJS.ts
@@ -1,4 +1,4 @@
-import { IConceptJS, INodeJS } from "@modelix/ts-model-api";
+import { IConceptJS, INodeJS, ITypedNode } from "@modelix/ts-model-api";
 import { customRef, markRaw } from "vue";
 import { Cache } from "./Cache";
 
@@ -86,6 +86,10 @@ export class ReactiveINodeJS implements INodeJS {
 
   remove(): void {
     this.unreactiveNode.remove();
+  }
+
+  wrap(): ITypedNode {
+    return this.unreactiveNode.wrap();
   }
 
   getChildren(role: string | undefined): INodeJS[] {


### PR DESCRIPTION
This PR introduces a convenience `wrap` method to the `INodeJS` interface to easily transition from the untyped API to the typed API as a counterpart to the `unwrap` method of the `ITypedNode` interface.

Example usage: 

```typescript
const untypedNode: INodeJS = foo();
const typedNode = untypedNode.wrap();

// instead of
import { LanguageRegistry } from "@modelix/ts-model-api";
const untypedNode: INodeJS = foo();
const typedNode = LanguageRegistry.INSTANCE.wrapNode(untypedNode);
```

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
