### PR TITLE
ci: configure commit type "build" for Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,9 @@
     "config:best-practices",
     // Opt-in to beta support for pre-commit.
     // See https://docs.renovatebot.com/modules/manager/pre-commit/
-    ":enablePreCommit"
+    ":enablePreCommit",
+    // Use the same commit type as with Dependabot.
+    ":semanticCommitTypeAll(build)"
   ],
   enabledManagers: ["pre-commit"],
 }


### PR DESCRIPTION
"build" is the prefix we are using with Dependabot.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
