### PR TITLE
fix(model-datastructure): correctly calculate linear history between the same version

### DIFF
--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/LinearHistory.kt
@@ -24,9 +24,9 @@ class LinearHistory(private val baseVersionHash: String?) {
     private val byVersionDistanceFromGlobalRoot = mutableMapOf<CLVersion, Int>()
 
     /**
-     * Returns all versions between the [fromVersions] and a common version.
+     * Returns all versions between the [fromVersions] (inclusive) and a common version (inclusive).
      * The common version may be identified by [baseVersionHash].
-     * If no [baseVersionHash] is given, the common version wile be the first version
+     * If no [baseVersionHash] is given, the common version will be the first version
      * aka the version without a [CLVersion.baseVersion].
      *
      * The order also ensures three properties:
@@ -35,14 +35,14 @@ class LinearHistory(private val baseVersionHash: String?) {
      *    This means adding a version to the set of all versions will never change
      *    the order of versions that were previously in the history.
      *    For example, given versions 1, 2 and 3:
-     *      If 1 and 2 are ordered as (1, 2), ordering 1, 2 and 3 will never produce (2, 3, 1).
-     *      3 can come anywhere (respecting the topological ordering), but 2 has to come after 1.
+     *      If 1 and 2 are ordered as (1, 2), ordering 1, 2 and x will never produce (2, x, 1).
+     *      x can come anywhere (respecting the topological ordering), but 2 has to come after 1.
      * 3. "Close versions are kept together"
-     *    Formally: A version that has only one child (ignoring) should always come before the child.
-     *      Example: 1 <- 2 <- 3 and 1 <- x, then [1, 2, 4, 3] is not allowed,
+     *    Formally: A version that has only one child should always come before the child.
+     *      Example: 1 <- 2 <- 3 and 1 <- x, then [1, 2, x, 3] is not allowed,
      *      because 3 is the only child of 2.
-     *      Valid orders would be (1, x, 3, 4) and (1, x, 2, 3)
-     *    This is relevant for UnduOp and RedoOp.
+     *      Valid orders would be (1, 2, 3, x) and (1, x, 2, 3)
+     *    This is relevant for UndoOp and RedoOp.
      *    See UndoTest.
      */
     fun load(vararg fromVersions: CLVersion): List<CLVersion> {
@@ -128,6 +128,9 @@ class LinearHistory(private val baseVersionHash: String?) {
     }
 
     private fun CLVersion.getParents(): List<CLVersion> {
+        if (this.getContentHash() == baseVersionHash) {
+            return emptyList()
+        }
         val ancestors = if (isMerge()) {
             listOf(getMergedVersion1()!!, getMergedVersion2()!!)
         } else {

--- a/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
@@ -29,6 +29,32 @@ class LinearHistoryTest {
     private val initialTree = CLTree.builder(ObjectStoreCache(MapBasedStore())).repositoryId("LinearHistoryTest").build()
 
     @Test
+    fun baseVersionAndFromVersionAreIncluded() {
+        val v1 = version(1, null)
+        val v2 = version(2, v1)
+        val v3 = version(3, v2)
+
+        assertHistory(v2, v3, listOf(v2, v3))
+    }
+
+    @Test
+    fun linearHistoryBetweenSameVersion() {
+        val v1 = version(1, null)
+        val v2 = version(2, v1)
+
+        assertHistory(v2, v2, listOf(v2))
+    }
+
+    @Test
+    fun linearHistoryBetweenAVersionAndItsBaseVersion() {
+        val v1 = version(1, null)
+        val v2 = version(2, v1)
+        val v3 = version(3, v2)
+
+        assertHistory(v2, v3, listOf(v2, v3))
+    }
+
+    @Test
     fun noCommonHistory() {
         val v20 = version(20, null)
         val v21 = version(21, null)


### PR DESCRIPTION
Previously, calculating the linear history between the same version resulted in linear history that contained more than only that one version.

This in turn resulted in needles computations and deltas that were too big.

Fixes: MODELIX-1025

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
