### PR TITLE
fix(ts-model-api): new single childs can have correct concept

### DIFF
--- a/model-api-gen-gradle-test/typescript-generation/package-lock.json
+++ b/model-api-gen-gradle-test/typescript-generation/package-lock.json
@@ -33,9 +33,9 @@
       "version": "1.3.2-kernelf.4.dirty-SNAPSHOT",
       "license": "Apache 2.0",
       "devDependencies": {
-        "@types/node": "^20.14.2",
-        "@typescript-eslint/eslint-plugin": "^7.13.0",
-        "@typescript-eslint/parser": "^7.13.0",
+        "@types/node": "^20.14.6",
+        "@typescript-eslint/eslint-plugin": "^7.13.1",
+        "@typescript-eslint/parser": "^7.13.1",
         "dukat": "^0.5.8-rc.4",
         "eslint": "^8.56.0",
         "husky": "^9.0.11",
@@ -1130,7 +1130,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-twpNFJrYmo9mCnXZPww7ma0h25MjDJ6Vi5NGpyhLbnqW1QtzJgcT4AL1H1Bz1BNm5Vo5yjmF5eLt3XMPbrKTkw==",
+      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",
@@ -5587,7 +5587,7 @@
     },
     "@modelix/model-client": {
       "version": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-twpNFJrYmo9mCnXZPww7ma0h25MjDJ6Vi5NGpyhLbnqW1QtzJgcT4AL1H1Bz1BNm5Vo5yjmF5eLt3XMPbrKTkw==",
+      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
       "requires": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",
@@ -5604,9 +5604,9 @@
     "@modelix/ts-model-api": {
       "version": "file:../../ts-model-api",
       "requires": {
-        "@types/node": "^20.14.2",
-        "@typescript-eslint/eslint-plugin": "^7.13.0",
-        "@typescript-eslint/parser": "^7.13.0",
+        "@types/node": "^20.14.6",
+        "@typescript-eslint/eslint-plugin": "^7.13.1",
+        "@typescript-eslint/parser": "^7.13.1",
         "dukat": "^0.5.8-rc.4",
         "eslint": "^8.56.0",
         "husky": "^9.0.11",

--- a/model-api-gen-gradle-test/typescript-generation/src/ChildrenAccessor.test.ts
+++ b/model-api-gen-gradle-test/typescript-generation/src/ChildrenAccessor.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Note: Ideally, this test should be placed in the ts-model-api module.
+ * However, due to the complexity of testing the code without the context
+ * of the generated languages, we will conduct the test here for now.
+ */
+
+import {
+  BaseCommentAttribute,
+  C_BaseCommentAttribute,
+  C_BaseConcept,
+  C_TypeAnnotated,
+  isOfConcept_BaseConcept,
+  isOfConcept_TypeAnnotated,
+} from "../build/typescript_src/L_jetbrains_mps_lang_core";
+import { useFakeNode } from "./test-helpers";
+
+const NODE_DATA_WITH_SINGLE_CHILD_ACCESSOR = {
+  root: {
+    children: [
+      {
+        concept: C_BaseCommentAttribute.getUID(),
+        role: "withSingleChildAccessor",
+        properties: {
+          name: "aName",
+        },
+      },
+    ],
+  },
+};
+
+test("new element can be added to SingleChildAccessor when provided the correct base concept", () => {
+  const { typedNode } = useFakeNode<BaseCommentAttribute>(
+    "withSingleChildAccessor",
+    NODE_DATA_WITH_SINGLE_CHILD_ACCESSOR
+  );
+  const childNode = typedNode.commentedNode.setNew(C_BaseConcept);
+  expect(isOfConcept_BaseConcept(childNode)).toBeTruthy();
+});
+
+test("new element can be added to SingleChildAccessor when provided a sub concept", () => {
+  const { typedNode } = useFakeNode<BaseCommentAttribute>(
+    "withSingleChildAccessor",
+    NODE_DATA_WITH_SINGLE_CHILD_ACCESSOR
+  );
+  const childNode = typedNode.commentedNode.setNew(C_TypeAnnotated);
+  expect(isOfConcept_TypeAnnotated(childNode)).toBeTruthy();
+  expect(isOfConcept_BaseConcept(childNode)).toBeTruthy();
+});

--- a/model-api-gen-gradle-test/typescript-generation/src/test-helpers.ts
+++ b/model-api-gen-gradle-test/typescript-generation/src/test-helpers.ts
@@ -1,5 +1,5 @@
 import { org } from "@modelix/model-client";
-import { LanguageRegistry } from "@modelix/ts-model-api";
+import { ITypedNode, LanguageRegistry } from "@modelix/ts-model-api";
 import { registerLanguages } from "../build/typescript_src";
 
 const DEFAULT_NODE_DATA = {
@@ -31,8 +31,8 @@ export function useFakeRootNode(nodeData: object = DEFAULT_NODE_DATA) {
     return rootNode.getChildren(role)[0];
   }
 
-  function getTypedNode(role?: string) {
-    return LanguageRegistry.INSTANCE.wrapNode(getUntypedNode(role));
+  function getTypedNode<T extends ITypedNode>(role?: string) {
+    return LanguageRegistry.INSTANCE.wrapNode(getUntypedNode(role)) as T;
   }
 
   return {
@@ -42,11 +42,14 @@ export function useFakeRootNode(nodeData: object = DEFAULT_NODE_DATA) {
   };
 }
 
-export function useFakeNode(role?: string, nodeData?: object) {
+export function useFakeNode<T extends ITypedNode>(
+  role?: string,
+  nodeData?: object
+) {
   const { getUntypedNode, getTypedNode, rootNode } = useFakeRootNode(nodeData);
   return {
     rootNode,
     untypedNode: getUntypedNode(role),
-    typedNode: getTypedNode(role),
+    typedNode: getTypedNode<T>(role),
   };
 }

--- a/model-api-gen-gradle-test/vue-integration/package-lock.json
+++ b/model-api-gen-gradle-test/vue-integration/package-lock.json
@@ -24,9 +24,9 @@
       "version": "1.3.2-kernelf.4.dirty-SNAPSHOT",
       "license": "Apache 2.0",
       "devDependencies": {
-        "@types/node": "^20.14.2",
-        "@typescript-eslint/eslint-plugin": "^7.13.0",
-        "@typescript-eslint/parser": "^7.13.0",
+        "@types/node": "^20.14.6",
+        "@typescript-eslint/eslint-plugin": "^7.13.1",
+        "@typescript-eslint/parser": "^7.13.1",
         "dukat": "^0.5.8-rc.4",
         "eslint": "^8.56.0",
         "husky": "^9.0.11",
@@ -1065,7 +1065,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-twpNFJrYmo9mCnXZPww7ma0h25MjDJ6Vi5NGpyhLbnqW1QtzJgcT4AL1H1Bz1BNm5Vo5yjmF5eLt3XMPbrKTkw==",
+      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",
@@ -1086,7 +1086,7 @@
     "node_modules/@modelix/vue-model-api": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../../vue-model-api/build/npmDevPackage/vue-model-api.tgz",
-      "integrity": "sha512-FM6EZ+3SR+brBQVqO9QxhHwhhuoH1sL7LIxg3nAmXiKq2UE7Gw28UP0hnKiLh1hGeiJtszfcc58cFZsOyQxauQ==",
+      "integrity": "sha512-msZyMhMvFBOQvhqqPLfalG35ZbnjPrkLJt24qy9Zv4aoedb01BB5c3ly5GWPHpgVjx3RAfOwNlG3C9VSMe+2PQ==",
       "dependencies": {
         "@modelix/model-client": "^8.2.1-1-g563e21c.dirty-SNAPSHOT"
       },

--- a/ts-model-api/src/ChildrenAccessor.ts
+++ b/ts-model-api/src/ChildrenAccessor.ts
@@ -44,11 +44,11 @@ export class SingleChildAccessor<ChildT extends ITypedNode> extends ChildrenAcce
     return children.length === 0 ? undefined : children[0]
   }
 
-  public setNew(): ChildT {
+  public setNew(subconcept?: IConceptJS | undefined): ChildT {
     const existing = this.get();
     if (existing !== undefined) {
       existing.remove();
     }
-    return this.wrapChild(this.parentNode.addNewChild(this.role, 0, undefined))
+    return this.wrapChild(this.parentNode.addNewChild(this.role, 0, subconcept))
   }
 }

--- a/vue-model-api/package-lock.json
+++ b/vue-model-api/package-lock.json
@@ -32,9 +32,9 @@
       "version": "1.3.2-kernelf.4.dirty-SNAPSHOT",
       "license": "Apache 2.0",
       "devDependencies": {
-        "@types/node": "^20.14.2",
-        "@typescript-eslint/eslint-plugin": "^7.13.0",
-        "@typescript-eslint/parser": "^7.13.0",
+        "@types/node": "^20.14.6",
+        "@typescript-eslint/eslint-plugin": "^7.13.1",
+        "@typescript-eslint/parser": "^7.13.1",
         "dukat": "^0.5.8-rc.4",
         "eslint": "^8.56.0",
         "husky": "^9.0.11",
@@ -1281,7 +1281,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-twpNFJrYmo9mCnXZPww7ma0h25MjDJ6Vi5NGpyhLbnqW1QtzJgcT4AL1H1Bz1BNm5Vo5yjmF5eLt3XMPbrKTkw==",
+      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",


### PR DESCRIPTION
Prior to this fix when using the `setNew` method of the `SingleChildAccessor` class, the created node had no concept and could not be given one. This PR introduces the possibility (while maintaining backwards compatibility) to provide a concept when invoking the method.

```typescipt
// before
const typedNode: BasePlaceholder = foo();
const childNode: IPlaceholderContent = typedNode.content.setNew(); // Actually UnknownTypedNode 
expect(isOfConcept_IPlaceholderContent(childNode)).toBeTruthy(); // <---- fails

// after
const typedNode: BasePlaceholder = foo();
const childNode: IPlaceholderContent = typedNode.content.setNew(C_IPlaceholderContent); 
expect(isOfConcept_IPlaceholderContent(childNode)).toBeTruthy(); // <---- succeeds
```

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
