### PR TITLE
fix(bulk-model-sync-gradle): fix MPS Runner configuration for server …

### DIFF
--- a/bulk-model-sync-gradle/build.gradle.kts
+++ b/bulk-model-sync-gradle/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(libs.modelix.buildtools.lib)
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.cio)
+    testImplementation(libs.kotest.assertions.coreJvm)
+    testImplementation(kotlin("test"))
 }
 
 kotlin {
@@ -35,4 +37,8 @@ val writeVersionFile by tasks.registering {
 }
 tasks.named("processResources") {
     dependsOn(writeVersionFile)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfiguration.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfiguration.kt
@@ -81,8 +81,13 @@ internal fun buildMpsRunConfigurationForLocalTarget(
             if (source is ServerSource && source.baseRevision != null) {
                 add("-Dmodelix.mps.model.sync.bulk.server.repository=${source.repositoryId}")
                 add("-Dmodelix.mps.model.sync.bulk.server.url=${source.url}")
-                add("-Dmodelix.mps.model.sync.bulk.server.version.hash=${source.revision}")
                 add("-Dmodelix.mps.model.sync.bulk.server.version.base.hash=${source.baseRevision}")
+                if (source.branchName != null) {
+                    add("-Dmodelix.mps.model.sync.bulk.server.branch=${source.branchName}")
+                }
+                if (source.revision != null) {
+                    add("-Dmodelix.mps.model.sync.bulk.server.version.hash=${source.revision}")
+                }
             }
         },
     )

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfiguration.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfiguration.kt
@@ -1,0 +1,93 @@
+package org.modelix.model.sync.bulk.gradle
+
+import org.modelix.buildtools.runner.BundledPluginPath
+import org.modelix.buildtools.runner.ExternalPluginPath
+import org.modelix.buildtools.runner.MPSRunnerConfig
+import org.modelix.buildtools.runner.PluginConfig
+import org.modelix.model.sync.bulk.gradle.config.BundledPluginSpec
+import org.modelix.model.sync.bulk.gradle.config.ExternalPluginSpec
+import org.modelix.model.sync.bulk.gradle.config.LocalSource
+import org.modelix.model.sync.bulk.gradle.config.LocalTarget
+import org.modelix.model.sync.bulk.gradle.config.PluginSpec
+import org.modelix.model.sync.bulk.gradle.config.ServerSource
+import org.modelix.model.sync.bulk.gradle.config.SyncDirection
+import java.io.File
+
+internal fun buildMpsRunConfigurationForLocalSources(
+    syncDirection: SyncDirection,
+    classPathElements: Set<File>,
+    jsonDir: File,
+): MPSRunnerConfig {
+    val source = requireNotNull(syncDirection.source)
+    val localSource = source as? LocalSource
+        ?: throw IllegalArgumentException("`syncDirection.source` is ${source::class.java} but should be ${LocalTarget::class.java}.")
+    val config = MPSRunnerConfig(
+        mainClassName = "org.modelix.mps.model.sync.bulk.MPSBulkSynchronizer",
+        mainMethodName = "exportRepository",
+        classPathElements = classPathElements.toList(),
+        mpsHome = localSource.mpsHome,
+        workDir = jsonDir,
+        additionalModuleDirs = localSource.mpsLibraries.toList() + listOfNotNull(localSource.repositoryDir),
+        plugins = createPluginConfig(localSource.mpsPlugins),
+        jvmArgs = listOfNotNull(
+            "-Dmodelix.mps.model.sync.bulk.output.path=${jsonDir.absolutePath}",
+            "-Dmodelix.mps.model.sync.bulk.output.modules=${syncDirection.includedModules.joinToString(",")}",
+            "-Dmodelix.mps.model.sync.bulk.output.modules.prefixes=${
+                syncDirection.includedModulePrefixes.joinToString(
+                    ",",
+                )
+            }",
+            "-Dmodelix.mps.model.sync.bulk.repo.path=${localSource.repositoryDir?.absolutePath}",
+            "-Xmx${localSource.mpsHeapSize}",
+            localSource.mpsDebugPort?.let { "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$it" },
+        ),
+    )
+    return config
+}
+
+internal fun buildMpsRunConfigurationForLocalTarget(
+    syncDirection: SyncDirection,
+    classPathElements: Set<File>,
+    jsonDir: File,
+): MPSRunnerConfig {
+    val target = requireNotNull(syncDirection.target)
+    val localTarget = target as? LocalTarget
+        ?: throw IllegalArgumentException("`syncDirection.target` is ${target::class.java} but should be ${LocalTarget::class.java}.")
+    val repositoryDir = checkNotNull(localTarget.repositoryDir) {
+        "syncDirection.target has no `repositoryDir` specified."
+    }
+    val hasBaseRevision = (syncDirection.source as? ServerSource)?.baseRevision != null
+    val config = MPSRunnerConfig(
+        mainClassName = "org.modelix.mps.model.sync.bulk.MPSBulkSynchronizer",
+        mainMethodName = if (hasBaseRevision) "importRepositoryFromModelServer" else "importRepository",
+        classPathElements = classPathElements.toList(),
+        mpsHome = localTarget.mpsHome,
+        workDir = jsonDir,
+        additionalModuleDirs = localTarget.mpsLibraries.toList() + repositoryDir,
+        plugins = createPluginConfig(localTarget.mpsPlugins),
+        jvmArgs = listOfNotNull(
+            "-Dmodelix.mps.model.sync.bulk.input.path=${jsonDir.absolutePath}",
+            "-Dmodelix.mps.model.sync.bulk.input.modules=${syncDirection.includedModules.joinToString(",")}",
+            "-Dmodelix.mps.model.sync.bulk.input.modules.prefixes=${syncDirection.includedModulePrefixes.joinToString(",")}",
+            "-Dmodelix.mps.model.sync.bulk.repo.path=${repositoryDir.absolutePath}",
+            "-Dmodelix.mps.model.sync.bulk.input.continueOnError=${syncDirection.continueOnError}",
+            "-Dmodelix.mps.model.sync.bulk.server.repository=${(syncDirection.source as ServerSource).repositoryId}".takeIf { hasBaseRevision },
+            "-Dmodelix.mps.model.sync.bulk.server.url=${(syncDirection.source as ServerSource).url}".takeIf { hasBaseRevision },
+            "-Dmodelix.mps.model.sync.bulk.server.version.hash=${(syncDirection.source as ServerSource).revision}".takeIf { hasBaseRevision },
+            "-Dmodelix.mps.model.sync.bulk.server.version.base.hash=${(syncDirection.source as ServerSource).baseRevision}".takeIf { hasBaseRevision },
+            "-Xmx${localTarget.mpsHeapSize}",
+            localTarget.mpsDebugPort?.let { "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$it" },
+        ),
+    )
+    return config
+}
+
+private fun createPluginConfig(mpsPlugins: Set<PluginSpec>): List<PluginConfig> {
+    return mpsPlugins.map {
+        val pluginPath = when (it) {
+            is BundledPluginSpec -> BundledPluginPath(it.folder)
+            is ExternalPluginSpec -> ExternalPluginPath(it.folder)
+        }
+        PluginConfig(it.id, pluginPath)
+    }
+}

