### PR TITLE
fix(model-api): do not require registered concept for serialization to NodeData

### DIFF
--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
+                implementation(project(":model-datastructure"))
                 implementation(kotlin("test"))
                 implementation(libs.kotest.assertions.core)
             }

--- a/model-api/src/commonMain/kotlin/org/modelix/model/data/ModelData.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/data/ModelData.kt
@@ -126,7 +126,7 @@ fun ModelData.nodeUID(node: NodeData): String = node.uid(this)
 
 fun INode.asData(): NodeData = NodeData(
     id = reference.serialize(),
-    concept = concept?.getUID(),
+    concept = getConceptReference()?.getUID(),
     role = roleInParent,
     properties = getPropertyRoles().associateWithNotNull { getPropertyValue(it) },
     references = getReferenceRoles().associateWithNotNull { getReferenceTargetRef(it)?.serialize() },

--- a/model-api/src/commonTest/kotlin/org/modelix/model/data/ModelDataTest.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/data/ModelDataTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.data
+
+import org.modelix.model.api.ChildLinkFromName
+import org.modelix.model.api.ConceptReference
+import org.modelix.model.api.INode
+import org.modelix.model.api.TreePointer
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.NonCachingObjectStore
+import org.modelix.model.persistent.MapBasedStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModelDataTest {
+
+    @Test
+    fun nodeWithConceptReferenceButWithoutRegisteredConceptCanSerialized() {
+        val aChildLink = ChildLinkFromName("aChildLink")
+        val aConceptReference = ConceptReference("aConceptReference")
+        val rootNode = createEmptyRootNode()
+        rootNode.addNewChild(aChildLink, -1, aConceptReference)
+
+        val nodeData = rootNode.asData()
+
+        val child = nodeData.children.single { child -> child.role == aChildLink.getUID() }
+        assertEquals(aConceptReference.getUID(), child.concept)
+    }
+}
+
+internal fun createEmptyRootNode(): INode {
+    val tree = CLTree(NonCachingObjectStore(MapBasedStore()))
+    val branch = TreePointer(tree, IdGenerator.getInstance(1))
+    return branch.getRootNode()
+}


### PR DESCRIPTION
Do not require registered concept for serialization to `NodeData`.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
