### PR TITLE
fix(model-api-gen): fix generated code not compiling if conceptProper…

### DIFF
--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptFileGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptFileGenerator.kt
@@ -43,7 +43,7 @@ internal class ConceptFileGenerator(
 ) : NameConfigBasedGenerator(nameConfig), FileGenerator {
 
     override fun generateFileSpec(): FileSpec {
-        val conceptObject = ConceptObjectGenerator(concept, nameConfig).generate()
+        val conceptObject = ConceptObjectGenerator(concept, nameConfig, conceptPropertiesInterfaceName).generate()
         val conceptWrapperInterface = ConceptWrapperInterfaceGenerator(
             concept,
             nameConfig,

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptObjectGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptObjectGenerator.kt
@@ -53,6 +53,7 @@ import kotlin.reflect.KClass
 internal class ConceptObjectGenerator(
     private val concept: ProcessedConcept,
     override val nameConfig: NameConfig,
+    private val conceptPropertiesInterfaceName: String?,
     private val alwaysUseNonNullableProperties: Boolean = true,
 ) : NameConfigBasedGenerator(nameConfig) {
 
@@ -101,7 +102,7 @@ internal class ConceptObjectGenerator(
     }
 
     private fun TypeSpec.Builder.addConceptPropertiesGetter() {
-        if (concept.metaProperties.isEmpty()) return
+        if (conceptPropertiesInterfaceName == null || concept.metaProperties.isEmpty()) return
 
         val getConceptPropertyFun = FunSpec.builder(GeneratedConcept<*, *>::getConceptProperty.name).runBuild {
             val paramName = GeneratedConcept<*, *>::getConceptProperty.parameters.first().name ?: "name"


### PR DESCRIPTION
…tiesInterfaceName was not set

This was a regression introduced in commit 86c141bd.

## To be verified by reviewers

* [x] Relevant public API members have been documented
* [x] Documentation related to this PR is complete
  * [x] Boundary conditions are documented
  * [x] Exceptions are documented
  * [x] Nullability is documented if used
* [x] Touched existing code has been extended with documentation if missing
* [x] Code is readable
* [ ] New features and fixed bugs are covered by tests
