### PR TITLE
Include legacy-* permissions in admin permission

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/ModelServerPermissionSchema.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/ModelServerPermissionSchema.kt
@@ -56,13 +56,21 @@ object ModelServerPermissionSchema {
         }
 
         resource(LEGACY_USER_DEFINED_ENTRIES) {
-            permission(READ)
-            permission(WRITE)
+            permission(READ) {
+                includedIn(MODEL_SERVER, ADMIN)
+            }
+            permission(WRITE) {
+                includedIn(MODEL_SERVER, ADMIN)
+            }
         }
 
         resource(LEGACY_GLOBAL_OBJECTS) {
-            permission(READ)
-            permission(ADD)
+            permission(READ) {
+                includedIn(MODEL_SERVER, ADMIN)
+            }
+            permission(ADD) {
+                includedIn(MODEL_SERVER, ADMIN)
+            }
         }
 
         resource(REPOSITORY) {


### PR DESCRIPTION
Legacy permissions (used by model client V1) were not included in the admin permission.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
