### PR TITLE
MODELIX-1008 Sync with subtree skipping fails syncing new node to MPS

### DIFF
--- a/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelSynchronizerWithInvalidationTreeTest.kt
+++ b/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelSynchronizerWithInvalidationTreeTest.kt
@@ -27,12 +27,11 @@ import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.ObjectStoreCache
 import org.modelix.model.operations.OTBranch
 import org.modelix.model.persistent.MapBasedStore
-import org.modelix.model.sync.bulk.ModelSynchronizerTest.BasicAssociation
 import org.modelix.model.test.RandomModelChangeGenerator
 import kotlin.random.Random
 import kotlin.test.assertTrue
 
-class ModelSynchronizerWithInvalidationTreeTest : AbstractModelSyncTest() {
+class ModelSynchronizerWithInvalidationTreeTest : ModelSynchronizerTest() {
 
     override fun runTest(initialData: ModelData, expectedData: ModelData, assertions: OTBranch.() -> Unit) {
         val sourceBranch = createOTBranchFromModel(expectedData)


### PR DESCRIPTION
The test cases can not be easily generalized.
It is fine to test this only for the ModelSynchronizer because bulk-model-sync-gradle-test already covers these cases for the ModelImporter.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
