### PR TITLE
feat(model-server)!: use a consistent status code for query failures

### DIFF
--- a/model-server-openapi/specifications/model-server-v2.yaml
+++ b/model-server-openapi/specifications/model-server-v2.yaml
@@ -322,8 +322,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200json'
-        "404":
-          $ref: '#/components/responses/modelql-404'
+        "422":
+          $ref: '#/components/responses/ModelQlQueryExecutionFailed'
         default:
           $ref: '#/components/responses/GeneralError'
   /repositories/{repository}/init:
@@ -429,8 +429,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200json'
-        "404":
-          $ref: '#/components/responses/modelql-404'
+        "422":
+          $ref: '#/components/responses/ModelQlQueryExecutionFailed'
         default:
           $ref: '#/components/responses/GeneralError'
 
@@ -503,8 +503,16 @@ components:
         application/problem+json:
           schema:
             $ref: 'problem.yaml#/Problem'
-    "modelql-404":
-      description: "A IProducingStep<INodeReference>.resolve() call failed to find the node."
+    "ModelQlQueryExecutionFailed":
+      description: "A syntactically valid query failed to provide a result due to a mismatch of the query and the underlying data."
+      content:
+        text/plain:
+          schema:
+            type: string
+            description: "Contains a technical error description why query execution failed."
+            example: |-
+              server version: 0.0.0
+              Exception in thread "main" java.lang.IllegalArgumentException: At least one element was expected. it<1004>.typed().flatMap { ...
     GeneralError:
       description: Unexpected error
       content:

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/Query.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/Query.kt
@@ -62,13 +62,15 @@ private abstract class BoundQuery<In, out AggregationOut, out ElementOut>(val ex
     }
 }
 
+class EmptyQueryResultException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
 private class MonoBoundQuery<In, Out>(executor: IQueryExecutor<In>, override val query: MonoUnboundQuery<In, Out>) : BoundQuery<In, Out, Out>(executor), IMonoQuery<Out> {
 
     override suspend fun execute(): IStepOutput<Out> {
         try {
             return executor.createStream(query).exactlyOne().getSuspending()
         } catch (ex: NoSuchElementException) {
-            throw RuntimeException("Empty query result: " + this, ex)
+            throw EmptyQueryResultException("Empty query result: $this", ex)
         }
     }
 
@@ -170,7 +172,7 @@ class MonoUnboundQuery<In, ElementOut>(
         try {
             return asStream(evaluationContext, input.asObservable()).exactlyOne().getSynchronous()
         } catch (ex: NoSuchElementException) {
-            throw RuntimeException("Empty query result: " + this, ex)
+            throw EmptyQueryResultException("Empty query result: $this", ex)
         }
     }
 

--- a/streams/src/commonMain/kotlin/org/modelix/streams/StreamExtensions.kt
+++ b/streams/src/commonMain/kotlin/org/modelix/streams/StreamExtensions.kt
@@ -34,6 +34,8 @@ import com.badoo.reaktive.single.map
 import com.badoo.reaktive.single.subscribe
 import kotlinx.coroutines.flow.single
 
+class StreamAssertionError(message: String) : IllegalArgumentException(message)
+
 fun Observable<*>.count(): Single<Int> = collect({ arrayOf(0) }) { acc, it -> acc[0]++ }.map { it[0] }
 fun <T, R> Observable<T>.fold(initial: R, operation: (R, T) -> R): Single<R> {
     return collect({ mutableListOf(initial) }) { acc, it -> acc[0] = operation(acc[0], it) }.map { it[0] }
@@ -51,13 +53,13 @@ fun <T> Observable<T>.withIndex(): Observable<IndexedValue<T>> {
     return map { IndexedValue(index++, it) }
 }
 fun <T> Observable<T>.assertNotEmpty(message: () -> String): Observable<T> {
-    return this.switchIfEmpty { throw IllegalArgumentException("At least one element was expected. " + message()) }
+    return this.switchIfEmpty { throw StreamAssertionError("At least one element was expected. xxx " + message()) }
 }
 fun <T> Maybe<T>.assertEmpty(message: (T) -> String): Completable {
-    return map { throw IllegalArgumentException(message(it)) }.asCompletable()
+    return map { throw StreamAssertionError(message(it)) }.asCompletable()
 }
 fun <T> Observable<T>.assertEmpty(message: (T) -> String): Completable {
-    return map { throw IllegalArgumentException(message(it)) }.asCompletable()
+    return map { throw StreamAssertionError(message(it)) }.asCompletable()
 }
 fun <T> Single<T>.cached(): Single<T> {
     return this.asObservable().replay(1).autoConnect()


### PR DESCRIPTION
When a modelql query fails due to a mismatch between what's expected by the query and the underlying data, always returns the same status code.

I have chosen 422 here. 5xx status codes are reserved for actual application failures instead of business logic errors. 404 would be too specific. 422 looks like it covers all kinds of errors related to being unable to "process" an otherwise valid query successfully.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
