### PR TITLE
fix(model-api): add UID for INamedConcept

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ micrometer = "1.13.2"
 dokka = "1.9.20"
 detekt = "1.23.6"
 xmlunit = "2.10.0"
+kotest = "5.9.1"
 
 [libraries]
 
@@ -84,7 +85,8 @@ ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlin
 
 keycloak-authz-client = { group = "org.keycloak", name = "keycloak-authz-client", version = "25.0.1" }
 
-kotest-assertions-coreJvm = { group = "io.kotest", name = "kotest-assertions-core-jvm", version = "5.9.1" }
+kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
+kotest-assertions-coreJvm = { group = "io.kotest", name = "kotest-assertions-core-jvm", version.ref = "kotest" }
 kotest-assertions-ktor = { group = "io.kotest.extensions", name = "kotest-assertions-ktor", version = "2.0.0" }
 
 guava = { group = "com.google.guava", name = "guava", version = "33.2.1-jre" }

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.kotest.assertions.core)
             }
         }
         val jvmMain by getting {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
@@ -68,7 +68,11 @@ object BuiltinLanguages {
             init { addConcept(this) }
         }
 
-        object INamedConcept : SimpleConcept(conceptName = "INamedConcept") {
+        object INamedConcept : SimpleConcept(
+            conceptName = "INamedConcept",
+            is_abstract = true,
+            uid = "mps:ceab5195-25ea-4f22-9b92-103b95ca8c0c/1169194658468",
+        ) {
             init { addConcept(this) }
             val name = SimpleProperty(
                 "name",

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IConcept.kt
@@ -56,6 +56,8 @@ interface IConcept {
     /**
      * Checks if this concept is abstract.
      *
+     * A concept is abstract if it is not designated to be instantiated directly.
+     *
      * @return true if the concept is abstract, false otherwise
      */
     fun isAbstract(): Boolean

--- a/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
@@ -16,6 +16,8 @@
 
 package org.modelix.model.api
 
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.string.shouldStartWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -40,5 +42,15 @@ class BuiltinLanguagesTest {
         // because previously, children were not listed at all in Model.getOwnChildLinks().
         // They were only accessible by directly calling Model.modelImports for example.
         assertEquals(3, childLinks.size)
+    }
+
+    @Test
+    fun allBuiltInLanguagesHaveMpsConceptId() {
+        val concepts = BuiltinLanguages.getAllLanguages()
+            .flatMap { it.getConcepts() }
+
+        concepts.forAll { concept: IConcept ->
+            concept.getUID().shouldStartWith("mps:")
+        }
     }
 }

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
@@ -54,6 +54,11 @@ data class MPSConcept(val concept: SAbstractConceptAdapter) : IConcept {
     }
 
     override fun isAbstract(): Boolean {
+        // In MPS `org.jetbrains.mps.openapi.language.SAbstractConcept.isAbstract`
+        // returns `true` for abstract concepts and interface concepts.
+        // See https://github.com/JetBrains/MPS/blob/78b81f56866370e227262000e597a211f885b9e6/core/kernel/source/jetbrains/mps/smodel/adapter/structure/concept/SConceptAdapterById.java#L54
+        // This exactly matches with the definition of `IConcept.isAbstract`,
+        // as such concepts are not designated to be instantiated directly.
         return concept.isAbstract
     }
 


### PR DESCRIPTION
Add UID for `INamedConcept`.
The UID was missing for some reason.
This made me run into errors testing when testing the sync plugin.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
