### PR TITLE
fix: IConcept.isSubConceptOf/.isExactly if concepts are of different …

### DIFF
--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/GeneratedConcept.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/GeneratedConcept.kt
@@ -149,7 +149,10 @@ abstract class GeneratedConcept<NodeT : ITypedNode, ConceptT : ITypedConcept>(
     }
 
     override fun isExactly(concept: IConcept?): Boolean {
-        return concept == this
+        if (concept == null) return false
+        if (concept == this) return true
+        if (concept.getUID() == this.getUID()) return true
+        return false
     }
 
     override fun isSubConceptOf(superConcept: IConcept?): Boolean {

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/TypedNodeImpl.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/TypedNodeImpl.kt
@@ -6,7 +6,7 @@ import org.modelix.model.api.INode
 abstract class TypedNodeImpl(val wrappedNode: INode) : ITypedNode {
 
     init {
-        val expected: IConcept = _concept._concept
+        val expected: IConcept = _concept.untyped()
         val actual: IConcept? = unwrap().concept
         require(actual != null && actual.isSubConceptOf(expected)) {
             "Concept of node ${unwrap()} expected to be a sub-concept of $expected, but was $actual"

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
@@ -73,7 +73,10 @@ open class SimpleConcept(
 
     override fun getShortName() = conceptName
 
-    override fun isExactly(concept: IConcept?) = concept == this
+    override fun isExactly(concept: IConcept?): Boolean {
+        if (concept == null) return false
+        return concept == this || getUID() == concept.getUID()
+    }
 
     override fun isSubConceptOf(superConcept: IConcept?): Boolean {
         if (superConcept == null) return false

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
@@ -63,8 +63,17 @@ data class MPSConcept(val concept: SAbstractConceptAdapter) : IConcept {
     }
 
     override fun isSubConceptOf(superConcept: IConcept?): Boolean {
-        val mpsSuperConcept = superConcept as? MPSConcept ?: return false
-        return concept.isSubConceptOf(mpsSuperConcept.concept)
+        if (superConcept == null) return false
+        if (isExactly(superConcept)) return true
+        if (superConcept is MPSConcept) {
+            // Use the MPS logic if possible, because it's faster (super concepts are cached in a set).
+            return concept.isSubConceptOf(superConcept.concept)
+        } else {
+            for (c in getDirectSuperConcepts()) {
+                if (c.isSubConceptOf(superConcept)) return true
+            }
+        }
+        return false
     }
 
     override fun getDirectSuperConcepts(): List<IConcept> {
@@ -77,8 +86,9 @@ data class MPSConcept(val concept: SAbstractConceptAdapter) : IConcept {
     }
 
     override fun isExactly(concept: IConcept?): Boolean {
-        val otherMpsConcept = concept as? MPSConcept ?: return false
-        return this.concept == otherMpsConcept.concept
+        if (concept == null) return false
+        if (concept == this) return true
+        return concept.getUID() == getUID()
     }
 
     override fun getOwnProperties(): List<IProperty> {


### PR DESCRIPTION
…implementations

All implementations returned false if the parameter was of a different type. This was causing exceptions when the typed model API was used on an MPS model.

The implementations now handle this case by also comparing UIDs.

TODO description of the PR

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
