### PR TITLE
fix(model-client): fix executing bulk queries in RestWebModelClient

### DIFF
--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IndirectObjectStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IndirectObjectStore.kt
@@ -14,6 +14,7 @@
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore
+import org.modelix.model.persistent.IKVValue
 
 abstract class IndirectObjectStore : IDeserializingKeyValueStore {
 
@@ -32,6 +33,10 @@ abstract class IndirectObjectStore : IDeserializingKeyValueStore {
 
     override fun <T> getAll(hash: Iterable<String>, deserializer: (String, String) -> T): Iterable<T> {
         return getStore().getAll(hash, deserializer)
+    }
+
+    override fun <T : IKVValue> getAll(regular: List<IKVEntryReference<T>>, prefetch: List<IKVEntryReference<T>>): Map<String, T?> {
+        return getStore().getAll(regular, prefetch)
     }
 
     override fun put(hash: String, deserialized: Any, serialized: String) {

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServerTest.kt
@@ -39,6 +39,7 @@ import org.modelix.model.server.store.forContextRepository
 import org.modelix.model.server.store.forGlobalRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class KeyValueLikeModelServerTest {
@@ -115,5 +116,20 @@ class KeyValueLikeModelServerTest {
 
         val branchAVersion = clientV2.pull(branchA, null) as CLVersion
         assertTrue(branchAVersion.isMerge())
+    }
+
+    @Test
+    fun `model client V1 can run a bulk query`() = runTest {
+        val clientV1 = RestWebModelClient(baseUrl = "http://localhost/", providedClient = client)
+        val clientV2 = createModelClient()
+        val repositoryId = RepositoryId("repo1")
+        val version = clientV2.initRepositoryWithLegacyStorage(repositoryId) as CLVersion
+        val treeHash = checkNotNull(version.treeHash) { "Tree has should be loaded." }
+
+        val bulkQuery = clientV1.storeCache.newBulkQuery()
+        val bulkQueryValue = bulkQuery.query(treeHash)
+        val bulkQueryResult = bulkQueryValue.executeQuery()
+
+        assertNotNull(bulkQueryResult)
     }
 }


### PR DESCRIPTION
Fix executing bulk queries in `RestWebModelClient`.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
