### PR TITLE
build(model-client): change Gradle configuration to avoid failing import into Intellij

### DIFF
--- a/model-client/integration-tests/build.gradle.kts
+++ b/model-client/integration-tests/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinTest
+
 // Tests for a model client that cannot run in isolation.
 // One such case is starting a server and using the model client from JS at the same time.
 // This integration tests start a mock server with Docker Compose.
@@ -45,6 +47,11 @@ kotlin {
     }
 }
 
-dockerCompose.isRequiredBy(tasks.named("jsBrowserTest"))
-dockerCompose.isRequiredBy(tasks.named("jsNodeTest"))
-dockerCompose.isRequiredBy(tasks.named("jvmTest"))
+// The tasks "jsNodeTest" and "jsBrowserTest" are of this type.
+tasks.withType(KotlinTest::class).all {
+    dockerCompose.isRequiredBy(this)
+}
+// The task "jvmTest" is of this type.
+tasks.withType(Test::class).all {
+    dockerCompose.isRequiredBy(this)
+}


### PR DESCRIPTION
Calling `dockerCompose.isRequiredBy(tasks.named("jsNodeTest"))` with `org.gradle.parallel=true` caused issues when running the Gradle task `prepareKotlinIdeaImport`. That task was run by Intellij when trying to import the Gradle project. The import failed when the task failed.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
