### PR TITLE
MODELIX-969 conceptAlias does not seem to work

### DIFF
--- a/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/metamodel/generator/GeneratedApiTest.kt
+++ b/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/metamodel/generator/GeneratedApiTest.kt
@@ -16,6 +16,7 @@ import org.modelix.metamodel.typed
 import org.modelix.metamodel.untyped
 import org.modelix.model.ModelFacade
 import org.modelix.model.api.INode
+import org.modelix.model.api.conceptAlias
 import org.modelix.model.api.getRootNode
 import org.modelix.model.data.ConceptData
 import org.modelix.model.data.ModelData
@@ -82,6 +83,11 @@ class GeneratedApiTest {
     fun `metaProperty alias has value`() {
         val alias = C_ClassConcept.alias
         assertEquals("class", alias)
+    }
+
+    @Test
+    fun `alias can be retrieved via conceptAlias`() {
+        assertEquals(C_ClassConcept.alias, C_ClassConcept.untyped().conceptAlias())
     }
 
     private fun KAnnotatedElement.hasDeprecationWithMessage() =

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptWrapperInterfaceGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptWrapperInterfaceGenerator.kt
@@ -89,8 +89,7 @@ internal class ConceptWrapperInterfaceGenerator(
     private fun TypeSpec.Builder.addConceptMetaPropertiesIfNecessary() {
         if (conceptPropertiesInterfaceName == null) return
 
-        // TODO use IConcept.getConceptProperty(name: String)
-        concept.metaProperties.forEach { (key, value) ->
+        for ((key, value) in concept.metaProperties) {
             val propertySpec = PropertySpec.builder(key, String::class.asTypeName()).runBuild {
                 addModifiers(KModifier.OVERRIDE)
                 initializer("%S", value)

--- a/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/HtmlBuilderTest.kt
+++ b/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/HtmlBuilderTest.kt
@@ -47,10 +47,12 @@ import org.modelix.modelql.untyped.property
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
 class HtmlBuilderTest {
+    @OptIn(ExperimentalTime::class)
     private fun runTest(block: suspend (HttpClient) -> Unit) = testApplication {
-        withTimeout(10.seconds) {
+        withTimeout(20.seconds) {
             application {
                 val tree = CLTree(ObjectStoreCache(MapBaseStore()))
                 val branch = PBranch(tree, IdGenerator.getInstance(1))


### PR DESCRIPTION
Generated concepts did not implement `getConceptProperty(name: String)`.

The generated code now roughly looks like this:

```kotlin
public object _C_UntypedImpl_MyConcept {
    override fun getConceptProperty(name: String): String? = when (name) {
        "alias" -> C_MyConcept.alias
        else -> null
    }
}

public interface C_MyConcept {
    companion object : C_MyConcept {
        override val alias: String = "my concept alias"
    }
}
```

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
