### PR TITLE
build(model-client): remove jacoco Gradle plugin

### DIFF
--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
     `modelix-kotlin-multiplatform`
     alias(libs.plugins.spotless)
     alias(libs.plugins.npm.publish)
-    `java-library`
-    jacoco
 }
 
 val kotlinCoroutinesVersion: String by rootProject
@@ -80,17 +78,6 @@ kotlin {
                 implementation(npm("ws", "^8.17.1"))
             }
         }
-    }
-}
-
-tasks.jacocoTestReport {
-    classDirectories.setFrom(project.layout.buildDirectory.dir("classes/kotlin/jvm/"))
-    sourceDirectories.setFrom(files("src/commonMain/kotlin", "src/jvmMain/kotlin"))
-    executionData.setFrom(project.layout.buildDirectory.file("jacoco/jvmTest.exec"))
-
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
     }
 }
 


### PR DESCRIPTION
Coverage is reported with kotlinx-kover.
Remove the `java-library` plugin as it was only necessary for the `jacoco` plugin.

This also solves the warning of incompatibility between `java-library` and `kotlin("multiplatform")`.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
