### PR TITLE
feat(vue-model-api): expose replicated model

### DIFF
--- a/vue-model-api/package-lock.json
+++ b/vue-model-api/package-lock.json
@@ -32,14 +32,14 @@
       "version": "1.3.2-kernelf.4.dirty-SNAPSHOT",
       "license": "Apache 2.0",
       "devDependencies": {
-        "@types/node": "^20.14.7",
-        "@typescript-eslint/eslint-plugin": "^7.13.1",
-        "@typescript-eslint/parser": "^7.13.1",
+        "@types/node": "^20.14.8",
+        "@typescript-eslint/eslint-plugin": "^7.14.1",
+        "@typescript-eslint/parser": "^7.14.1",
         "dukat": "^0.5.8-rc.4",
         "eslint": "^8.56.0",
         "husky": "^9.0.11",
         "shx": "^0.3.2",
-        "typescript": "^4.7.4"
+        "typescript": "^5.5.2"
       },
       "engines": {
         "node": ">= 10.18.1",
@@ -1281,7 +1281,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.1.2-5-g7ca0fce.dirty-SNAPSHOT",
       "resolved": "file:../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-mGk+2IRIyjjgonIJZWN5c1z+NacF+SEDwQZU230glp+teBE3vlS1rB9ItPBCy/6S6cSGtK+sgeikdIAbxYx5iQ==",
+      "integrity": "sha512-tgflvtuv4IGxetwihoB8RvIPeOK43ZinahB6Yla6uEB6BTYvzS3qxPqCx0xrC9d2tfKEjxWbr3CcT8WLYazz1Q==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",

--- a/vue-model-api/src/index.ts
+++ b/vue-model-api/src/index.ts
@@ -1,3 +1,3 @@
 export { useModelsFromJson } from "./useModelsFromJson";
 export { useModelClient } from "./useModelClient";
-export { useRootNode } from "./useRootNode";
+export { useReplicatedModel } from "./useReplicatedModel";

--- a/vue-model-api/src/useReplicatedModel.test.ts
+++ b/vue-model-api/src/useReplicatedModel.test.ts
@@ -2,7 +2,7 @@ import { org } from "@modelix/model-client";
 import { INodeJS } from "@modelix/ts-model-api";
 import { watchEffect } from "vue";
 import { useModelClient } from "./useModelClient";
-import { useRootNode } from "./useRootNode";
+import { useReplicatedModel } from "./useReplicatedModel";
 
 type BranchJS = org.modelix.model.client2.BranchJS;
 type ReplicatedModelJS = org.modelix.model.client2.ReplicatedModelJS;
@@ -53,11 +53,13 @@ test("test branch connects", (done) => {
   const { client } = useModelClient("anURL", () =>
     Promise.resolve(new SuccessfulClientJS() as unknown as ClientJS),
   );
-
-  const { rootNode } = useRootNode(client, "aRepository", "aBranch");
-
+  const { rootNode, replicatedModel } = useReplicatedModel(
+    client,
+    "aRepository",
+    "aBranch",
+  );
   watchEffect(() => {
-    if (rootNode.value !== null) {
+    if (rootNode.value !== null && replicatedModel.value !== null) {
       expect(rootNode.value.getPropertyValue("branchId")).toBe("aBranch");
       done();
     }
@@ -78,7 +80,7 @@ test("test branch connection error is exposed", (done) => {
     Promise.resolve(new FailingClientJS() as unknown as ClientJS),
   );
 
-  const { error } = useRootNode(client, "aRepository", "aBranch");
+  const { error } = useReplicatedModel(client, "aRepository", "aBranch");
 
   watchEffect(() => {
     if (error.value !== null) {


### PR DESCRIPTION
Expose replicated model in Vue.js API.
The replicated model can be used to subscribe to changes on the branch or get information about the current version.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
