### PR TITLE
build: avoid task configuration in Grade builds

### DIFF
--- a/model-api-gen-gradle-test/typescript-generation/build.gradle.kts
+++ b/model-api-gen-gradle-test/typescript-generation/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("org.modelix.model-api-gen") apply false
 }
 
-val updateDependencies = tasks.create<NpmTask>("updateDependencies") {
+val updateDependencies = tasks.register<NpmTask>("updateDependencies") {
     args.set(
         listOf(
             "install",

--- a/model-api-gen-gradle-test/vue-integration/build.gradle.kts
+++ b/model-api-gen-gradle-test/vue-integration/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.node)
 }
 
-val updateDependencies = tasks.create<NpmTask>("updateDependencies") {
+val updateDependencies = tasks.register<NpmTask>("updateDependencies") {
     dependsOn(":typescript-generation:packJsPackage")
     args.set(
         listOf(

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -74,7 +74,7 @@ kotlin {
     }
 }
 
-val generateVersionVariable by tasks.creating {
+val generateVersionVariable by tasks.registering {
     doLast {
         val outputDir = project.layout.buildDirectory.dir("version_gen/org/modelix/modelql/core").get().asFile
         outputDir.mkdirs()

--- a/ts-model-api/build.gradle.kts
+++ b/ts-model-api/build.gradle.kts
@@ -13,7 +13,7 @@ val npmRunBuild = tasks.named("npm_run_build") {
   outputs.dir("dist")
 }
 
-val patchKotlinExternals = tasks.create("patchKotlinExternals") {
+val patchKotlinExternals = tasks.register("patchKotlinExternals") {
   dependsOn("npm_run_generateKotlin")
   doLast {
     val annotationLine = """@file:JsModule("@modelix/ts-model-api") @file:JsNonModule"""
@@ -51,7 +51,7 @@ tasks.named("npm_run_generateKotlin") {
 // With `NpmPackage.files` we cannot copy the "dist" directory into `destinationDir`.
 // We can only either copy the files from "dist" directly into `destinationDir`
 // or copy all files from `projectDir` into `destinationDir`.
-val copyBuildTypeScriptForPackaging = tasks.create<Copy>("copyBuildTypeScriptForPackaging") {
+val copyBuildTypeScriptForPackaging = tasks.register<Copy>("copyBuildTypeScriptForPackaging") {
   dependsOn(npmRunBuild)
   from(projectDir)
   include("dist/**")
@@ -74,7 +74,7 @@ npmPublish {
         version.set("${project.version}")
       }
       files {
-        setFrom(copyBuildTypeScriptForPackaging.outputs)
+        setFrom(copyBuildTypeScriptForPackaging.map { it.outputs })
       }
     }
   }

--- a/vue-model-api/build.gradle.kts
+++ b/vue-model-api/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("modelix-project-repositories")
 }
 
-val updateModelClient = tasks.create<NpmTask>("updateModelClient") {
+val updateModelClient = tasks.register<NpmTask>("updateModelClient") {
     val modelClientPackage = "../model-client/build/npmDevPackage/model-client.tgz"
     inputs.file(modelClientPackage)
     outputs.cacheIf { true }
@@ -49,7 +49,7 @@ tasks.named("npm_run_lint") {
 }
 
 val packageJsonForProd = layout.buildDirectory.file("package-for-publishing.json").get().asFile
-val createPackageJsonForPublishing = tasks.create("createPackageJsonForPublishing") {
+val createPackageJsonForPublishing = tasks.register("createPackageJsonForPublishing") {
     dependsOn(updateModelClient)
 
     val packageJsonForDev = projectDir.resolve("package.json")


### PR DESCRIPTION
Replace `create` with `register` and `creating` with `registering`.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
