### PR TITLE
MODELIX-876 Deduplicate Kotlin configuration

### DIFF
--- a/authorization/build.gradle.kts
+++ b/authorization/build.gradle.kts
@@ -1,7 +1,7 @@
 description = "Library that checks is allowed to do something"
 
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     kotlin("plugin.serialization")
 }
 
@@ -20,16 +20,6 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlin.logging)
     testImplementation(kotlin("test"))
-}
-
-tasks.getByName<Test>("test") {
-    useJUnitPlatform()
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
 }
 
 publishing {

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm-with-junit.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm-with-junit.gradle.kts
@@ -1,5 +1,3 @@
-import gradle.kotlin.dsl.accessors._8758bf21ec0488ee6f70886b9f0e8378.test
-
 /*
  * Copyright (c) 2024.
  *
@@ -15,6 +13,9 @@ import gradle.kotlin.dsl.accessors._8758bf21ec0488ee6f70886b9f0e8378.test
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.gradle.kotlin.dsl.invoke
+
 
 plugins {
     id("modelix-kotlin-jvm")

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm-with-junit.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm-with-junit.gradle.kts
@@ -1,0 +1,25 @@
+import gradle.kotlin.dsl.accessors._8758bf21ec0488ee6f70886b9f0e8378.test
+
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("modelix-kotlin-jvm")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
@@ -1,0 +1,34 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+kotlin {
+    jvmToolchain(11)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
@@ -18,12 +18,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    id("modelix-language-config")
 }
 
 kotlin {

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
@@ -1,7 +1,3 @@
-
-import org.modelix.MODELIX_JDK_VERSION
-import org.modelix.MODELIX_JVM_TARGET
-
 /*
  * Copyright (c) 2024.
  *
@@ -17,6 +13,10 @@ import org.modelix.MODELIX_JVM_TARGET
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.modelix.MODELIX_JDK_VERSION
+import org.modelix.MODELIX_JVM_TARGET
+
 
 plugins {
     kotlin("jvm")

--- a/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
@@ -1,3 +1,5 @@
+import org.modelix.MODELIX_JDK_VERSION
+
 /*
  * Copyright (c) 2024.
  *
@@ -20,7 +22,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(MODELIX_JDK_VERSION)
     js(IR) {
         browser {
             testTask {

--- a/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    kotlin("multiplatform")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+kotlin {
+    jvmToolchain(11)
+    js(IR) {
+        browser {
+            testTask {
+                useMocha {
+                    timeout = "60s"
+                }
+            }
+        }
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "60s"
+                }
+            }
+        }
+        useCommonJs()
+    }
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
@@ -16,12 +16,7 @@
 
 plugins {
     kotlin("multiplatform")
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    id("modelix-language-config")
 }
 
 kotlin {

--- a/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
@@ -1,5 +1,3 @@
-import org.modelix.MODELIX_JDK_VERSION
-
 /*
  * Copyright (c) 2024.
  *
@@ -15,6 +13,8 @@ import org.modelix.MODELIX_JDK_VERSION
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.modelix.MODELIX_JDK_VERSION
 
 plugins {
     kotlin("multiplatform")

--- a/build-logic/src/main/kotlin/modelix-language-config.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-language-config.gradle.kts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gradle.kotlin.dsl.accessors._9d6accdeac6876c73060866945fb6d8c.java
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+val kotlinApiVersion = KotlinVersion.KOTLIN_1_6
+tasks.withType<KotlinCompile>().configureEach {
+    if (!name.lowercase().contains("test")) {
+        this.compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+            freeCompilerArgs.addAll(listOf("-Xjvm-default=all-compatibility", "-Xexpect-actual-classes"))
+            apiVersion.set(kotlinApiVersion)
+        }
+    }
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+    if (!name.lowercase().contains("test")) {
+        this.compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+            freeCompilerArgs.addAll(listOf("-Xjvm-default=all-compatibility"))
+            apiVersion.set(kotlinApiVersion)
+        }
+    }
+}
+
+plugins.withType<KotlinPlatformJvmPlugin> {
+    extensions.configure<KotlinJvmProjectExtension> {
+        jvmToolchain(11)
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+}
+
+plugins.withType<KotlinMultiplatformPluginWrapper> {
+    extensions.configure<KotlinMultiplatformExtension> {
+        jvmToolchain(11)
+        sourceSets.all {
+            if (!name.lowercase().contains("test")) {
+                languageSettings {
+                    apiVersion = kotlinApiVersion.version
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/modelix-language-config.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-language-config.gradle.kts
@@ -15,28 +15,28 @@
  */
 
 import gradle.kotlin.dsl.accessors._9d6accdeac6876c73060866945fb6d8c.java
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import org.modelix.MODELIX_JDK_VERSION
+import org.modelix.MODELIX_JVM_TARGET
+import org.modelix.MODELIX_KOTLIN_API_VERSION
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(MODELIX_JDK_VERSION))
     }
 }
 
