### PR TITLE
fix(model-server): set jwkKeyId from system envvar

### DIFF
--- a/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationConfig.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationConfig.kt
@@ -106,7 +106,7 @@ class ModelixAuthorizationConfig : IModelixAuthorizationConfig {
                 URI("${keycloakBaseUrl}realms/$keycloakRealm/protocol/openid-connect/certs")
             }
         }
-    override var jwkKeyId: String? = null
+    override var jwkKeyId: String? = System.getenv("MODELIX_JWK_KEY_ID")
     override var permissionSchema: Schema = buildPermissionSchema { }
 
     private val hmac512KeyFromEnv by lazy {


### PR DESCRIPTION
#678 did not let the `AuthorizationConfig.jwkKeyId` to be set from a system envvar. This PR fixes this bug.

`jwkKeyId` is used when we load the JWK from a URI and [we want to select from the bunch of JWKs the one to use](https://github.com/modelix/modelix.core/blob/df0e3649dd3d4c38708ac3632ab8a69bfc7ffcd4/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationConfig.kt#L137).

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
