### PR TITLE
build: do not cache output of NPX tasks if package-lock.json changes

### DIFF
--- a/model-server-openapi/build.gradle.kts
+++ b/model-server-openapi/build.gradle.kts
@@ -19,6 +19,7 @@ val bundleSpecs = tasks.register<NpxTask>("bundleSpecs") {
 
     dependsOn(tasks.getByName("npmInstall"))
 
+    inputs.file("package-lock.json")
     inputs.dir(specDir)
 
     outputs.cacheIf { true }
@@ -33,8 +34,10 @@ val joinSpecs = tasks.register<NpxTask>("joinSpecs") {
     description = "combines all OpenAPI specifications into a single one"
 
     dependsOn(tasks.getByName("npmInstall"))
+
     dependsOn(bundleSpecs)
 
+    inputs.file("package-lock.json")
     inputs.dir(bundleDir)
 
     outputs.cacheIf { true }


### PR DESCRIPTION
A PR with a new Redocly version should have failed because of a bug, but it did not because we cached the results. 

See https://github.com/modelix/modelix.core/pull/1037 
See https://github.com/Redocly/redocly-cli/issues/1715

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
