### PR TITLE
MODELIX-938 Configure dependabot to merge patch versions automatically

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge on the PR
+        if: (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Approve the PR
+        if: (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This should set minor and patch updates to auto-merge and approve them automatically.
As long as the pipelines are green it should then be merged automatically.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
