### PR TITLE
ci: add missing contents permission to dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -2,6 +2,7 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Followup to #846 
