### PR TITLE
chore(model-server): remove implementation of `LightModelServer` from model-server code

### DIFF
--- a/light-model-client/build.gradle.kts
+++ b/light-model-client/build.gradle.kts
@@ -40,12 +40,6 @@ kotlin {
                 implementation(libs.kotlin.logging)
                 implementation(libs.kotlin.coroutines.core)
                 implementation(libs.kotlin.serialization.json)
-
-//                implementation("io.ktor:ktor-client-core:$ktorVersion")
-//                implementation("io.ktor:ktor-client-cio:$ktorVersion")
-//                implementation("io.ktor:ktor-client-auth:$ktorVersion")
-//                implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-//                implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
             }
         }
         val commonTest by getting {
@@ -63,7 +57,7 @@ kotlin {
             dependencies {
 
                 implementation(project(":authorization"))
-//                implementation(project(":model-client"))
+                implementation(project(":model-client", configuration = "jvmRuntimeElements"))
                 implementation(project(":model-server"))
                 implementation(project(":model-server-lib"))
                 implementation(libs.modelix.incremental)

--- a/light-model-client/src/jvmTest/kotlin/org/modelix/client/light/FakeLightModelServer.kt
+++ b/light-model-client/src/jvmTest/kotlin/org/modelix/client/light/FakeLightModelServer.kt
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) 2024.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.modelix.model.server.handlers
+
+package org.modelix.client.light
 
 import io.ktor.server.application.Application
 import io.ktor.server.request.host
@@ -22,8 +25,6 @@ import io.ktor.server.websocket.webSocket
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
 import io.ktor.websocket.send
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -55,14 +56,17 @@ import org.modelix.model.server.api.OperationData
 import org.modelix.model.server.api.SetPropertyOpData
 import org.modelix.model.server.api.SetReferenceOpData
 import org.modelix.model.server.api.VersionData
+import org.modelix.model.server.handlers.RepositoriesManager
 import org.modelix.model.server.store.ContextScopedStoreClient
 import org.modelix.model.server.store.LocalModelClient
 import java.util.Date
-import kotlin.collections.set
 
 private val LOG = KotlinLogging.logger {}
 
-class LightModelServer(val client: LocalModelClient, val repositoriesManager: RepositoriesManager) {
+/**
+ * Simplified fake implementation of [org.modelix.model.server.light.LightModelServer].
+ */
+class FakeLightModelServer(val client: LocalModelClient, val repositoriesManager: RepositoriesManager) {
 
     fun init(application: Application) {
         application.routing {
@@ -193,7 +197,16 @@ class LightModelServer(val client: LocalModelClient, val repositoriesManager: Re
                                         }
                                     }
                                 } catch (ex: Exception) {
-                                    send(MessageFromServer(exception = ExceptionData(RuntimeException("Failed to process message: $text", ex))).toJson())
+                                    send(
+                                        MessageFromServer(
+                                            exception = ExceptionData(
+                                                RuntimeException(
+                                                    "Failed to process message: $text",
+                                                    ex,
+                                                ),
+                                            ),
+                                        ).toJson(),
+                                    )
                                 }
                             }
                             else -> {}
@@ -364,11 +377,4 @@ class LightModelServer(val client: LocalModelClient, val repositoriesManager: Re
             node.allChildren.forEach { node2json(it, true, outputList) }
         }
     }
-}
-
-@OptIn(ExperimentalCoroutinesApi::class)
-private suspend fun <T> Channel<T>.receiveLast(): T {
-    var latest = receive()
-    while (!isEmpty) latest = receive()
-    return latest
 }

--- a/light-model-client/src/jvmTest/kotlin/org/modelix/client/light/LightModelClientTest.kt
+++ b/light-model-client/src/jvmTest/kotlin/org/modelix/client/light/LightModelClientTest.kt
@@ -27,7 +27,6 @@ import org.modelix.incremental.incrementalFunction
 import org.modelix.model.api.IProperty
 import org.modelix.model.api.addNewChild
 import org.modelix.model.api.getDescendants
-import org.modelix.model.server.handlers.LightModelServer
 import org.modelix.model.server.handlers.RepositoriesManager
 import org.modelix.model.server.store.InMemoryStoreClient
 import org.modelix.model.server.store.LocalModelClient
@@ -41,8 +40,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class LightModelClientTest {
-    var localModelClient: LocalModelClient? = null
-
     private fun runTest(block: suspend (HttpClient) -> Unit) = testApplication {
         val modelClient = LocalModelClient(InMemoryStoreClient())
         val repositoryManager = RepositoriesManager(modelClient)
@@ -52,8 +49,11 @@ class LightModelClientTest {
             installAuthentication(unitTestMode = true)
             install(io.ktor.server.websocket.WebSockets)
             install(io.ktor.server.resources.Resources)
-            localModelClient = modelClient
-            LightModelServer(modelClient, repositoryManager).init(this)
+            // TODO MODELIX-994 Should use `org.modelix.model.server.light.LightModelServer`
+            // to test against the actual implementation.
+            // But just using it does not work.
+            // Might be caused by the setup here or actual bugs in the server or client.
+            FakeLightModelServer(modelClient, repositoryManager).init(this)
         }
         val client = createClient {
             install(WebSockets)


### PR DESCRIPTION
The implementation `org.modelix.model.server.handlers.LightModelServer` was only used as a fake to test the light-model-client.
Renaming and moving it into the test code of the light-model-client helps to understand that.

The light-model-server implementation running in MPS is `org.modelix.model.server.light.LightModelServer`.

The next step would be to remove `FakeLightModelServer` and use `org.modelix.model.server.light.LightModelServer` to test the light-model-client.
See MODELIX-994

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
