### PR TITLE
fix(vue-model-api): do not evict ReactiveINodeJS from cache when objects manged by it are still used

### DIFF
--- a/vue-model-api/package.json
+++ b/vue-model-api/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc --build",
-    "test": "jest",
+    "test": "node --expose-gc node_modules/.bin/jest",
     "prettier": "prettier . --check",
     "prettier:fix": "npm run prettier -- --write"
   },

--- a/vue-model-api/src/internal/Cache.test.ts
+++ b/vue-model-api/src/internal/Cache.test.ts
@@ -1,5 +1,6 @@
 import type { INodeJS } from "@modelix/ts-model-api";
 import { Cache } from "./Cache";
+import { runGarbageCollection } from "./runGarbageCollection";
 
 test("wrapper is added to cache", () => {
   const cache = new Cache<{ id: string }>();
@@ -16,4 +17,17 @@ test("wrapper is added to cache", () => {
   expect(wrapped1.id).toBe("aWrapper1");
   const wrapped2 = cache.memoize(node, wrap2);
   expect(wrapped2.id).toBe("aWrapper1");
+});
+
+test("wrapper is removed from cache after garbage collection", async () => {
+  const iNode = {
+    getReference() {
+      return "myKey";
+    },
+  } as INodeJS;
+  const cache = new Cache();
+  cache.memoize(iNode, () => ({}));
+  expect(cache.get(iNode)).not.toBeUndefined();
+  await runGarbageCollection();
+  expect(cache.get(iNode)).toBeUndefined();
 });

--- a/vue-model-api/src/internal/ReactiveINodeJS.ts
+++ b/vue-model-api/src/internal/ReactiveINodeJS.ts
@@ -148,9 +148,7 @@ export class ReactiveINodeJS implements INodeJS {
       index,
       concept,
     );
-    return unreacitveNode
-      ? toReactiveINodeJS(unreacitveNode, this.cache)
-      : unreacitveNode;
+    return toReactiveINodeJS(unreacitveNode, this.cache);
   }
 
   removeChild(child: INodeJS): void {
@@ -182,10 +180,6 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   setReferenceTargetNode(role: string, target: INodeJS | undefined): void {
-    // Do not call `this.unreactiveNode.setReferenceTargetNode` directly,
-    // because the target is declared as `INodeJS`, but actuall an `NodeAdapterJS` is expected.
-    // Just using the reference is cleaner then unwrapping
-    // then checking for ReactiveINodeJS and eventuall unwrapping it
     return this.unreactiveNode.setReferenceTargetNode(
       role,
       unwrapReactiveINodeJS(target),

--- a/vue-model-api/src/internal/ReactiveINodeJS.ts
+++ b/vue-model-api/src/internal/ReactiveINodeJS.ts
@@ -143,6 +143,8 @@ export class ReactiveINodeJS implements INodeJS {
     index: number,
     concept: IConceptJS | undefined,
   ): INodeJS {
+    // The related Vue-`Ref` does not need to be triggered.
+    // It will be updated through the changed listener of the branch.
     const unreactiveNode = this.unreactiveNode.addNewChild(
       role,
       index,
@@ -180,6 +182,8 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   setReferenceTargetNode(role: string, target: INodeJS | undefined): void {
+    // The related Vue-`Ref` does not need to be triggered.
+    // It will be updated through the changed listener of the branch.
     return this.unreactiveNode.setReferenceTargetNode(
       role,
       unwrapReactiveINodeJS(target),
@@ -190,6 +194,8 @@ export class ReactiveINodeJS implements INodeJS {
     role: string,
     target: INodeReferenceJS | undefined,
   ): void {
+    // The related Vue-`Ref` does not need to be triggered.
+    // It will be updated through the changed listener of the branch.
     this.unreactiveNode.setReferenceTargetRef(role, target);
   }
 
@@ -209,6 +215,8 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   setPropertyValue(role: string, value: string | undefined): void {
+    // The related Vue-`Ref` does not need to be triggered.
+    // It will be updated through the changed listener of the branch.
     this.unreactiveNode.setPropertyValue(role, value);
   }
 

--- a/vue-model-api/src/internal/ReactiveINodeJS.ts
+++ b/vue-model-api/src/internal/ReactiveINodeJS.ts
@@ -11,12 +11,12 @@ export function toReactiveINodeJS(
   return cache.memoize(node, () => new ReactiveINodeJS(node, cache));
 }
 
-// This declaration specifies the types of the implemenation in `unwrapReactiveINodeJS` further.
+// This declaration specifies the types of the implementation in `unwrapReactiveINodeJS` further.
 // It declares, that when
 // * an `INodeJS` is given an `INodeJS` is returned
 // * an `undefined` is given an `undefined` is returned
 // * an `null` is given an `null` is returned
-// This so called conditional types help avoid unneed assertsion about types on the usage site.
+// This so called conditional types help avoid unneeded assertions about types on the usage site.
 // See. https://www.typescriptlang.org/docs/handbook/2/conditional-types.html
 function unwrapReactiveINodeJS<T extends INodeJS | null | undefined>(
   maybeReactive: T,
@@ -34,7 +34,7 @@ function unwrapReactiveINodeJS(
   }
 }
 
-// `any` is currectly provided as the type for references from `@modelix/ts-model-api`,
+// `any` is correctly provided as the type for references from `@modelix/ts-model-api`,
 // so we have to work with it for now.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type INodeReferenceJS = any;
@@ -108,10 +108,10 @@ export class ReactiveINodeJS implements INodeJS {
 
   getParent(): INodeJS | undefined {
     // This does not need to be made reacitve for the same reason as getRoleInParent
-    const unreacitveNode = this.unreactiveNode.getParent();
-    return unreacitveNode
-      ? toReactiveINodeJS(unreacitveNode, this.cache)
-      : unreacitveNode;
+    const unreactiveNode = this.unreactiveNode.getParent();
+    return unreactiveNode
+      ? toReactiveINodeJS(unreactiveNode, this.cache)
+      : unreactiveNode;
   }
 
   remove(): void {
@@ -143,12 +143,12 @@ export class ReactiveINodeJS implements INodeJS {
     index: number,
     concept: IConceptJS | undefined,
   ): INodeJS {
-    const unreacitveNode = this.unreactiveNode.addNewChild(
+    const unreactiveNode = this.unreactiveNode.addNewChild(
       role,
       index,
       concept,
     );
-    return toReactiveINodeJS(unreacitveNode, this.cache);
+    return toReactiveINodeJS(unreactiveNode, this.cache);
   }
 
   removeChild(child: INodeJS): void {
@@ -200,7 +200,11 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   getPropertyValue(role: string): string | undefined {
-    const ref = this.getOrCreateRefForRole(this.byRoleRefToProperty, role, this.propertyGetter);
+    const ref = this.getOrCreateRefForRole(
+      this.byRoleRefToProperty,
+      role,
+      this.propertyGetter,
+    );
     return ref.value;
   }
 

--- a/vue-model-api/src/internal/ReactiveINodeJS.ts
+++ b/vue-model-api/src/internal/ReactiveINodeJS.ts
@@ -1,6 +1,8 @@
 import type { IConceptJS, INodeJS } from "@modelix/ts-model-api";
-import { customRef, markRaw } from "vue";
+import type { Ref } from "vue";
+import { markRaw, shallowRef } from "vue";
 import type { Cache } from "./Cache";
+import type { Nullable } from "@modelix/model-client";
 
 export function toReactiveINodeJS(
   node: INodeJS,
@@ -37,15 +39,19 @@ function unwrapReactiveINodeJS(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type INodeReferenceJS = any;
 
-interface TrackAndTrigger {
-  track: () => void;
-  trigger: () => void;
-}
-
 export class ReactiveINodeJS implements INodeJS {
-  private byRoleTrackAndTrigger: Map<string | undefined, TrackAndTrigger> =
+  private byRoleRefToProperty: Map<string, Ref<string | undefined>> = new Map();
+  private byRoleRefToReferenceTargetNode: Map<
+    string,
+    Ref<INodeJS | undefined>
+  > = new Map();
+  private byRoleRefToReferenceTargetRef: Map<
+    string,
+    Ref<INodeReferenceJS | undefined>
+  > = new Map();
+  private byRoleRefToChildren: Map<string | undefined, Ref<INodeJS[]>> =
     new Map();
-  private trackAndTriggerForAllChildren: TrackAndTrigger | undefined;
+  private refForAllChildren: Ref<INodeJS[]> | undefined = undefined;
 
   constructor(
     public readonly unreactiveNode: INodeJS,
@@ -55,6 +61,30 @@ export class ReactiveINodeJS implements INodeJS {
     // see. https://vuejs.org/api/reactivity-advanced.html#markraw
     markRaw(this);
   }
+
+  private propertyGetter = (role: string) =>
+    this.unreactiveNode.getPropertyValue(role);
+
+  private referenceTargetRefGetter = (role: string) =>
+    this.unreactiveNode.getReferenceTargetRef(role);
+
+  private referenceTargetNodeGetter = (role: string) => {
+    const unreactiveTargetNode =
+      this.unreactiveNode.getReferenceTargetNode(role);
+    return unreactiveTargetNode
+      ? toReactiveINodeJS(unreactiveTargetNode, this.cache)
+      : unreactiveTargetNode;
+  };
+
+  private childrenGetter = (role: string | undefined) =>
+    this.unreactiveNode
+      .getChildren(role)
+      .map((node) => toReactiveINodeJS(node, this.cache));
+
+  private allChildrenGetter = () =>
+    this.unreactiveNode
+      .getAllChildren()
+      .map((node) => toReactiveINodeJS(node, this.cache));
 
   getConcept(): IConceptJS | undefined {
     return this.unreactiveNode.getConcept();
@@ -89,19 +119,19 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   getChildren(role: string | undefined): INodeJS[] {
-    const { track } = this.getOrCreateTrackAndTriggerForRole(role);
-    track();
-    return this.unreactiveNode
-      .getChildren(role)
-      .map((node) => toReactiveINodeJS(node, this.cache));
+    const ref = this.getOrCreateRefForRole(
+      this.byRoleRefToChildren,
+      role,
+      this.childrenGetter,
+    );
+    return ref.value;
   }
 
   getAllChildren(): INodeJS[] {
-    const { track } = this.getOrCreateTrackAndTriggerForAllChildren();
-    track();
-    return this.unreactiveNode
-      .getAllChildren()
-      .map((node) => toReactiveINodeJS(node, this.cache));
+    if (this.refForAllChildren == undefined) {
+      this.refForAllChildren = shallowRef(this.allChildrenGetter());
+    }
+    return this.refForAllChildren!.value;
   }
 
   moveChild(role: string | undefined, index: number, child: INodeJS): void {
@@ -134,18 +164,21 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   getReferenceTargetNode(role: string): INodeJS | undefined {
-    const { track } = this.getOrCreateTrackAndTriggerForRole(role);
-    track();
-    const unreacitveNode = this.unreactiveNode.getReferenceTargetNode(role);
-    return unreacitveNode
-      ? toReactiveINodeJS(unreacitveNode, this.cache)
-      : unreacitveNode;
+    const ref = this.getOrCreateRefForRole(
+      this.byRoleRefToReferenceTargetNode,
+      role,
+      this.referenceTargetNodeGetter,
+    );
+    return ref.value;
   }
 
   getReferenceTargetRef(role: string): INodeReferenceJS | undefined {
-    const { track } = this.getOrCreateTrackAndTriggerForRole(role);
-    track();
-    return this.unreactiveNode.getReferenceTargetRef(role);
+    const ref = this.getOrCreateRefForRole(
+      this.byRoleRefToReferenceTargetRef,
+      role,
+      this.referenceTargetRefGetter,
+    );
+    return ref.value;
   }
 
   setReferenceTargetNode(role: string, target: INodeJS | undefined): void {
@@ -173,69 +206,57 @@ export class ReactiveINodeJS implements INodeJS {
   }
 
   getPropertyValue(role: string): string | undefined {
-    const { track } = this.getOrCreateTrackAndTriggerForRole(role);
-    track();
-    return this.unreactiveNode.getPropertyValue(role);
+    const ref = this.getOrCreateRefForRole(this.byRoleRefToProperty, role, this.propertyGetter);
+    return ref.value;
   }
 
   setPropertyValue(role: string, value: string | undefined): void {
     this.unreactiveNode.setPropertyValue(role, value);
   }
 
-  private getOrCreateTrackAndTriggerForAllChildren(): TrackAndTrigger {
-    if (this.trackAndTriggerForAllChildren === undefined) {
-      customRef((track, trigger) => {
-        this.trackAndTriggerForAllChildren = {
-          track,
-          trigger,
-        };
-        return {
-          // Getter and setter ar empty for the same reason as in `getOrCreateTrackAndTriggerForRole`
-          get() {},
-          set() {},
-        };
-      });
+  getOrCreateRefForRole<RoleT, ValueT>(
+    byRoleRefs: Map<RoleT, Ref<ValueT>>,
+    role: RoleT,
+    getValue: (role: RoleT) => ValueT,
+  ): Ref<ValueT> {
+    const maybeCreatedShallowRef = byRoleRefs.get(role);
+
+    if (maybeCreatedShallowRef != undefined) {
+      return maybeCreatedShallowRef;
+    } else {
+      const newRef = shallowRef(getValue(role));
+      byRoleRefs.set(role, newRef);
+      return newRef;
     }
-    // `this.trackAndTriggerForAllChildren` will always be set, because the `factory`
-    // argument of `customRef` will be evaluated immedialty.
-    return this.trackAndTriggerForAllChildren!;
   }
 
-  private getOrCreateTrackAndTriggerForRole(
-    role: string | undefined,
-  ): TrackAndTrigger {
-    const existing = this.byRoleTrackAndTrigger.get(role);
-    if (existing !== undefined) {
-      return existing;
+  triggerChangeInChild(role: Nullable<string>) {
+    if (this.refForAllChildren) {
+      this.refForAllChildren.value = this.allChildrenGetter();
     }
-    let created;
-    customRef((track, trigger) => {
-      created = {
-        track,
-        trigger,
-      };
-      this.byRoleTrackAndTrigger.set(role, created);
-      return {
-        // The getters and setters will never be called directly
-        // and therefore the are empty.
-        // We use `customRef` to get access to a pair of `trigger` and `track`
-        // to call them directly from outside.
-        get() {},
-        set() {},
-      };
-    });
-    // `created` will always be set, because the `factory`
-    // argument of `customRef` will be evaluated immedialty.
-    return created!;
+
+    const normalizedRole = role ?? undefined;
+    const maybeRef = this.byRoleRefToChildren.get(normalizedRole);
+    if (maybeRef) {
+      maybeRef.value = this.childrenGetter(normalizedRole);
+    }
   }
 
-  triggerChangeInRole(role: string | undefined | null) {
-    const normalizedRole =
-      role !== undefined && role !== null ? role : undefined;
-    this.byRoleTrackAndTrigger.get(normalizedRole)?.trigger();
+  triggerChangeInReference(role: string) {
+    const maybeTargetNodeRef = this.byRoleRefToReferenceTargetNode.get(role);
+    if (maybeTargetNodeRef) {
+      maybeTargetNodeRef.value = this.referenceTargetNodeGetter(role);
+    }
+    const maybeTargetRefRef = this.byRoleRefToReferenceTargetRef.get(role);
+    if (maybeTargetRefRef) {
+      maybeTargetRefRef.value = this.referenceTargetRefGetter(role);
+    }
   }
 
-  triggerChangeInAllChildren() {
-    this.trackAndTriggerForAllChildren?.trigger();
+  triggerChangeInProperty(role: string) {
+    const maybeRef = this.byRoleRefToProperty.get(role);
+    if (maybeRef) {
+      maybeRef.value = this.propertyGetter(role);
+    }
   }
 }

--- a/vue-model-api/src/internal/handleChange.ts
+++ b/vue-model-api/src/internal/handleChange.ts
@@ -9,15 +9,15 @@ type ChangeJS = org.modelix.model.client2.ChangeJS;
 
 export function handleChange(change: ChangeJS, cache: Cache<ReactiveINodeJS>) {
   const unreactiveNode = change.node;
-  const reacitveNode = cache.get(unreactiveNode);
-  if (reacitveNode === undefined) {
+  const reactiveNode = cache.get(unreactiveNode);
+  if (reactiveNode === undefined) {
     return;
   }
   if (change instanceof PropertyChanged) {
-    reacitveNode.triggerChangeInProperty(change.role);
+    reactiveNode.triggerChangeInProperty(change.role);
   } else if (change instanceof ReferenceChanged) {
-    reacitveNode.triggerChangeInReference(change.role);
+    reactiveNode.triggerChangeInReference(change.role);
   } else if (change instanceof ChildrenChanged) {
-    reacitveNode.triggerChangeInChild(change.role);
+    reactiveNode.triggerChangeInChild(change.role);
   }
 }

--- a/vue-model-api/src/internal/handleChange.ts
+++ b/vue-model-api/src/internal/handleChange.ts
@@ -13,10 +13,11 @@ export function handleChange(change: ChangeJS, cache: Cache<ReactiveINodeJS>) {
   if (reacitveNode === undefined) {
     return;
   }
-  if (change instanceof PropertyChanged || change instanceof ReferenceChanged) {
-    reacitveNode.triggerChangeInRole(change.role);
+  if (change instanceof PropertyChanged) {
+    reacitveNode.triggerChangeInProperty(change.role);
+  } else if (change instanceof ReferenceChanged) {
+    reacitveNode.triggerChangeInReference(change.role);
   } else if (change instanceof ChildrenChanged) {
-    reacitveNode.triggerChangeInRole(change.role);
-    reacitveNode.triggerChangeInAllChildren();
+    reacitveNode.triggerChangeInChild(change.role);
   }
 }

--- a/vue-model-api/src/internal/runGarbageCollection.test.ts
+++ b/vue-model-api/src/internal/runGarbageCollection.test.ts
@@ -1,0 +1,7 @@
+import { runGarbageCollection } from "./runGarbageCollection";
+
+test("test garbage collection invocation", async () => {
+  const weakRef = new WeakRef({});
+  await runGarbageCollection();
+  expect(weakRef.deref()).toBeUndefined();
+});

--- a/vue-model-api/src/internal/runGarbageCollection.ts
+++ b/vue-model-api/src/internal/runGarbageCollection.ts
@@ -1,0 +1,16 @@
+/**
+ * Force garbage collection to run.
+ * See https://github.com/orgs/nodejs/discussions/36467
+ **/
+export async function runGarbageCollection() {
+  // Enqueue a micro task is needed to run before garbage collection
+  // See https://github.com/orgs/nodejs/discussions/36467#discussioncomment-3367722
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  if (global.gc) {
+    global.gc();
+  } else {
+    fail(
+      "Garbage collection unavailable. Pass --expose-gc when launching node to enable forced garbage collection.",
+    );
+  }
+}

--- a/vue-model-api/src/internal/useLastPromiseEffect.ts
+++ b/vue-model-api/src/internal/useLastPromiseEffect.ts
@@ -3,14 +3,14 @@ import { watchEffect } from "vue";
 /**
  * This function takes a `promiseEffect` callback and executes it every time its used reactive values are changed.
  *
- * If a promise is fullfilled, the `onfulfilled` call back is called with the value and aboolean,
+ * If a promise is fulfilled, the `onfulfilled` call back is called with the value and a boolean,
  * which indicates if the value is the result of the last create promise.
  *
  * If a promise is rejected, the `onrejected` call back is called with the reason and a boolean,
  * which indicates if the value is the result of the last create promise.
  *
- * This function is usefull, if you need to trigger a new promise every time some reavtive value changes and
- * then need to distinguashe if the value/error of the settled promise comes from the last started promise.
+ * This function is useful, if you need to trigger a new promise every time some reavtive value changes and
+ * then need to distinguish if the value/error of the settled promise comes from the last started promise.
  *
  * @param promiseEffect A function that may create a new promise.
  *
@@ -30,7 +30,7 @@ export function useLastPromiseEffect<ValueT>(
     const thisPromise = promiseEffect();
     lastStartedPromise = thisPromise;
     const isResultOfLastStartedPromise = () =>
-      // `lastStartedPromise` might be diffrent to `thisPromise`,
+      // `lastStartedPromise` might be different to `thisPromise`,
       // because this function gets called asynchronously, when `thisPromise` is settled.
       // In the meantime `promiseEffect()` might have been called again and assigned a new value to `lastStartedPromise`.
       lastStartedPromise == thisPromise;

--- a/vue-model-api/tsconfig.json
+++ b/vue-model-api/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/recommended/tsconfig.json",
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/runGarbageCollection.ts"],
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",


### PR DESCRIPTION
Garbage collection broke the `vue-model-api` as shown the added test.
Correctly using Vue refs fixes it.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
