### PR TITLE
fix(model-server): provide a valid operative spec

### DIFF
--- a/model-server-openapi/specifications/model-server-operative.yaml
+++ b/model-server-openapi/specifications/model-server-operative.yaml
@@ -35,12 +35,20 @@ paths:
         - health
       responses:
         "200":
-          $ref: '#/components/responses/200'
+          $ref: '#/components/responses/Healthy'
         default:
           $ref: '#/components/responses/GeneralError'
 
 components:
   responses:
+    Healthy:
+      description: OK
+      content:
+        text/plain:
+          schema:
+            type: string
+            enum: ["healthy"]
+
     MetricsResponse:
       description: OK
       content:


### PR DESCRIPTION
Fixes the missing response specification for a healthy /health reply.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
