### PR TITLE
fix(mps-model-adapters): resolve language dependency correctly in `MPSModuleAsNode`

### DIFF
--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNodeTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNodeTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.modelix.model.mpsadapters
+
+import org.modelix.model.api.INode
+import org.modelix.model.api.NodeReference
+
+class MPSModuleAsNodeTest : MpsAdaptersTestBase("SimpleProject") {
+
+    fun `test resolve language dependency from reference`() {
+        val repositoryNode: INode = MPSRepositoryAsNode(mpsProject.repository)
+        val languageDependencyNodeReference = NodeReference(
+            "mps-lang:f3061a53-9226-4cc5-a443-f952ceaf5816#IN#mps-module:6517ba0d-f632-49c5-a166-401587c2c3ca(Solution1)",
+        )
+
+        val resolvedLanguageDependency = readAction {
+            repositoryNode.getArea().resolveNode(languageDependencyNodeReference)
+        }
+
+        assertNotNull(resolvedLanguageDependency)
+        assertEquals(languageDependencyNodeReference.serialize(), resolvedLanguageDependency!!.reference.serialize())
+    }
+}

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
@@ -183,9 +183,11 @@ data class MPSModuleAsNode(val module: SModule) : IDefaultNodeAdapter {
         if (module !is AbstractModule) {
             return null
         }
-        module.moduleDescriptor?.dependencyVersions?.forEach { entry ->
-            if (entry.key.moduleId == dependencyId) {
-                return MPSSingleLanguageDependencyAsNode(entry.key, entry.value, moduleImporter = module)
+        val languageDependencies = module.moduleDescriptor?.languageVersions
+        languageDependencies?.forEach { entry ->
+            val sourceModelReference = entry.key.sourceModuleReference
+            if (sourceModelReference.moduleId == dependencyId) {
+                return MPSSingleLanguageDependencyAsNode(sourceModelReference, entry.value, moduleImporter = module)
             }
         }
         return null


### PR DESCRIPTION
Fixes a wrong lookup in `findSingleLanguageDependency`.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