--- a/bulk-model-sync-gradle/src/test/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfigurationTest.kt
+++ b/bulk-model-sync-gradle/src/test/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfigurationTest.kt
@@ -59,7 +59,7 @@ class MpsRunnerConfigurationTest {
             "-Dmodelix.mps.model.sync.bulk.input.continueOnError=false",
             "-Xmx2g",
             "-Dmodelix.mps.model.sync.bulk.server.repository=aRepositoryId",
-            "-Dmodelix.mps.model.sync.bulk.server.version.hash=null",
+            "-Dmodelix.mps.model.sync.bulk.server.branch=aBranchName",
             "-Dmodelix.mps.model.sync.bulk.server.url=aUrl",
             "-Dmodelix.mps.model.sync.bulk.server.version.base.hash=aBaseRevision",
         )

--- a/bulk-model-sync-gradle/src/test/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfigurationTest.kt
+++ b/bulk-model-sync-gradle/src/test/kotlin/org/modelix/model/sync/bulk/gradle/MpsRunnerConfigurationTest.kt
@@ -1,0 +1,99 @@
+package org.modelix.model.sync.bulk.gradle
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import org.modelix.model.sync.bulk.gradle.config.LocalTarget
+import org.modelix.model.sync.bulk.gradle.config.ServerSource
+import org.modelix.model.sync.bulk.gradle.config.SyncDirection
+import java.io.File
+import kotlin.test.Test
+
+class MpsRunnerConfigurationTest {
+
+    private val jsonDir = File("/jsonDir")
+    private val classPathElements = emptySet<File>()
+
+    @Test
+    fun `build configuration for local target with a server source without a base revision`() {
+        val serverSource = ServerSource(
+            url = "aUrl",
+            repositoryId = "aRepositoryId",
+            branchName = "aBranchName",
+        )
+        val localTarget = LocalTarget(repositoryDir = File("/repositoryDir"))
+        val syncDirection = SyncDirection("syncDirection", serverSource, localTarget)
+
+        val config = buildMpsRunConfigurationForLocalTarget(syncDirection, classPathElements, jsonDir)
+        val jvmArgs = config.jvmArgs
+
+        val expectedJvmArgs = listOf(
+            "-Dmodelix.mps.model.sync.bulk.input.path=/jsonDir",
+            "-Dmodelix.mps.model.sync.bulk.input.modules=",
+            "-Dmodelix.mps.model.sync.bulk.input.modules.prefixes=",
+            "-Dmodelix.mps.model.sync.bulk.repo.path=/repositoryDir",
+            "-Dmodelix.mps.model.sync.bulk.input.continueOnError=false",
+            "-Xmx2g",
+        )
+
+        jvmArgs shouldContainExactlyInAnyOrder expectedJvmArgs
+    }
+
+    @Test
+    fun `build configuration for local target with a server source with a base revision and branch name`() {
+        val serverSource = ServerSource(
+            url = "aUrl",
+            repositoryId = "aRepositoryId",
+            branchName = "aBranchName",
+            baseRevision = "aBaseRevision",
+        )
+        val localTarget = LocalTarget(repositoryDir = File("/repositoryDir"))
+        val syncDirection = SyncDirection("syncDirection", serverSource, localTarget)
+
+        val config = buildMpsRunConfigurationForLocalTarget(syncDirection, classPathElements, jsonDir)
+        val jvmArgs = config.jvmArgs
+
+        val expectedJvmArgs = listOf(
+            "-Dmodelix.mps.model.sync.bulk.input.path=/jsonDir",
+            "-Dmodelix.mps.model.sync.bulk.input.modules=",
+            "-Dmodelix.mps.model.sync.bulk.input.modules.prefixes=",
+            "-Dmodelix.mps.model.sync.bulk.repo.path=/repositoryDir",
+            "-Dmodelix.mps.model.sync.bulk.input.continueOnError=false",
+            "-Xmx2g",
+            "-Dmodelix.mps.model.sync.bulk.server.repository=aRepositoryId",
+            "-Dmodelix.mps.model.sync.bulk.server.version.hash=null",
+            "-Dmodelix.mps.model.sync.bulk.server.url=aUrl",
+            "-Dmodelix.mps.model.sync.bulk.server.version.base.hash=aBaseRevision",
+        )
+
+        jvmArgs shouldContainExactlyInAnyOrder expectedJvmArgs
+    }
+
+    @Test
+    fun `build configuration for local target with a server source with a base revision and revision`() {
+        val serverSource = ServerSource(
+            url = "aUrl",
+            repositoryId = "aRepositoryId",
+            revision = "aRevisionToSync",
+            baseRevision = "aBaseRevision",
+        )
+        val localTarget = LocalTarget(repositoryDir = File("/repositoryDir"))
+        val syncDirection = SyncDirection("syncDirection", serverSource, localTarget)
+
+        val config = buildMpsRunConfigurationForLocalTarget(syncDirection, classPathElements, jsonDir)
+        val jvmArgs = config.jvmArgs
+
+        val expectedJvmArgs = listOf(
+            "-Dmodelix.mps.model.sync.bulk.input.path=/jsonDir",
+            "-Dmodelix.mps.model.sync.bulk.input.modules=",
+            "-Dmodelix.mps.model.sync.bulk.input.modules.prefixes=",
+            "-Dmodelix.mps.model.sync.bulk.repo.path=/repositoryDir",
+            "-Dmodelix.mps.model.sync.bulk.input.continueOnError=false",
+            "-Xmx2g",
+            "-Dmodelix.mps.model.sync.bulk.server.repository=aRepositoryId",
+            "-Dmodelix.mps.model.sync.bulk.server.url=aUrl",
+            "-Dmodelix.mps.model.sync.bulk.server.version.base.hash=aBaseRevision",
+            "-Dmodelix.mps.model.sync.bulk.server.version.hash=aRevisionToSync",
+        )
+
+        jvmArgs shouldContainExactlyInAnyOrder expectedJvmArgs
+    }
+}


### PR DESCRIPTION
…sources with base revision

When a base revision was specified, the specified branch was not passed as a system property to the bulk sync.

When a base revision was specified without a source revision, the property value for the source revision was the string `"null"`.

To write test with TestKit we would need further adjustments to the build setup. For this fix, I considered them out of scope.

I tried to test execution with Gradles TestKit first. See https://docs.gradle.org/current/userguide/test_kit.html But the Plugin tries to download the package "org.modelix:bulk-model-sync-mps" as `mpsDependencies`. The names of the downloaded files are then used as `classPathElements` in the MPS Runner configuration. Therefore, the plugin cannot be tested with TestKit without publishing "org.modelix:bulk-model-sync-mps" and its dependents locally or including the "modelix.core" project from within a test execution.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
