### PR TITLE
MODELIX-950: lint for OpenAPI breaking changes

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,3 +10,29 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1
+
+  openapi-breaking-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+        with:
+          # We need the history to find the common ancestor of the PR and the target branch from which we fetch the
+          # baseline OpenAPI specifications to compare against.
+          fetch-depth: 0
+      - name: Fetch baseline OpenAPI specifications
+        run: |
+          mergeBase="$(git merge-base --fork-point "origin/${{ github.base_ref }}")"
+          echo "mergeBase: $mergeBase"
+          git restore -s "$mergeBase" -W -- model-server-openapi/specifications
+          cp -R model-server-openapi/specifications model-server-openapi/specifications-before
+          git checkout model-server-openapi/specifications
+      - name: Run oasdiff
+        id: breaking
+        uses: oasdiff/oasdiff-action/breaking@main
+        with:
+          base: 'model-server-openapi/specifications-before/*.yaml'
+          revision: 'model-server-openapi/specifications/*.yaml'
+          composed: true


### PR DESCRIPTION
This PR enables linting the OpenAPI specifications for breaking changes. For this purpose, the most recent version of the specs is compared to the specs present at the time the PR branched off. In case of findings, those are presented as inline annotations in the diff:

![image](https://github.com/modelix/modelix.core/assets/1336287/cc2ec0a5-156c-481a-bbd0-f357521168bf)

Currently, most detected findings have no line association and are therefore attached to the top of the openapi spec.

Breaking changes are detected after internally fusing all specs. That way, we would be free to move routes from one file to the other without triggering a breaking change (`composed` mode of oasdiff).

The added linter is not mandatory and does not fail the build, assuming that sometimes performing breaking changes is fine if no known uses exist.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
