### PR TITLE
build(deps): replace deprecated trove with trove4j

### DIFF
--- a/bulk-model-sync-mps/build.gradle.kts
+++ b/bulk-model-sync-mps/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
         },
     )
 
-    implementation(libs.trove)
+    implementation(libs.trove4j)
 
     implementation(kotlin("stdlib"))
     implementation(libs.kotlin.logging)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,8 +93,7 @@ vavr = { group = "io.vavr", name = "vavr", version = "0.10.4" }
 apache-commons-lang = { group = "org.apache.commons", name = "commons-lang3", version = "3.14.0" }
 apache-commons-io = { group = "commons-io", name = "commons-io", version = "2.16.1" }
 apache-commons-collections = { group = "org.apache.commons", name = "commons-collections4", version = "4.4" }
-trove = { group = "trove", name = "trove", version = "1.0.2"}
-trove4j = { group = "net.sf.trove4j", name = "trove4j", version = "3.0.3" }
+trove4j = { group = "net.sf.trove4j", name = "core", version = "3.1.0" }
 
 ignite-core = { group = "org.apache.ignite", name = "ignite-core", version.ref = "ignite" }
 ignite-spring = { group = "org.apache.ignite", name = "ignite-spring", version.ref = "ignite" }

--- a/mps-model-adapters/build.gradle.kts
+++ b/mps-model-adapters/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
         },
     )
 
-    implementation(libs.trove)
+    implementation(libs.trove4j)
     implementation(kotlin("stdlib"))
     implementation(libs.kotlin.logging)
 }


### PR DESCRIPTION
We had the ~19-year-old Trove and the ~12-year-old Trove4j on the CP. To avoid confusion and to keep the dependencies up to date, I replaced the former with the latter, because that is the continuation of that library.

<img width="503" alt="image" src="https://github.com/modelix/modelix.core/assets/8940487/882a14c9-bd5f-4c1b-9e34-5123e8f52496">

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
