### PR TITLE
allow Authorization header to be sent from foreign origins

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -140,6 +140,7 @@ object Main {
                 install(CORS) {
                     anyHost()
                     allowHeader(HttpHeaders.ContentType)
+                    allowHeader(HttpHeaders.Authorization)
                     allowMethod(HttpMethod.Options)
                     allowMethod(HttpMethod.Get)
                     allowMethod(HttpMethod.Put)


### PR DESCRIPTION
needed for in-browser clients

So far, I receive a 403 for an OPTIONS request that includes `access-control-request-headers:Authorization`. This PR intends to fix that (I didn't test this locally yet).


For example:

```bash
# this command with httpie
http OPTIONS :28101/v2/generate-client-id access-control-request-method:POST access-control-request-headers: Origin:http://localhost:5173

# correctly gives that result
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Content-Type
Access-Control-Allow-Methods: OPTIONS, PUT
Access-Control-Allow-Origin: *
Access-Control-Max-Age: 86400
Connection: keep-alive
Content-Length: 0
```

```bash
# but this command with httpie
http OPTIONS :28101/v2/generate-client-id access-control-request-method:POST access-control-request-headers:Authorization Origin:http://localhost:5173

# errorneously gives that result (which should rather be a 200 imo)
HTTP/1.1 403 Forbidden
Connection: keep-alive
Content-Length: 0
```

```bash
# sending the request itself
http POST :28101/v2/generate-client-id access-control-request-method:POST access-control-request-headers:authorization Origin:http://localhost:5173 -A bearer -a eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJTRUNVUkUgUm…

# will succeed as expected
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 2
Content-Type: text/plain; charset=UTF-8

20
```

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