-val kotlinApiVersion = KotlinVersion.KOTLIN_1_6
 tasks.withType<KotlinCompile>().configureEach {
     if (!name.lowercase().contains("test")) {
         this.compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(MODELIX_JVM_TARGET)
             freeCompilerArgs.addAll(listOf("-Xjvm-default=all-compatibility", "-Xexpect-actual-classes"))
-            apiVersion.set(kotlinApiVersion)
+            apiVersion.set(MODELIX_KOTLIN_API_VERSION)
         }
     }
 }
@@ -44,29 +44,29 @@ tasks.withType<KotlinCompile>().configureEach {
 tasks.withType<KotlinJvmCompile>().configureEach {
     if (!name.lowercase().contains("test")) {
         this.compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(MODELIX_JVM_TARGET)
             freeCompilerArgs.addAll(listOf("-Xjvm-default=all-compatibility"))
-            apiVersion.set(kotlinApiVersion)
+            apiVersion.set(MODELIX_KOTLIN_API_VERSION)
         }
     }
 }
 
 plugins.withType<KotlinPlatformJvmPlugin> {
     extensions.configure<KotlinJvmProjectExtension> {
-        jvmToolchain(11)
+        jvmToolchain(MODELIX_JDK_VERSION)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(MODELIX_JVM_TARGET)
         }
     }
 }
 
 plugins.withType<KotlinMultiplatformPluginWrapper> {
     extensions.configure<KotlinMultiplatformExtension> {
-        jvmToolchain(11)
+        jvmToolchain(MODELIX_JDK_VERSION)
         sourceSets.all {
             if (!name.lowercase().contains("test")) {
                 languageSettings {
-                    apiVersion = kotlinApiVersion.version
+                    apiVersion = MODELIX_KOTLIN_API_VERSION.version
                 }
             }
         }

--- a/build-logic/src/main/kotlin/org/modelix/LanguageConfig.kt
+++ b/build-logic/src/main/kotlin/org/modelix/LanguageConfig.kt
@@ -1,7 +1,3 @@
-
-import org.modelix.MODELIX_JDK_VERSION
-import org.modelix.MODELIX_JVM_TARGET
-
 /*
  * Copyright (c) 2024.
  *
@@ -18,14 +14,11 @@ import org.modelix.MODELIX_JVM_TARGET
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-    id("modelix-language-config")
-}
+package org.modelix
 
-kotlin {
-    jvmToolchain(MODELIX_JDK_VERSION)
-    compilerOptions {
-        jvmTarget.set(MODELIX_JVM_TARGET)
-    }
-}
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+const val MODELIX_JDK_VERSION = 11
+val MODELIX_JVM_TARGET = JvmTarget.JVM_11
+val MODELIX_KOTLIN_API_VERSION = KotlinVersion.KOTLIN_1_6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,6 @@ import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformJvmPlugin
 
 buildscript {
     dependencies {
@@ -72,58 +67,6 @@ subprojects {
     tasks.withType<DokkaTaskPartial>().configureEach {
         pluginConfiguration<DokkaBase, DokkaBaseConfiguration> {
             footerMessage = dokkaFooterMessage
-        }
-    }
-
-    val kotlinApiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_6
-    subproject.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        if (!name.lowercase().contains("test")) {
-            this.compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-                freeCompilerArgs.addAll(listOf("-Xjvm-default=all-compatibility", "-Xexpect-actual-classes"))
-                apiVersion.set(kotlinApiVersion)
-            }
-        }
-    }
-    subproject.tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
-        if (!name.lowercase().contains("test")) {
-            this.compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-                freeCompilerArgs.addAll(listOf("-Xjvm-default=all-compatibility"))
-                apiVersion.set(kotlinApiVersion)
-            }
-        }
-    }
-
-    subproject.plugins.withType<JavaPlugin> {
-        subproject.extensions.configure<JavaPluginExtension> {
-            toolchain {
-                languageVersion.set(JavaLanguageVersion.of(11))
-            }
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
-        }
-    }
-
-    subproject.plugins.withType<KotlinPlatformJvmPlugin> {
-        subproject.extensions.configure<KotlinJvmProjectExtension> {
-            jvmToolchain(11)
-            compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-            }
-        }
-    }
-
-    subproject.plugins.withType<KotlinMultiplatformPluginWrapper> {
-        subproject.extensions.configure<KotlinMultiplatformExtension> {
-            jvmToolchain(11)
-            sourceSets.all {
-                if (!name.lowercase().contains("test")) {
-                    languageSettings {
-                        apiVersion = kotlinApiVersion.version
-                    }
-                }
-            }
         }
     }
 

--- a/bulk-model-sync-gradle-test/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     id("org.modelix.bulk-model-sync")
 }
 
@@ -30,14 +30,6 @@ dependencies {
     testImplementation("org.modelix:bulk-model-sync-lib")
     testImplementation(kotlin("test"))
     testImplementation(libs.xmlunit.core)
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(11)
 }
 
 val repoDir = project.layout.buildDirectory.dir("test-repo").get().asFile

--- a/bulk-model-sync-gradle-test/graph-lang-api/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/graph-lang-api/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("org.modelix.model-api-gen")
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
 }
 
 repositories {
@@ -30,7 +30,6 @@ kotlin {
     sourceSets.named("main") {
         kotlin.srcDir(kotlinGenDir)
     }
-    jvmToolchain(11)
 }
 
 metamodel {

--- a/bulk-model-sync-gradle/build.gradle.kts
+++ b/bulk-model-sync-gradle/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     `java-gradle-plugin`
 }
 
@@ -13,10 +13,6 @@ dependencies {
     implementation(libs.ktor.client.cio)
     testImplementation(libs.kotest.assertions.coreJvm)
     testImplementation(kotlin("test"))
-}
-
-kotlin {
-    jvmToolchain(11)
 }
 
 gradlePlugin {

--- a/bulk-model-sync-lib/build.gradle.kts
+++ b/bulk-model-sync-lib/build.gradle.kts
@@ -1,23 +1,8 @@
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
 }
 
 kotlin {
-    jvmToolchain(11)
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "60s"
-                }
-            }
-        }
-    }
-    jvm {
-        testRuns["test"].executionTask.configure {
-            useJUnitPlatform()
-        }
-    }
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/bulk-model-sync-lib/mps-test/build.gradle.kts
+++ b/bulk-model-sync-lib/mps-test/build.gradle.kts
@@ -17,7 +17,7 @@
 import org.modelix.copyMps
 
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm`
     // We are not building an actual plugin here.
     // We use/abuse the gradle-intellij-plugin run tests with MPS.
     // (With enough time and effort,

--- a/bulk-model-sync-lib/mps-test/build.gradle.kts
+++ b/bulk-model-sync-lib/mps-test/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     // and build something custom using the relevant parts.
     // For the time being, this solution works without much overhead and great benefit.)
     alias(libs.plugins.intellij)
-    id("modelix-project-repositories")
+    `modelix-project-repositories`
 }
 
 dependencies {

--- a/bulk-model-sync-mps/build.gradle.kts
+++ b/bulk-model-sync-mps/build.gradle.kts
@@ -1,11 +1,7 @@
 import org.modelix.mpsHomeDir
 
 plugins {
-    kotlin("jvm")
-}
-
-kotlin {
-    jvmToolchain(11)
+    `modelix-kotlin-jvm-with-junit`
 }
 
 dependencies {

--- a/kotlin-utils/build.gradle.kts
+++ b/kotlin-utils/build.gradle.kts
@@ -1,27 +1,9 @@
 plugins {
     `maven-publish`
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        useCommonJs()
-    }
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/light-model-client/build.gradle.kts
+++ b/light-model-client/build.gradle.kts
@@ -1,28 +1,9 @@
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/metamodel-export/build.gradle.kts
+++ b/metamodel-export/build.gradle.kts
@@ -2,7 +2,7 @@ import org.modelix.mpsHomeDir
 
 plugins {
     base
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
 }
 
 group = "org.modelix.mps"

--- a/model-api-gen-gradle/build.gradle.kts
+++ b/model-api-gen-gradle/build.gradle.kts
@@ -4,8 +4,7 @@ plugins {
     `java-gradle-plugin`
     java
 
-    // Apply the Kotlin JVM plugin to add support for Kotlin.
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
 }
 
 dependencies {

--- a/model-api-gen-runtime/build.gradle.kts
+++ b/model-api-gen-runtime/build.gradle.kts
@@ -1,30 +1,11 @@
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
 }
 
 val mpsExtensionsVersion: String by rootProject
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         all {
             languageSettings.optIn("kotlin.js.ExperimentalJsExport")

--- a/model-api-gen/build.gradle.kts
+++ b/model-api-gen/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     kotlin("plugin.serialization")
 }
 

--- a/model-api/build.gradle.kts
+++ b/model-api/build.gradle.kts
@@ -1,23 +1,12 @@
 plugins {
     `maven-publish`
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
 }
 
 description = "API to access models stored in Modelix"
 
 kotlin {
-    jvm()
-    js(IR) {
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -2,17 +2,11 @@ import dev.petuska.npm.publish.task.NpmPackTask
 
 plugins {
     `maven-publish`
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     alias(libs.plugins.spotless)
     alias(libs.plugins.npm.publish)
     `java-library`
     jacoco
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
 }
 
 val kotlinCoroutinesVersion: String by rootProject
@@ -21,26 +15,9 @@ val ktorVersion: String by rootProject
 val kotlinxSerializationVersion: String by rootProject
 
 kotlin {
-    jvmToolchain(11)
-    jvm()
     js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
         binaries.library()
         generateTypeScriptDefinitions()
-        useCommonJs()
     }
     sourceSets {
         val commonMain by getting {

--- a/model-client/integration-tests/build.gradle.kts
+++ b/model-client/integration-tests/build.gradle.kts
@@ -15,29 +15,11 @@
 // The solution with Docker Compose works for now
 // because the number of tests is small and only one container configuration is enough.
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     alias(libs.plugins.docker.compose)
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        useCommonJs()
-    }
     sourceSets {
         val commonTest by getting {
             dependencies {

--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -1,27 +1,9 @@
 plugins {
     `maven-publish`
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "30s"
-                }
-            }
-        }
-        useCommonJs()
-    }
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-datastructure/src/jvmTest/kotlin/org/modelix/model/InMemoryModelTest.kt
+++ b/model-datastructure/src/jvmTest/kotlin/org/modelix/model/InMemoryModelTest.kt
@@ -16,7 +16,6 @@
 
 package org.modelix.model
 
-import org.junit.Test
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.TreePointer
 import org.modelix.model.api.getRootNode
@@ -26,6 +25,7 @@ import org.modelix.model.lazy.ObjectStoreCache
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.persistent.CPTree
 import org.modelix.model.persistent.MapBasedStore
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class InMemoryModelTest {

--- a/model-server-api/build.gradle.kts
+++ b/model-server-api/build.gradle.kts
@@ -1,29 +1,10 @@
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/model-server-lib/build.gradle.kts
+++ b/model-server-lib/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     `maven-publish`
 }
 

--- a/model-server-test/build.gradle.kts
+++ b/model-server-test/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     alias(libs.plugins.docker.compose)
 }
 

--- a/model-server-test/build.gradle.kts
+++ b/model-server-test/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
 
 tasks.test {
     dependsOn(":model-server:compileTestKotlin")
-    useJUnitPlatform()
     doFirst {
         val db = dockerCompose.servicesInfos.getValue("db")
         systemProperty("jdbc.url", "jdbc:postgresql://${db.host}:${db.port}/")

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -84,10 +84,6 @@ dependencies {
     testImplementation(project(":modelql-untyped"))
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
-
 tasks.named<ShadowJar>("shadowJar") {
     archiveBaseName.set("model-server")
     archiveClassifier.set("fatJar")

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.spotless)
     alias(libs.plugins.test.logger)
     alias(libs.plugins.shadow)
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     kotlin("plugin.serialization")
     alias(libs.plugins.openapi.generator)
 }
@@ -18,12 +18,6 @@ plugins {
 description = "Model Server offering access to model storage"
 
 defaultTasks.add("build")
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-}
 
 val mpsExtensionsVersion: String by project
 

--- a/modelql-client/build.gradle.kts
+++ b/modelql-client/build.gradle.kts
@@ -12,30 +12,11 @@
  * limitations under the License.
  */
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -15,31 +15,12 @@ import org.modelix.registerVersionGenerationTask
  * limitations under the License.
  */
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-html/build.gradle.kts
+++ b/modelql-html/build.gradle.kts
@@ -14,31 +14,12 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  * limitations under the License.
  */
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-server/build.gradle.kts
+++ b/modelql-server/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     `maven-publish`
 }
 

--- a/modelql-typed/build.gradle.kts
+++ b/modelql-typed/build.gradle.kts
@@ -12,31 +12,12 @@
  * limitations under the License.
  */
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/modelql-untyped/build.gradle.kts
+++ b/modelql-untyped/build.gradle.kts
@@ -12,31 +12,12 @@
  * limitations under the License.
  */
 plugins {
-    kotlin("multiplatform")
+    `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")
     `maven-publish`
 }
 
 kotlin {
-    jvm()
-    js(IR) {
-        browser {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "10s"
-                }
-            }
-        }
-        useCommonJs()
-    }
-
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/mps-model-adapters-plugin/build.gradle.kts
+++ b/mps-model-adapters-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.modelix.copyMps
 
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm`
     alias(libs.plugins.intellij)
     id("modelix-project-repositories")
 }

--- a/mps-model-adapters-plugin/build.gradle.kts
+++ b/mps-model-adapters-plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import org.modelix.copyMps
 plugins {
     `modelix-kotlin-jvm`
     alias(libs.plugins.intellij)
-    id("modelix-project-repositories")
+    `modelix-project-repositories`
 }
 
 dependencies {

--- a/mps-model-adapters/build.gradle.kts
+++ b/mps-model-adapters/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.modelix.mpsHomeDir
 
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm-with-junit`
     `maven-publish`
 }
 

--- a/mps-model-server-plugin/build.gradle.kts
+++ b/mps-model-server-plugin/build.gradle.kts
@@ -1,8 +1,7 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.modelix.mpsHomeDir
 
 plugins {
-    kotlin("jvm")
+    `modelix-kotlin-jvm`
     alias(libs.plugins.intellij)
     id("modelix-project-repositories")
 }
@@ -19,22 +18,7 @@ intellij {
     instrumentCode = false
 }
 
-java {
-    sourceCompatibility = JavaVersion.toVersion(11)
-    targetCompatibility = JavaVersion.toVersion(11)
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
-    }
-}
-
 tasks {
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
-    }
-
     patchPluginXml {
         sinceBuild.set("203")
         untilBuild.set("241.*")

--- a/mps-model-server-plugin/build.gradle.kts
+++ b/mps-model-server-plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import org.modelix.mpsHomeDir
 plugins {
     `modelix-kotlin-jvm`
     alias(libs.plugins.intellij)
-    id("modelix-project-repositories")
+    `modelix-project-repositories`
 }
 
 dependencies {

--- a/ts-model-api/build.gradle.kts
+++ b/ts-model-api/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   base
   alias(libs.plugins.node)
   alias(libs.plugins.npm.publish)
-  id("modelix-project-repositories")
+  `modelix-project-repositories`
 }
 
 val npmRunBuild = tasks.named("npm_run_build") {

--- a/vue-model-api/build.gradle.kts
+++ b/vue-model-api/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     base
     alias(libs.plugins.node)
     alias(libs.plugins.npm.publish)
-    id("modelix-project-repositories")
+    `modelix-project-repositories`
 }
 
 val updateModelClient = tasks.register<NpmTask>("updateModelClient") {


### PR DESCRIPTION
Share the same kotlin config across the buildscripts. Unifies jvm version config and kotlin multiplatform js timeout

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
