### PR TITLE
build(deps): fix version of ws to mitigate CVE-2024-37890

### DIFF
--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -974,6 +974,11 @@ ws@8.5.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
   integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
+ws@^8.17.1:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
 ws@^8.9.0:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -75,6 +75,9 @@ kotlin {
                 implementation(npm("uuid", "^8.3.0"))
                 implementation(npm("js-sha256", "^0.9.0"))
                 implementation(npm("js-base64", "^3.4.5"))
+
+                // Version fixed because of CVE-2024-37890
+                implementation(npm("ws", "^8.17.1"))
             }
         }
     }


### PR DESCRIPTION
Updated the  [ws npm dependency](https://www.npmjs.com/package/ws) in the `model-client` module to mitigate  [CVE-2024-37890](https://nvd.nist.gov/vuln/detail/CVE-2024-37890) which was fixed with version [8.17.1](https://github.com/websockets/ws/releases/tag/8.17.1)

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
