### PR TITLE
chore: removed licence and copyright headers

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,0 @@
-<component name="CopyrightManager">
-  <settings default="Modelix" />
-</component>

--- a/authorization/src/main/kotlin/org/modelix/authorization/AccessTokenPrincipal.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/AccessTokenPrincipal.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.authorization
 
 import com.auth0.jwt.interfaces.DecodedJWT

--- a/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationConfig.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationConfig.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization
 
 import com.auth0.jwk.JwkProvider

--- a/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationPlugin.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/AuthorizationPlugin.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization
 
 import com.auth0.jwt.JWT

--- a/authorization/src/main/kotlin/org/modelix/authorization/EPermissionType.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/EPermissionType.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.authorization
 
 enum class EPermissionType(vararg val includedTypes: EPermissionType) {

--- a/authorization/src/main/kotlin/org/modelix/authorization/KeycloakUtils.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/KeycloakUtils.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.authorization
 
 import com.auth0.jwk.JwkProvider

--- a/authorization/src/main/kotlin/org/modelix/authorization/KtorAuthUtils.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/KtorAuthUtils.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.authorization
 
 import com.auth0.jwt.JWT

--- a/authorization/src/main/kotlin/org/modelix/authorization/NoPermissionException.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/NoPermissionException.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.authorization
 
 class NoPermissionException(val user: AccessTokenPrincipal?, val resourceId: String?, val scope: String?, message: String) :

--- a/authorization/src/main/kotlin/org/modelix/authorization/NotLoggedInException.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/NotLoggedInException.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.authorization
 
 class NotLoggedInException : RuntimeException("No valid JWT token found in the request headers")

--- a/authorization/src/main/kotlin/org/modelix/authorization/PermissionPage.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/PermissionPage.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization
 
 import kotlinx.html.FlowContent

--- a/authorization/src/main/kotlin/org/modelix/authorization/UnknownPermissionException.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/UnknownPermissionException.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization
 
 class UnknownPermissionException(val permissionId: String, val unknownElement: String?, cause: Exception? = null) : Exception("Unknown permission: $permissionId ($unknownElement)", cause)

--- a/authorization/src/main/kotlin/org/modelix/authorization/permissions/PermissionEvaluator.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/permissions/PermissionEvaluator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization.permissions
 
 class PermissionEvaluator(val schemaInstance: SchemaInstance) {

--- a/authorization/src/main/kotlin/org/modelix/authorization/permissions/PermissionParser.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/permissions/PermissionParser.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization.permissions
 
 import org.modelix.authorization.UnknownPermissionException

--- a/authorization/src/main/kotlin/org/modelix/authorization/permissions/PermissionParts.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/permissions/PermissionParts.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization.permissions
 
 import java.net.URLDecoder

--- a/authorization/src/main/kotlin/org/modelix/authorization/permissions/Schema.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/permissions/Schema.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization.permissions
 
 import kotlinx.serialization.Serializable

--- a/authorization/src/main/kotlin/org/modelix/authorization/permissions/SchemaBuilder.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/permissions/SchemaBuilder.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization.permissions
 
 fun buildPermissionSchema(body: SchemaBuilder.() -> Unit): Schema {

--- a/authorization/src/main/kotlin/org/modelix/authorization/permissions/SchemaInstance.kt
+++ b/authorization/src/main/kotlin/org/modelix/authorization/permissions/SchemaInstance.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.authorization.permissions
 
 /**

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,18 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 dependencyResolutionManagement {
     repositories.gradlePluginPortal()
     versionCatalogs {

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm-with-junit.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm-with-junit.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.gradle.kotlin.dsl.invoke
 
 

--- a/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-jvm.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.MODELIX_JDK_VERSION
 import org.modelix.MODELIX_JVM_TARGET
 

--- a/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-kotlin-multiplatform.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.MODELIX_JDK_VERSION
 
 plugins {

--- a/build-logic/src/main/kotlin/modelix-language-config.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-language-config.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper

--- a/build-logic/src/main/kotlin/modelix-project-repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-project-repositories.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // For some projects we need to redeclare repositories on project level
 // because plugins like npm and intellij may override our settings
 repositories {

--- a/build-logic/src/main/kotlin/modelix-repositories.settings.gradle.kts
+++ b/build-logic/src/main/kotlin/modelix-repositories.settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 val modelixRegex = "org\\.modelix.*"
 pluginManagement {
     repositories {

--- a/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix
 
 import org.gradle.api.Project

--- a/build-logic/src/main/kotlin/org/modelix/GenerateVersion.kt
+++ b/build-logic/src/main/kotlin/org/modelix/GenerateVersion.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix
 
 import org.gradle.api.Project

--- a/build-logic/src/main/kotlin/org/modelix/LanguageConfig.kt
+++ b/build-logic/src/main/kotlin/org/modelix/LanguageConfig.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix
 
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import io.gitlab.arturbosch.detekt.Detekt
@@ -18,7 +17,6 @@ plugins {
     `version-catalog`
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.gitVersion)
-    alias(libs.plugins.spotless) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.node) apply false
     alias(libs.plugins.detekt)

--- a/bulk-model-sync-gradle-test/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `modelix-kotlin-jvm-with-junit`
     id("org.modelix.bulk-model-sync")

--- a/bulk-model-sync-gradle-test/settings.gradle.kts
+++ b/bulk-model-sync-gradle-test/settings.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 pluginManagement {
     includeBuild("..")
     includeBuild("../build-logic")

--- a/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/ChangeApplier.kt
+++ b/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/ChangeApplier.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.test
 
 import GraphLang.C_Node

--- a/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/PullTest.kt
+++ b/bulk-model-sync-gradle-test/src/test/kotlin/org/modelix/model/sync/bulk/gradle/test/PullTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.test
 
 import org.junit.jupiter.api.Test

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/ModelSyncGradlePlugin.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle
 
 import org.gradle.api.Plugin

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/config/ModelSyncGradleSettings.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.config
 
 import org.gradle.api.Action

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ExportFromModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ExportFromModelServer.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.tasks
 
 import kotlinx.coroutines.runBlocking

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/GetRevisionInfo.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/GetRevisionInfo.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.tasks
 
 import kotlinx.coroutines.runBlocking

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ImportIntoModelServer.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.tasks
 
 import kotlinx.coroutines.runBlocking

--- a/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ValidateSyncSettings.kt
+++ b/bulk-model-sync-gradle/src/main/kotlin/org/modelix/model/sync/bulk/gradle/tasks/ValidateSyncSettings.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle.tasks
 
 import org.gradle.api.DefaultTask

--- a/bulk-model-sync-gradle/src/test/kotlin/org/modelix/model/sync/bulk/gradle/ExportFunctionalTest.kt
+++ b/bulk-model-sync-gradle/src/test/kotlin/org/modelix/model/sync/bulk/gradle/ExportFunctionalTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.gradle
 
 import io.kotest.matchers.file.shouldContainFile

--- a/bulk-model-sync-lib/mps-test/build.gradle.kts
+++ b/bulk-model-sync-lib/mps-test/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.copyMps
 
 plugins {

--- a/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ExportRepositoryTest.kt
+++ b/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ExportRepositoryTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.lib.test
 import com.google.common.jimfs.Jimfs
 import org.modelix.mps.model.sync.bulk.MPSBulkSynchronizer

--- a/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/MPSTestBase.kt
+++ b/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/MPSTestBase.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.lib.test
 
 import com.intellij.testFramework.HeavyPlatformTestCase

--- a/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ModelImporterWithMPSAdaptersTest.kt
+++ b/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ModelImporterWithMPSAdaptersTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.lib.test
 
 import jetbrains.mps.persistence.DefaultModelRoot

--- a/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ResolveInfoUpdateTest.kt
+++ b/bulk-model-sync-lib/mps-test/src/test/kotlin/org/modelix/model/sync/bulk/lib/test/ResolveInfoUpdateTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk.lib.test
 import kotlinx.serialization.json.Json
 import org.hamcrest.CoreMatchers.equalTo

--- a/bulk-model-sync-lib/mps-test/src/test/resources/log4j.xml
+++ b/bulk-model-sync-lib/mps-test/src/test/resources/log4j.xml
@@ -1,20 +1,4 @@
 <?xml version='1.0' encoding='ISO-8859-1' ?>
-<!--
-  ~ Copyright (c) 2023.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <!--

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/INodeAssociation.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/INodeAssociation.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.INode

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelExporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelExporter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.INode

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelImporter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import mu.KotlinLogging

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelSynchronizer.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/ModelSynchronizer.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import mu.KotlinLogging

--- a/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/Util.kt
+++ b/bulk-model-sync-lib/src/commonMain/kotlin/org/modelix/model/sync/bulk/Util.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import mu.KLogger

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/AbstractModelSyncTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/AbstractModelSyncTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.IBranch

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelExporterTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelExporterTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.IBranch

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelImporterOrderPropertyTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelImporterOrderPropertyTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.IBranch

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelImporterTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelImporterTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.IProperty

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelSynchronizerTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModelSynchronizerTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.ModelFacade

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModuleInclusionTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/ModuleInclusionTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import kotlin.js.JsName

--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/SyncTestUtil.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/SyncTestUtil.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import kotlinx.serialization.encodeToString

--- a/bulk-model-sync-lib/src/jsMain/kotlin/org/modelix/model/sync/bulk/ModelExporter.kt
+++ b/bulk-model-sync-lib/src/jsMain/kotlin/org/modelix/model/sync/bulk/ModelExporter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.INode

--- a/bulk-model-sync-lib/src/jsMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
+++ b/bulk-model-sync-lib/src/jsMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 actual fun isTty(): Boolean {

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/InvalidatingVisitor.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/InvalidatingVisitor.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.ITree

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/InvalidationTree.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/InvalidationTree.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import gnu.trove.map.TLongObjectMap

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/ModelExporter.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/ModelExporter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/PlatformSpecific.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/PlatformSpecific.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
+++ b/bulk-model-sync-lib/src/jvmMain/kotlin/org/modelix/model/sync/bulk/Utils.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 actual fun isTty(): Boolean {

--- a/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/InvalidationTreeTest.kt
+++ b/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/InvalidationTreeTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.ModelFacade

--- a/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelSynchronizerWithInvalidationTreeTest.kt
+++ b/bulk-model-sync-lib/src/jvmTest/kotlin/org/modelix/model/sync/bulk/ModelSynchronizerWithInvalidationTreeTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.sync.bulk
 
 import org.modelix.model.api.IProperty

--- a/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/CompositeFilter.kt
+++ b/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/CompositeFilter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.mps.model.sync.bulk
 
 import org.modelix.model.api.INode

--- a/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/IncludedModulesFilter.kt
+++ b/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/IncludedModulesFilter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.mps.model.sync.bulk
 
 import org.modelix.model.api.BuiltinLanguages

--- a/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/MPSBulkSynchronizer.kt
+++ b/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/MPSBulkSynchronizer.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.mps.model.sync.bulk
 
 import com.intellij.openapi.project.ProjectManager

--- a/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/NodeAssociations.kt
+++ b/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/NodeAssociations.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.mps.model.sync.bulk
 
 import gnu.trove.map.TLongObjectMap

--- a/docs/global/modules/core/pages/reference/component-model-server.adoc
+++ b/docs/global/modules/core/pages/reference/component-model-server.adoc
@@ -38,16 +38,6 @@ While this component is independent of MPS, it is possible to replicates the dat
 This can be achieved using the modelix MPS plugin: One can connect an MPS instances to a `model-server`, upload the current module repository, and keep it synchronized.
 This can also be a local MPS instance without a web editor - both options are supported at the same time.
 
-
-== Development
-
-To reformat and add license header to all files run:
-
-[source,bash]
---
-../gradlew spotlessApply
---
-
 == APIs
 
 Valid keys are keys starting with the PROTECTED_PREFIX ($$$).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 gitVersion = { id = "com.palantir.git-version", version = "3.1.0" }
-spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
 modelix-mps-buildtools = { id = "org.modelix.mps.build-tools", version.ref = "modelixBuildtools" }
 dokka = {id = "org.jetbrains.dokka", version.ref = "dokka"}
 node = {id = "com.github.node-gradle.node", version = "7.1.0"}

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/Atomic.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/Atomic.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.kotlin.utils
 
 expect class AtomicLong(initial: Long) {

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ContextValue.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.kotlin.utils
 
 /**

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/DataStructures.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/DataStructures.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 /**

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/DeprecationInfo.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/DeprecationInfo.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 /**

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 expect inline fun <R> runSynchronized(lock: Any, block: () -> R): R

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ThreadLocal.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/ThreadLocal.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 expect class ThreadLocal<E>(initialValueSupplier: () -> E) {

--- a/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/UnstableModelixFeature.kt
+++ b/kotlin-utils/src/commonMain/kotlin/org/modelix/kotlin/utils/UnstableModelixFeature.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 /**

--- a/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
+++ b/kotlin-utils/src/commonTest/kotlin/org/modelix/kotlin/utils/ContextValueTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 import kotlinx.coroutines.coroutineScope

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/Atomic.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/Atomic.js.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 actual class AtomicLong actual constructor(initial: Long) {

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/ContextValue.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/ContextValue.js.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.kotlin.utils
 
 import kotlinx.coroutines.currentCoroutineContext

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/DataStructures.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/DataStructures.js.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 actual fun <K, V> createMemoryEfficientMap(): MutableMap<K, V> = HashMap()

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.js.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {

--- a/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/ThreadLocal.js.kt
+++ b/kotlin-utils/src/jsMain/kotlin/org/modelix/kotlin/utils/ThreadLocal.js.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 actual class ThreadLocal<E> actual constructor(val initialValueSupplier: () -> E) {

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/Atomic.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/Atomic.jvm.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 public actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/ContextValue.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/ContextValue.jvm.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.kotlin.utils
 
 import kotlinx.coroutines.asContextElement

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/DataStructures.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/DataStructures.jvm.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 import gnu.trove.map.hash.THashMap

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/RunSynchronized.jvm.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {

--- a/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/ThreadLocal.jvm.kt
+++ b/kotlin-utils/src/jvmMain/kotlin/org/modelix/kotlin/utils/ThreadLocal.jvm.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.kotlin.utils
 
 import java.lang.ThreadLocal as JvmThreadLocal

--- a/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTest.kt
+++ b/model-api-gen-gradle-test/kotlin-generation/src/test/kotlin/org/modelix/modelql/typed/TypedModelQLTest.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.typed
 
 import jetbrains.mps.baseLanguage.C_ClassConcept

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/IPropertyValueSerializer.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/IPropertyValueSerializer.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel
 
 interface IPropertyValueSerializer<ValueT> {

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ITypedChildLink.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ITypedChildLink.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel
 
 import org.modelix.model.api.IChildLink

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ITypedProperty.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ITypedProperty.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel
 
 import org.modelix.model.api.INode

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ITypedReferenceLink.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ITypedReferenceLink.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel
 
 import org.modelix.model.api.INode

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ModelApiExt.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/ModelApiExt.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel
 
 import org.modelix.model.api.INode

--- a/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/TypedNodeTraversal.kt
+++ b/model-api-gen-runtime/src/commonMain/kotlin/org/modelix/metamodel/TypedNodeTraversal.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel
 
 import org.modelix.model.api.INode

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/GeneratorInput.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.metamodel.generator
 
 import org.modelix.model.api.IConcept

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptFileGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptFileGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.FileSpec

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptObjectGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptObjectGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptWrapperInterfaceGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ConceptWrapperInterfaceGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/EnumFileGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/EnumFileGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/FileGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/FileGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.FileSpec

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/LanguageFileGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/LanguageFileGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.FileSpec

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/MetaPropertiesInterfaceGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/MetaPropertiesInterfaceGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ModelQLExtensionsGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/ModelQLExtensionsGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/NameConfigBasedGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/NameConfigBasedGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/NodeWrapperImplGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/NodeWrapperImplGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.CodeBlock

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/NodeWrapperInterfaceGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/NodeWrapperInterfaceGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/RegistrationHelperGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/internal/RegistrationHelperGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.metamodel.generator.internal
 
 import com.squareup.kotlinpoet.ClassName

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/BuiltinLanguages.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ConceptReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ConceptReference.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 import kotlinx.serialization.KSerializer

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ConceptUtil.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ConceptUtil.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ContextValue.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 @Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranch.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranch.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranchListener.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IBranchListener.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IChildLink.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.serialization.Serializable

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IConcept.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IConceptReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IConceptReference.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 import org.modelix.model.area.IArea

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IIdGenerator.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IIdGenerator.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ILanguage.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ILanguage.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IMutableNode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IMutableNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 interface IMutableNode {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INode.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.coroutines.flow.Flow

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeReference.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.serialization.KSerializer

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeWrapper.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/INodeWrapper.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IProperty.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IProperty.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.serialization.Serializable

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IReadTransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IReadTransaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IReferenceLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IReferenceLink.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.serialization.Serializable

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransactionManager.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITransactionManager.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 interface ITransactionManager {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITree.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITree.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.coroutines.flow.Flow

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitor.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitor.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitorEx.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ITreeChangeVisitorEx.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IWriteTransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IWriteTransaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 /**

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/LocalPNodeReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/LocalPNodeReference.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import org.modelix.model.area.IArea

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/NodeReferenceById.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/NodeReferenceById.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 import org.modelix.model.area.IArea

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/NodeUtil.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/NodeUtil.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 fun INode.getDescendants(includeSelf: Boolean): Sequence<INode> {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/PBranch.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/PBranch.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import org.modelix.kotlin.utils.ContextValue

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeAdapter.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeAdapter.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import kotlinx.coroutines.flow.Flow

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeReference.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 import org.modelix.model.area.IArea

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/PlatformSpecific.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/PlatformSpecific.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 expect inline fun <R> runSynchronized(lock: Any, block: () -> R): R

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/ReadTransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/ReadTransaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 class ReadTransaction(override val tree: ITree, branch: IBranch) : Transaction(branch), IReadTransaction

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleChildLink.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 class SimpleChildLink(

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 open class SimpleConcept(

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleLanguage.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleLanguage.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 open class SimpleLanguage(private val name: String, private val uid: String? = null) : ILanguage {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleProperty.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleProperty.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 import kotlin.jvm.JvmOverloads

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleReferenceLink.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleReferenceLink.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 import kotlin.jvm.JvmOverloads

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/Transaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/Transaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 abstract class Transaction(override val branch: IBranch) : ITransaction {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/TreeAsBranch.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/TreeAsBranch.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 data class TreeAsBranch(override val tree: ITree) : IBranch, IReadTransaction {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/WriteTransaction.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/WriteTransaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.api
 
 class WriteTransaction(_tree: ITree, branch: IBranch, idGenerator: IIdGenerator) : Transaction(branch), IWriteTransaction {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/async/AsyncNode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/async/AsyncNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.async
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/async/IAsyncNode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/async/IAsyncNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.async
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/async/IAsyncTree.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/async/IAsyncTree.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.async
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/async/NodeAsAsyncNode.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/async/NodeAsAsyncNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.async
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/async/TreeChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/async/TreeChangeEvent.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.async
 
 import org.modelix.model.api.IChildLinkReference

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/meta/EmptyConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/meta/EmptyConcept.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.meta
 
 import org.modelix.model.api.IChildLink

--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/meta/NullConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/meta/NullConcept.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api.meta
 
 import org.modelix.model.api.ConceptReference

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/AbstractArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/AbstractArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.IBranch

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaListenerRegistry.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaListenerRegistry.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 object AreaListenerRegistry {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaListenerWrapper.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaListenerWrapper.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 abstract class AreaListenerWrapper(val wrappedListener: IAreaListener) : IAreaListener

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaWithMounts.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/AreaWithMounts.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.ConceptReference

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/ChildrenChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/ChildrenChangeEvent.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.INode

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/CompositeArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/CompositeArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.ConceptReference

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/ContextArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/ContextArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.INodeResolutionScope

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/IArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/IArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.IBranch

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaChangeEvent.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 interface IAreaChangeEvent

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaChangeList.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaChangeList.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 interface IAreaChangeList {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaListener.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaListener.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 interface IAreaListener {

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/IAreaReference.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 interface IAreaReference

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/NodeChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/NodeChangeEvent.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.INode

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/PArea.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/PArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.IBranch

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/PropertyChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/PropertyChangeEvent.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.INode

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/ReferenceChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/ReferenceChangeEvent.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.INode

--- a/model-api/src/commonMain/kotlin/org/modelix/model/area/RoleChangeEvent.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/area/RoleChangeEvent.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.INode

--- a/model-api/src/commonTest/kotlin/ReferenceSerializationTests.kt
+++ b/model-api/src/commonTest/kotlin/ReferenceSerializationTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.PNodeReference
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/api/BuiltinLanguagesTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 import io.kotest.inspectors.forAll

--- a/model-api/src/commonTest/kotlin/org/modelix/model/api/IConceptTests.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/api/IConceptTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 import kotlin.test.Test

--- a/model-api/src/commonTest/kotlin/org/modelix/model/data/ModelDataTest.kt
+++ b/model-api/src/commonTest/kotlin/org/modelix/model/data/ModelDataTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.data
 
 import org.modelix.model.api.ChildLinkFromName

--- a/model-api/src/jsMain/kotlin/org/modelix/model/api/ContextValue.kt
+++ b/model-api/src/jsMain/kotlin/org/modelix/model/api/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 actual class ContextValue<E> {

--- a/model-api/src/jsMain/kotlin/org/modelix/model/api/PlatformSpecific.kt
+++ b/model-api/src/jsMain/kotlin/org/modelix/model/api/PlatformSpecific.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {

--- a/model-api/src/jsTest/kotlin/org/modelix/model/api/NodeAdapterJSTest.kt
+++ b/model-api/src/jsTest/kotlin/org/modelix/model/api/NodeAdapterJSTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 import org.modelix.model.ModelFacade

--- a/model-api/src/jvmMain/kotlin/org/modelix/model/api/ContextValue.kt
+++ b/model-api/src/jvmMain/kotlin/org/modelix/model/api/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 actual class ContextValue<E> {

--- a/model-api/src/jvmMain/kotlin/org/modelix/model/api/PlatformSpecific.kt
+++ b/model-api/src/jvmMain/kotlin/org/modelix/model/api/PlatformSpecific.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.api
 
 actual inline fun <R> runSynchronized(lock: Any, block: () -> R): R {

--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -3,7 +3,6 @@ import dev.petuska.npm.publish.task.NpmPackTask
 plugins {
     `maven-publish`
     `modelix-kotlin-multiplatform`
-    alias(libs.plugins.spotless)
     alias(libs.plugins.npm.publish)
 }
 
@@ -78,28 +77,6 @@ kotlin {
                 implementation(npm("ws", "^8.17.1"))
             }
         }
-    }
-}
-
-spotless {
-    kotlin {
-        licenseHeader(
-            "/*\n" +
-                """ * Licensed under the Apache License, Version 2.0 (the "License");""" + "\n" +
-                """ * you may not use this file except in compliance with the License.""" + "\n" +
-                """ * You may obtain a copy of the License at""" + "\n" +
-                """ *""" + "\n" +
-                """ *  http://www.apache.org/licenses/LICENSE-2.0""" + "\n" +
-                """ *""" + "\n" +
-                """ * Unless required by applicable law or agreed to in writing,""" + "\n" +
-                """ * software distributed under the License is distributed on an""" + "\n" +
-                """ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY""" + "\n" +
-                """ * KIND, either express or implied.  See the License for the""" + "\n" +
-                """ * specific language governing permissions and limitations""" + "\n" +
-                """ * under the License.""" + "\n" +
-                " */\n" +
-                "\n",
-        )
     }
 }
 

--- a/model-client/integration-tests/src/commonTest/kotlin/org/modelix/model/client2/AuthTestFixture.kt
+++ b/model-client/integration-tests/src/commonTest/kotlin/org/modelix/model/client2/AuthTestFixture.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 /**

--- a/model-client/src/commonMain/kotlin/org/modelix/model/AutoTransactionsBranch.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/AutoTransactionsBranch.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 import org.modelix.model.api.IBranch

--- a/model-client/src/commonMain/kotlin/org/modelix/model/IKeyValueStoreWrapper.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/IKeyValueStoreWrapper.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 interface IKeyValueStoreWrapper : IKeyValueStore {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/ModelIndex.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/ModelIndex.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 import org.modelix.model.api.ITransaction

--- a/model-client/src/commonMain/kotlin/org/modelix/model/ModelMigrations.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/ModelMigrations.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 import org.modelix.model.api.IBranch

--- a/model-client/src/commonMain/kotlin/org/modelix/model/SubtreeChanges.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/SubtreeChanges.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 import org.modelix.model.api.ITree

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client/ActiveBranch.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client/ActiveBranch.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.api.IBranch

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client/GarbageFilteringStore.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client/GarbageFilteringStore.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.IKeyListener

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client/IIndirectBranch.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client/IIndirectBranch.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.api.IBranch

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client/IModelClient.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client/IModelClient.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.IKeyValueStore

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client/SimpleIndirectBranch.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client/SimpleIndirectBranch.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.api.IBranch

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/Closable.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/Closable.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 internal expect interface Closable {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.client2
 
 import org.modelix.kotlin.utils.DeprecationInfo

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2Internal.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2Internal.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import org.modelix.model.lazy.RepositoryId

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.client2
 
 import io.ktor.client.HttpClient

--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaMetaLanguage.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaMetaLanguage.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.metameta
 
 import org.modelix.model.api.SimpleChildLink

--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelIndex.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelIndex.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.metameta
 
 import org.modelix.model.api.IChildLink

--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelMigration.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelMigration.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.metameta
 
 import org.modelix.model.api.ConceptReference

--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelSynchronizer.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/MetaModelSynchronizer.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.metameta
 
 import org.modelix.model.SubtreeChanges

--- a/model-client/src/commonMain/kotlin/org/modelix/model/metameta/PersistedConcept.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/metameta/PersistedConcept.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.metameta
 
 import org.modelix.model.api.IChildLink

--- a/model-client/src/commonMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.oauth
 
 import io.ktor.client.HttpClientConfig

--- a/model-client/src/commonTest/kotlin/org/modelix/model/IncrementalBranchTest.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/IncrementalBranchTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model
 
 import org.modelix.incremental.IncrementalEngine

--- a/model-client/src/commonTest/kotlin/org/modelix/model/api/TreePointerTest.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/api/TreePointerTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.api
 
 import org.modelix.model.ModelFacade

--- a/model-client/src/commonTest/kotlin/org/modelix/model/area/AreaWithMountsTests.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/area/AreaWithMountsTests.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.area
 
 import org.modelix.model.api.IConcept

--- a/model-client/src/commonTest/kotlin/org/modelix/model/client2/ModelClientV2Test.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/client2/ModelClientV2Test.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client2
 
 import io.ktor.client.HttpClient

--- a/model-client/src/commonTest/kotlin/org/modelix/model/metameta/MetaModelMigrationsTest.kt
+++ b/model-client/src/commonTest/kotlin/org/modelix/model/metameta/MetaModelMigrationsTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.metameta
 
 import org.modelix.model.ModelMigrations

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/BranchJSImpl.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/BranchJSImpl.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import INodeJS

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ChangeJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ChangeJS.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import INodeJS

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 @file:OptIn(DelicateCoroutinesApi::class)
 
 package org.modelix.model.client2

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/Closable.js.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/Closable.js.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 internal actual interface Closable {

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ReplicatedModelJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ReplicatedModelJS.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import kotlin.js.Promise

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ReplicatedModelJSImpl.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ReplicatedModelJSImpl.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 @file:OptIn(DelicateCoroutinesApi::class)
 
 package org.modelix.model.client2

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/VersionInformationJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/VersionInformationJS.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import kotlin.js.Date

--- a/model-client/src/jsMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.oauth
 
 import io.ktor.client.HttpClientConfig

--- a/model-client/src/jsTest/kotlin/org/modelix/model/client2/BranchJSTest.kt
+++ b/model-client/src/jsTest/kotlin/org/modelix/model/client2/BranchJSTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import GeneratedConcept

--- a/model-client/src/jsTest/kotlin/org/modelix/model/client2/ClientJSTest.kt
+++ b/model-client/src/jsTest/kotlin/org/modelix/model/client2/ClientJSTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import GeneratedConcept

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/KeyValueStoreCache.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/KeyValueStoreCache.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model
 
 import org.apache.commons.collections4.map.LRUMap

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/AsyncStore.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/AsyncStore.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.IKeyListener

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/ReplicatedRepository.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/ReplicatedRepository.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import kotlinx.coroutines.CoroutineScope

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import io.ktor.client.HttpClient

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/SharedExecutors.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/SharedExecutors.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import java.util.concurrent.Executors

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/VersionChangeDetector.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/VersionChangeDetector.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client
 
 import kotlinx.coroutines.CoroutineScope

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client2/Closable.jvm.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client2/Closable.jvm.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 internal actual interface Closable : java.io.Closeable {

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client2/LazyLoading.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client2/LazyLoading.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client2
 
 import kotlinx.coroutines.runBlocking

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.oauth
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/util/StreamUtils.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/util/StreamUtils.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.util
 
 import java.util.stream.Collectors

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/util/pmap/CustomPMap.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/util/pmap/CustomPMap.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.util.pmap
 
 interface CustomPMap<K, V> {

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/util/pmap/LongKeyPMap.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/util/pmap/LongKeyPMap.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.util.pmap
 
 import org.apache.commons.lang3.mutable.MutableObject

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/util/pmap/SmallPMap.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/util/pmap/SmallPMap.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.util.pmap
 
 import org.modelix.model.lazy.COWArrays.add

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/ModelClientV2JvmTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/ModelClientV2JvmTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.client2
 
 import io.ktor.client.HttpClient

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyListener.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyListener.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model
 
 interface IKeyListener : IGenericKeyListener<String>

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyValueStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/IKeyValueStore.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model
 
 import org.modelix.model.lazy.BulkQuery

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/ITransactionWrapper.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/ITransactionWrapper.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 import org.modelix.model.api.ITransaction

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/IVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/IVersion.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model
 
 import org.modelix.model.api.IBranch

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncAsSynchronousTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncAsSynchronousTree.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.observable.map

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncStoreAsLegacyDeserializingStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncStoreAsLegacyDeserializingStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.observable.asObservable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncTree.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.andThen

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/BulkAsyncStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/BulkAsyncStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.Completable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/BulkQueryAsAsyncStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/BulkQueryAsAsyncStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.Completable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/CachingAsyncStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/CachingAsyncStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.Completable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/IAsyncObjectStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/IAsyncObjectStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.Completable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/LegacyDeserializingStoreAsAsyncStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/LegacyDeserializingStoreAsAsyncStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.Completable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/LegacyKeyValueStoreAsAsyncStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/LegacyKeyValueStoreAsAsyncStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.async
 
 import com.badoo.reaktive.completable.Completable

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/client/IdGenerator.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/client/IdGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.api.IIdGenerator

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/AccessTrackingStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/AccessTrackingStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyListener

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/BulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/BulkQuery.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLNode.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLNodeRef.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLNodeRef.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 @Deprecated("unused")

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLTree.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/COWArrays.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/COWArrays.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 object COWArrays {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkQuery.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IBulkTree.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IDeserializingKeyValueStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IDeserializingKeyValueStore.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IKVEntryReference.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IKVEntryReference.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.single.Single

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/INodeReferenceSerializer.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/INodeReferenceSerializer.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.model.api.INodeReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ITreeWrapper.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ITreeWrapper.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IndirectObjectStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/IndirectObjectStore.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/KVEntryReference.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/KVEntryReference.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.single.Single

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonBulkQuery.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonCachingObjectStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonCachingObjectStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.model.IKeyValueStore

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonWrittenEntry.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/NonWrittenEntry.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.single.Single

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ObjectStoreCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/ObjectStoreCache.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.kotlin.utils.runSynchronized

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/OperationsCompressor.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/OperationsCompressor.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import org.modelix.model.operations.AddNewChildOp

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/PrefetchCache.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import org.modelix.kotlin.utils.ContextValue

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/RepositoryId.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/RepositoryId.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.lazy
 
 import org.modelix.model.randomUUID

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/SynchronizedBulkQuery.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/SynchronizedBulkQuery.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/WrittenEntry.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/WrittenEntry.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.lazy
 
 import com.badoo.reaktive.maybe.asSingleOrError

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AbstractOperation.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AbstractOperation.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AddNewChildOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AddNewChildOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.IConceptReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AddNewChildSubtreeOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AddNewChildSubtreeOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import com.badoo.reaktive.observable.map

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/BulkUpdateOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/BulkUpdateOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/DeleteNodeOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/DeleteNodeOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.IConceptReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/IAppliedOperation.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/IAppliedOperation.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 interface IAppliedOperation {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/IOperation.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/IOperation.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/MoveNodeOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/MoveNodeOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/NoOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/NoOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTBranch.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTBranch.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.IBranch

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTWriteTransaction.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/OTWriteTransaction.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.ITransactionWrapper

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/SetConceptOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/SetConceptOp.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.IConceptReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/SetPropertyOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/SetPropertyOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/SetReferenceOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/SetReferenceOp.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.operations
 
 import org.modelix.model.api.INodeReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtInternal.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtInternal.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtLeaf.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtLeaf.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtNode.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtSingle.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPHamtSingle.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import com.badoo.reaktive.maybe.Maybe

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPNode.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.model.lazy.COWArrays.copy

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPNodeRef.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPNodeRef.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 abstract class CPNodeRef

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPOperationsList.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPOperationsList.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.model.lazy.KVEntryReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPTree.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.model.lazy.KVEntryReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPVersion.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.model.lazy.KVEntryReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/HashUtil.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/HashUtil.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 object HashUtil {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/IKVValue.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/IKVValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.persistent
 
 import org.modelix.model.lazy.KVEntryReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapBasedStore.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.kotlin.utils.createMemoryEfficientMap

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapChangeEvent.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/MapChangeEvent.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.model.lazy.KVEntryReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/OperationSerializer.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/OperationSerializer.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import org.modelix.model.api.IConceptReference

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/Separators.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/Separators.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.persistent
 
 /**

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/SerializationUtil.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/SerializationUtil.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 fun nullAsEmptyString(str: String?): String {

--- a/model-datastructure/src/commonTest/kotlin/ConflictResolutionTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/ConflictResolutionTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IConcept
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonTest/kotlin/ContainmentCycleTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/ContainmentCycleTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.ITree
 import org.modelix.model.async.ContainmentCycleException

--- a/model-datastructure/src/commonTest/kotlin/DiffTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/DiffTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonTest/kotlin/FailingVisitor.kt
+++ b/model-datastructure/src/commonTest/kotlin/FailingVisitor.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.ITreeChangeVisitorEx
 import kotlin.test.fail
 

--- a/model-datastructure/src/commonTest/kotlin/HamtTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/HamtTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import com.badoo.reaktive.maybe.Maybe
 import com.badoo.reaktive.maybe.map
 import org.modelix.model.lazy.KVEntryReference

--- a/model-datastructure/src/commonTest/kotlin/HashUtilsTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/HashUtilsTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.persistent.HashUtil
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/LinearHistoryTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.LinearHistory
 import org.modelix.model.VersionMerger
 import org.modelix.model.lazy.CLTree

--- a/model-datastructure/src/commonTest/kotlin/MergeOrderTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/MergeOrderTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IIdGenerator
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonTest/kotlin/OTBranchTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/OTBranchTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.modelix.model.api.PBranch
 import org.modelix.model.operations.IAppliedOperation
 import org.modelix.model.operations.OTBranch

--- a/model-datastructure/src/commonTest/kotlin/PlatformSpecificTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/PlatformSpecificTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.bitCount
 import org.modelix.model.randomUUID
 import kotlin.test.Test

--- a/model-datastructure/src/commonTest/kotlin/RandomTreeChangeGenerator.kt
+++ b/model-datastructure/src/commonTest/kotlin/RandomTreeChangeGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.IConcept

--- a/model-datastructure/src/commonTest/kotlin/RevertTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/RevertTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IIdGenerator
 import org.modelix.model.api.ITree

--- a/model-datastructure/src/commonTest/kotlin/TreeChangeCollector.kt
+++ b/model-datastructure/src/commonTest/kotlin/TreeChangeCollector.kt
@@ -1,36 +1,4 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.ITreeChangeVisitorEx
-
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 class TreeChangeCollector : ITreeChangeVisitorEx {
     val events: MutableList<ChangeEvent> = ArrayList()

--- a/model-datastructure/src/commonTest/kotlin/TreeDiffTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/TreeDiffTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.ITreeChangeVisitor
 import org.modelix.model.api.ITreeChangeVisitorEx
 import org.modelix.model.api.PBranch

--- a/model-datastructure/src/commonTest/kotlin/TreeSerializationTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/TreeSerializationTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.IKeyValueStore
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.IConcept

--- a/model-datastructure/src/commonTest/kotlin/TreeTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/TreeTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.modelix.model.api.ITree
 import kotlin.test.Test
 

--- a/model-datastructure/src/commonTest/kotlin/TreeTestBase.kt
+++ b/model-datastructure/src/commonTest/kotlin/TreeTestBase.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.ITree
 import org.modelix.model.api.PBranch

--- a/model-datastructure/src/commonTest/kotlin/TreeTestUtil.kt
+++ b/model-datastructure/src/commonTest/kotlin/TreeTestUtil.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.modelix.model.api.ITree
 import kotlin.random.Random
 

--- a/model-datastructure/src/commonTest/kotlin/UndoTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/UndoTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import org.modelix.model.LinearHistory
 import org.modelix.model.VersionMerger
 import org.modelix.model.api.IIdGenerator

--- a/model-datastructure/src/jsMain/kotlin/org/modelix/model/client/IdGenerator.kt
+++ b/model-datastructure/src/jsMain/kotlin/org/modelix/model/client/IdGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.api.IIdGenerator

--- a/model-datastructure/src/jvmMain/kotlin/org/modelix/model/client/IdGenerator.kt
+++ b/model-datastructure/src/jvmMain/kotlin/org/modelix/model/client/IdGenerator.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.client
 
 import org.modelix.model.api.IIdGenerator

--- a/model-datastructure/src/jvmMain/kotlin/org/modelix/model/persistent/PlatformSpecificHashUtil.kt
+++ b/model-datastructure/src/jvmMain/kotlin/org/modelix/model/persistent/PlatformSpecificHashUtil.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import java.security.MessageDigest

--- a/model-datastructure/src/jvmMain/kotlin/org/modelix/model/persistent/SerializationUtil.kt
+++ b/model-datastructure/src/jvmMain/kotlin/org/modelix/model/persistent/SerializationUtil.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.persistent
 
 import java.net.URLDecoder

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/ExceptionData.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/ExceptionData.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api
 
 import kotlinx.serialization.Serializable

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/MessageFromClient.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/MessageFromClient.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api
 
 import kotlinx.serialization.Serializable

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/MessageFromServer.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/MessageFromServer.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api
 
 import kotlinx.serialization.Serializable

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/ModelQuery.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/ModelQuery.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2022.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.api
 
 import kotlinx.serialization.SerialName

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/ModelQueryBuilder.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/ModelQueryBuilder.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2022.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.api
 
 fun buildModelQuery(body: ModelQueryBuilder.() -> Unit): ModelQuery {

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/NodeData.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/NodeData.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api
 
 import kotlinx.serialization.Serializable

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/NodeUpdateData.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/NodeUpdateData.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api
 
 import kotlinx.serialization.Serializable

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/OperationData.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/OperationData.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2022.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.api
 
 import kotlinx.serialization.SerialName

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/VersionData.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/VersionData.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api
 
 import kotlinx.serialization.Serializable

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/ImmutableObjectsStream.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/ImmutableObjectsStream.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.api.v2
 
 import io.ktor.http.ContentType

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/VersionDelta.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/VersionDelta.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.api.v2
 
 import io.ktor.http.ContentType

--- a/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2.kt
+++ b/model-server-api/src/commonMain/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.api.v2
 
 import io.ktor.http.ContentType

--- a/model-server-api/src/commonTest/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2Test.kt
+++ b/model-server-api/src/commonTest/kotlin/org/modelix/model/server/api/v2/VersionDeltaStreamV2Test.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.api.v2
 
 import io.ktor.util.cio.use

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -7,7 +7,6 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 plugins {
     application
     `maven-publish`
-    alias(libs.plugins.spotless)
     alias(libs.plugins.test.logger)
     alias(libs.plugins.shadow)
     `modelix-kotlin-jvm-with-junit`
@@ -142,44 +141,6 @@ publishing {
             artifactId = "model-server-with-dependencies"
             artifact(fatJarArtifact)
         }
-    }
-}
-
-spotless {
-    java {
-        googleJavaFormat("1.18.1").aosp()
-        licenseHeader(
-            "/*\n" +
-                """ * Licensed under the Apache License, Version 2.0 (the "License");""" + "\n" +
-                """ * you may not use this file except in compliance with the License.""" + "\n" +
-                """ * You may obtain a copy of the License at""" + "\n" +
-                """ *""" + "\n" +
-                """ *  http://www.apache.org/licenses/LICENSE-2.0""" + "\n" +
-                """ *""" + "\n" +
-                """ * Unless required by applicable law or agreed to in writing,""" + "\n" +
-                """ * software distributed under the License is distributed on an""" + "\n" +
-                """ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY""" + "\n" +
-                """ * KIND, either express or implied.  See the License for the""" + "\n" +
-                """ * specific language governing permissions and limitations""" + "\n" +
-                """ * under the License.""" + "\n" +
-                " */\n" +
-                "\n",
-        )
-        /*licenseHeader '/*\n' +
-                ' * Licensed under the Apache License, Version 2.0 (the "License");\n' +
-                ' * you may not use this file except in compliance with the License.\n' +
-                ' * You may obtain a copy of the License at\n' +
-                ' *\n' +
-                ' *  http://www.apache.org/licenses/LICENSE-2.0\n' +
-                ' *\n' +
-                ' * Unless required by applicable law or agreed to in writing,\n' +
-                ' * software distributed under the License is distributed on an\n' +
-                ' * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n' +
-                ' * KIND, either express or implied.  See the License for the\n' +
-                ' * specific language governing permissions and limitations\n' +
-                ' * under the License.\n' +
-                ' */\n' +
-                '\n'*/
     }
 }
 

--- a/model-server/src/main/kotlin/org/modelix/model/server/FileConverter.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/FileConverter.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server
 
 import com.beust.jcommander.IStringConverter

--- a/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/Main.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server
 
 import com.beust.jcommander.JCommander

--- a/model-server/src/main/kotlin/org/modelix/model/server/ModelServerPermissionSchema.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/ModelServerPermissionSchema.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import org.modelix.authorization.permissions.PermissionParts

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/AboutApiImpl.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/AboutApiImpl.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.server.application.ApplicationCall

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/HealthApiImpl.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/HealthApiImpl.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.http.ContentType

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/HttpException.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/HttpException.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.http.HttpStatusCode

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/IRepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/IRepositoriesManager.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import org.modelix.model.async.IAsyncObjectStore

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/IdsApiImpl.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/IdsApiImpl.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.server.application.Application

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/JsonUtils.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/JsonUtils.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.handlers
 
 import org.json.JSONArray

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServer.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.http.ContentType

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/MetricsApiImpl.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/MetricsApiImpl.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.server.application.Application

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ModelReplicationServer.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import com.google.common.cache.CacheBuilder

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/RepositoriesManager.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.server.handlers
 
 import com.badoo.reaktive.coroutinesinterop.asFlow

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/ContentExplorer.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/ContentExplorer.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import io.ktor.http.HttpStatusCode

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/ContentExplorerExpandedNodes.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/ContentExplorerExpandedNodes.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import kotlinx.serialization.Serializable

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/DiffView.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/DiffView.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import com.google.common.collect.ArrayListMultimap

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/HistoryHandler.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/HistoryHandler.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import io.ktor.server.application.Application

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/IndexPage.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/ui/IndexPage.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import io.ktor.server.application.Application

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/ClientIdProcessor.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/ClientIdProcessor.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server.store
 
 import javax.cache.processor.EntryProcessor

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/DumpStore.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/DumpStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import java.io.File

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IGenericStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IGenericStoreClient.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import org.modelix.model.IGenericKeyListener

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IStoreClient.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server.store
 
 import kotlinx.coroutines.Dispatchers

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/IgniteStoreClient.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server.store
 
 import mu.KotlinLogging

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/InMemoryStoreClient.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server.store
 
 import org.modelix.model.IGenericKeyListener

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/ObjectInRepository.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/ObjectInRepository.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 /**

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/PostgresDialect.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/PostgresDialect.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server.store
 
 import org.apache.ignite.cache.store.jdbc.dialect.BasicJdbcDialect

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/StoreClientAdapter.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/StoreClientAdapter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import org.modelix.model.IGenericKeyListener

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/StoreClientAsAsyncStore.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/StoreClientAsAsyncStore.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import com.badoo.reaktive.completable.Completable

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/StoreClientAsKeyValueStore.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/StoreClientAsKeyValueStore.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server.store
 
 import org.apache.commons.collections4.IterableUtils

--- a/model-server/src/main/kotlin/org/modelix/model/server/store/StoreManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/store/StoreManager.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import org.modelix.model.IKeyValueStore

--- a/model-server/src/test/java/org/modelix/model/server/RestModelServerTest.kt
+++ b/model-server/src/test/java/org/modelix/model/server/RestModelServerTest.kt
@@ -1,17 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.modelix.model.server
 
 import org.junit.Assert

--- a/model-server/src/test/kotlin/org/modelix/model/server/AuthorizationTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/AuthorizationTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server
 
 import com.auth0.jwt.JWT

--- a/model-server/src/test/kotlin/org/modelix/model/server/IgniteStoreClientParallelTransactionsTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/IgniteStoreClientParallelTransactionsTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import kotlinx.coroutines.Dispatchers

--- a/model-server/src/test/kotlin/org/modelix/model/server/LazyLoadingTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/LazyLoadingTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.application.install

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelClientV2Test.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/ModelServerTestUtil.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ModelServerTestUtil.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.serialization.kotlinx.json.json

--- a/model-server/src/test/kotlin/org/modelix/model/server/PermissionsTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/PermissionsTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server
 
 import com.auth0.jwt.JWTCreator

--- a/model-server/src/test/kotlin/org/modelix/model/server/PullPerformanceTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/PullPerformanceTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedModelTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedModelTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedRepositoryTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/RepositoryStorageBackwardsCompatiblityTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/RepositoryStorageBackwardsCompatiblityTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/StoreClientTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/StoreClientTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import kotlinx.coroutines.coroutineScope

--- a/model-server/src/test/kotlin/org/modelix/model/server/StoreClientWithStatistics.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/StoreClientWithStatistics.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import org.modelix.model.server.store.IsolatingStore

--- a/model-server/src/test/kotlin/org/modelix/model/server/V1ApiTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/V1ApiTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server
 
 import com.google.gson.JsonParser

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/AboutApiTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/AboutApiTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.kotest.assertions.ktor.client.shouldHaveContentType

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/HealthApiTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/HealthApiTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.client.request.get

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/KeyValueLikeModelServerTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.client.request.get

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerBackwardsCompatibilityTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerBackwardsCompatibilityTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import io.ktor.server.testing.ApplicationTestBuilder

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ModelReplicationServerTest.kt
@@ -1,18 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package org.modelix.model.server.handlers
 
 import com.google.api.client.http.HttpStatusCodes

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/ContentExplorerTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/ContentExplorerTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import io.kotest.assertions.ktor.client.shouldHaveStatus

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/DiffViewTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/DiffViewTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import com.google.common.collect.ArrayListMultimap

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/IndexPageTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/IndexPageTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import io.ktor.client.request.get

--- a/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/RepositoryOverviewTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/handlers/ui/RepositoryOverviewTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023-2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.handlers.ui
 
 import kotlinx.html.span

--- a/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresRepositoryRemovalTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresRepositoryRemovalTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import org.junit.jupiter.api.Test

--- a/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import org.modelix.model.lazy.RepositoryId

--- a/model-server/src/test/kotlin/org/modelix/model/server/store/InMemoryIsolatingStoreTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/store/InMemoryIsolatingStoreTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.server.store
 
 import org.junit.jupiter.api.Nested

--- a/model-server/src/test/kotlin/permissions/AdminPermissionOnServerTest.kt
+++ b/model-server/src/test/kotlin/permissions/AdminPermissionOnServerTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package permissions
 
 import org.modelix.model.server.ModelServerPermissionSchema

--- a/model-server/src/test/kotlin/permissions/PermissionTestBase.kt
+++ b/model-server/src/test/kotlin/permissions/PermissionTestBase.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package permissions
 
 import com.auth0.jwt.JWT

--- a/model-server/src/test/kotlin/permissions/ReadPermissionOnBranchTest.kt
+++ b/model-server/src/test/kotlin/permissions/ReadPermissionOnBranchTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package permissions
 
 import org.modelix.model.server.ModelServerPermissionSchema

--- a/model-server/src/test/kotlin/permissions/UnknownPermissionTest.kt
+++ b/model-server/src/test/kotlin/permissions/UnknownPermissionTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package permissions
 
 import org.junit.jupiter.api.assertThrows

--- a/model-server/src/test/kotlin/permissions/WritePermissionOnRepositoryTest.kt
+++ b/model-server/src/test/kotlin/permissions/WritePermissionOnRepositoryTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package permissions
 
 import org.modelix.model.server.ModelServerPermissionSchema

--- a/modelql-client/build.gradle.kts
+++ b/modelql-client/build.gradle.kts
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     `modelix-kotlin-multiplatform`
     `maven-publish`

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLArea.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import org.modelix.model.api.IBranch

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import io.ktor.client.HttpClient

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClientBuilder.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLClientBuilder.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import io.ktor.client.HttpClient

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLNode.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLNode.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import com.badoo.reaktive.coroutinesinterop.singleFromCoroutine

--- a/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLNodeSerializer.kt
+++ b/modelql-client/src/commonMain/kotlin/org/modelix/modelql/client/ModelQLNodeSerializer.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import org.modelix.model.api.ConceptReference

--- a/modelql-client/src/jsMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
+++ b/modelql-client/src/jsMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import org.modelix.model.api.INode

--- a/modelql-client/src/jsMain/kotlin/org/modelix/modelql/client/PlatformSpecificModelQLClientBuilder.kt
+++ b/modelql-client/src/jsMain/kotlin/org/modelix/modelql/client/PlatformSpecificModelQLClientBuilder.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import io.ktor.client.engine.HttpClientEngineFactory

--- a/modelql-client/src/jvmMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
+++ b/modelql-client/src/jvmMain/kotlin/org/modelix/modelql/client/ModelQLClient.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import kotlinx.coroutines.runBlocking

--- a/modelql-client/src/jvmMain/kotlin/org/modelix/modelql/client/PlatformSpecificModelQLClientBuilder.kt
+++ b/modelql-client/src/jvmMain/kotlin/org/modelix/modelql/client/PlatformSpecificModelQLClientBuilder.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import io.ktor.client.engine.HttpClientEngineFactory

--- a/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/HtmlBuilderTest.kt
+++ b/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/HtmlBuilderTest.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import io.ktor.client.HttpClient

--- a/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/ModelQLClientTest.kt
+++ b/modelql-client/src/jvmTest/kotlin/org/modelix/modelql/client/ModelQLClientTest.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.client
 
 import io.ktor.client.HttpClient

--- a/modelql-core/build.gradle.kts
+++ b/modelql-core/build.gradle.kts
@@ -1,19 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.modelix.registerVersionGenerationTask
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/AndOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/AndOperatorStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/AtomicLong.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/AtomicLong.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 expect class AtomicLong(initial: Long) {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectionSizeStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectionSizeStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CollectorStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.toList

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ConstantSourceStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ConstantSourceStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.observableOf

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ContextValue.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 @Deprecated("use org.modelix.kotlin.utils.ContextValue from org.modelix:kotlin-utils")

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CountingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/CountingStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.single.Single

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/DropStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/DropStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.skip

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EmptyStringIfNullStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EmptyStringIfNullStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EqualsOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/EqualsOperatorStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FilteringStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FilteringStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.firstOrDefault

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstElementStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstElementStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.take

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstOrNullStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FirstOrNullStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.maybe.defaultIfEmpty

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FlatMapStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FlatMapStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FoldingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FoldingStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.single.Single

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FragmentBuilder.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/FragmentBuilder.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 typealias FragmentBody<ContextT> = ContextT.() -> Unit

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IBulkQueryExecutor.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IBulkQueryExecutor.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 interface IBulkQueryExecutor {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IMemoizationPersistence.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IMemoizationPersistence.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.modelql.core
 
 import org.modelix.kotlin.utils.ContextValue

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.Observable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStepOutput.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IStepOutput.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.Observable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IdentityStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IdentityStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IfEmpty.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IfEmpty.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/InPredicate.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/InPredicate.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IntSumAggregationStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IntSumAggregationStep.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.single.Single

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IntSumStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IntSumStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsEmptyStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsEmptyStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.single.Single

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsNullPredicateStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/IsNullPredicateStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/JoinStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/JoinStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.asObservable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ListAsFluxStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ListAsFluxStep.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.asObservable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/LocalMappingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/LocalMappingStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MapAccessStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MapAccessStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MapIfNotNullStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MapIfNotNullStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MappingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MappingStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MemoizingStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MemoizingStep.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MultiplexedOutput.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/MultiplexedOutput.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NotOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NotOperatorStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NullIfEmpty.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/NullIfEmpty.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.defaultIfEmpty

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/Optional.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/Optional.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlin.jvm.JvmInline

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/OrOperatorStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/OrOperatorStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/PrintStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/PrintStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/Query.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/Query.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.Observable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryBuilderContext.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryBuilderContext.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import org.modelix.kotlin.utils.ContextValue

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryCallStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryCallStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryDescriptor.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryDescriptor.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.Serializable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryEvaluationContext.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/QueryEvaluationContext.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.single.Single

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/RegexPredicate.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/RegexPredicate.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SharedStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SharedStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SingleStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/SingleStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.single.Single

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringContainsPredicate.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringContainsPredicate.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToBooleanStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToBooleanStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToIntStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/StringToIntStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/TakeStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/TakeStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.take

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ToStringStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ToStringStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/TransformingStepWithParameter.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/TransformingStepWithParameter.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.Observable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/VersionAndData.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/VersionAndData.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.KSerializer

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/WhenStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/WhenStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.asObservable

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/WithIndexStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/WithIndexStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipBuilder.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipBuilder.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 class ZipBuilder {

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipElementAccessStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.map

--- a/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
+++ b/modelql-core/src/commonMain/kotlin/org/modelix/modelql/core/ZipStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.Observable

--- a/modelql-core/src/commonTest/kotlin/org/modelix/modelql/core/ModelQLTest.kt
+++ b/modelql-core/src/commonTest/kotlin/org/modelix/modelql/core/ModelQLTest.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import com.badoo.reaktive.observable.asObservable

--- a/modelql-core/src/commonTest/kotlin/org/modelix/modelql/core/Testdata.kt
+++ b/modelql-core/src/commonTest/kotlin/org/modelix/modelql/core/Testdata.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.Serializable

--- a/modelql-core/src/jsMain/kotlin/org/modelix/modelql/core/AtomicLong.kt
+++ b/modelql-core/src/jsMain/kotlin/org/modelix/modelql/core/AtomicLong.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 actual class AtomicLong actual constructor(initial: Long) {

--- a/modelql-core/src/jsMain/kotlin/org/modelix/modelql/core/ContextValue.kt
+++ b/modelql-core/src/jsMain/kotlin/org/modelix/modelql/core/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 actual class ContextValue<E : Any> {

--- a/modelql-core/src/jvmMain/kotlin/org/modelix/modelql/core/AtomicLong.kt
+++ b/modelql-core/src/jvmMain/kotlin/org/modelix/modelql/core/AtomicLong.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 actual class AtomicLong actual constructor(initial: Long) {

--- a/modelql-core/src/jvmMain/kotlin/org/modelix/modelql/core/ContextValue.kt
+++ b/modelql-core/src/jvmMain/kotlin/org/modelix/modelql/core/ContextValue.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 actual class ContextValue<E : Any> {

--- a/modelql-core/src/jvmTest/kotlin/org/modelix/modelql/core/SerializerTest.kt
+++ b/modelql-core/src/jvmTest/kotlin/org/modelix/modelql/core/SerializerTest.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.core
 
 import kotlinx.serialization.InternalSerializationApi

--- a/modelql-html/build.gradle.kts
+++ b/modelql-html/build.gradle.kts
@@ -1,18 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")

--- a/modelql-html/src/jvmMain/kotlin/org/modelix/modelql/html/HtmlTemplates.kt
+++ b/modelql-html/src/jvmMain/kotlin/org/modelix/modelql/html/HtmlTemplates.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.html
 
 import io.ktor.server.html.Template

--- a/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
+++ b/modelql-server/src/main/kotlin/org/modelix/modelql/server/ModelQLServer.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.server
 
 import io.ktor.http.ContentType

--- a/modelql-typed/build.gradle.kts
+++ b/modelql-typed/build.gradle.kts
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")

--- a/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/ConceptSwitch.kt
+++ b/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/ConceptSwitch.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.typed
 
 import org.modelix.metamodel.IConceptOfTypedNode

--- a/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
+++ b/modelql-typed/src/commonMain/kotlin/org/modelix/modelql/typed/TypedModelQL.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.typed
 
 import com.badoo.reaktive.observable.map

--- a/modelql-untyped/build.gradle.kts
+++ b/modelql-untyped/build.gradle.kts
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 plugins {
     `modelix-kotlin-multiplatform`
     kotlin("plugin.serialization")

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AddNewChildNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AddNewChildNodeStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllChildrenTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllChildrenTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllReferencesTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/AllReferencesTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ChildrenTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ChildrenTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceSetSourceStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceSetSourceStep.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.SerialName

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ConceptReferenceUIDTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/DescendantsTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/DescendantsTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.flatMap

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/LinkInParentTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/LinkInParentTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.flatMapSingle

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/MoveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/MoveNodeStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeKSerializer.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeKSerializer.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceAsStringTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceSourceStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceSourceStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/NodeReferenceTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/OfConceptStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/OfConceptStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.filter

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ParentTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ParentTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.maybe.map

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/PropertyTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/PropertyTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.flatMapSingle

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ReferenceTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ReferenceTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.maybe.map

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RemoveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RemoveNodeStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.map

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ResolveNodeStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/ResolveNodeStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.observable.map

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RoleInParentTraversalStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/RoleInParentTraversalStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetPropertyStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetPropertyStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetReferenceStep.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/SetReferenceStep.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import kotlinx.serialization.KSerializer

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/UntypedModelQL.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/UntypedModelQL.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.modelql.untyped
 
 import com.badoo.reaktive.single.map

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/AllChildrenActuallyReturnsAllChildrenTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/AllChildrenActuallyReturnsAllChildrenTest.kt
@@ -2,22 +2,6 @@ package org.modelix.model.mpsadapters
 
 import org.modelix.model.api.INode
 
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 class AllChildrenActuallyReturnsAllChildrenTest : MpsAdaptersTestBase("SimpleProject") {
 
     fun `test repository adapter consistency`() {

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ChangePropertyTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ChangePropertyTest.kt
@@ -3,22 +3,6 @@ package org.modelix.model.mpsadapters
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
 
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 class ChangePropertyTest : MpsAdaptersTestBase("SimpleProject") {
 
     fun testModuleCreation() {

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ChangeReferenceTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ChangeReferenceTest.kt
@@ -3,22 +3,6 @@ package org.modelix.model.mpsadapters
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
 
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 class ChangeReferenceTest : MpsAdaptersTestBase("SimpleProject") {
 
     fun testCanRemoveReference() {

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ConceptResolutionTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ConceptResolutionTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.modelix.model.api.BuiltinLanguages

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/DescriptorModelIsFilteredTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/DescriptorModelIsFilteredTest.kt
@@ -2,22 +2,6 @@ package org.modelix.model.mpsadapters
 
 import org.modelix.model.api.BuiltinLanguages
 
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 class DescriptorModelIsFilteredTest : MpsAdaptersTestBase("SimpleProject") {
 
     fun `test descriptor model is filtered by adapter`() {

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MPSAreaTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MPSAreaTest.kt
@@ -3,22 +3,6 @@ package org.modelix.model.mpsadapters
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INode
 
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 class MPSAreaTest : MpsAdaptersTestBase("SimpleProject") {
 
     fun testResolveModuleInNonExistingProject() {

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNodeTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNodeTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.modelix.model.api.INode

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MpsAdaptersTestBase.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/MpsAdaptersTestBase.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import com.intellij.ide.impl.OpenProjectTask

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.junit.Ignore

--- a/mps-model-adapters/src/main/java/org/modelix/model/mpsadapters/ConceptWorkaround.java
+++ b/mps-model-adapters/src/main/java/org/modelix/model/mpsadapters/ConceptWorkaround.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters;
 
 import org.jetbrains.mps.openapi.language.SAbstractConcept;

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/GlobalModelListener.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/GlobalModelListener.kt
@@ -1,21 +1,5 @@
 @file:Suppress("removal")
 
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.jetbrains.mps.openapi.model.SModel

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IDefaultNodeAdapter.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IDefaultNodeAdapter.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.modelix.model.api.IChildLink

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSArea.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSArea.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.ide.ThreadUtils

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSChildLink.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSChildLink.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.structure.link.SContainmentLinkAdapter

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSConcept.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.ids.SConceptId

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSDevKitDependencyAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSDevKitDependencyAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.jetbrains.mps.openapi.model.SModel

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSJavaModuleFacetAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.project.AbstractModule

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSLanguage.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSLanguage.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.ids.MetaIdHelper

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSLanguageRepository.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSLanguageRepository.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.ids.SConceptId

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelAsNode.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.extapi.model.SModelDescriptorStub

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelImportAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModelImportAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.jetbrains.mps.openapi.model.SModel

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.project.AbstractModule

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleDependencyAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleDependencyAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.MPSModuleRepository

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSNode.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.lang.smodel.generator.smodelAdapter.SNodeOperations

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.project.ProjectBase

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectModuleAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProjectModuleAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.project.ProjectBase

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProperty.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSProperty.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.structure.property.SPropertyAdapter

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferenceLink.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferenceLink.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.structure.ref.SReferenceLinkAdapter

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferences.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferences.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.SNodePointer

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSRepositoryAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSRepositoryAsNode.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.project.ProjectBase

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSSingleLanguageDependencyAsNode.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.jetbrains.mps.openapi.model.SModel

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/RepositoryLanguage.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/RepositoryLanguage.kt
@@ -1,16 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.adapter.structure.concept.SConceptAdapterById

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/Util.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/Util.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2023.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.model.mpsadapters
 
 import org.modelix.model.api.IChildLink

--- a/streams/src/commonMain/kotlin/org/modelix/streams/CompletableObservable.kt
+++ b/streams/src/commonMain/kotlin/org/modelix/streams/CompletableObservable.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.streams
 
 import com.badoo.reaktive.single.SingleEmitter

--- a/streams/src/commonMain/kotlin/org/modelix/streams/StreamExtensions.kt
+++ b/streams/src/commonMain/kotlin/org/modelix/streams/StreamExtensions.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.streams
 
 import com.badoo.reaktive.base.tryCatch

--- a/streams/src/commonMain/kotlin/org/modelix/streams/SynchronousPipeline.kt
+++ b/streams/src/commonMain/kotlin/org/modelix/streams/SynchronousPipeline.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2024.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.modelix.streams
 
 import com.badoo.reaktive.observable.Observable

--- a/ts-model-api/src/GeneratedConcept.ts
+++ b/ts-model-api/src/GeneratedConcept.ts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2022.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import type {IConceptJS} from "./IConceptJS.js";
 
 export abstract class GeneratedConcept implements IConceptJS {

--- a/ts-model-api/src/IConceptJS.ts
+++ b/ts-model-api/src/IConceptJS.ts
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2022.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 export interface IConceptJS {
   getUID(): string
   getDirectSuperConcepts(): Array<IConceptJS>


### PR DESCRIPTION
The LICENCE file in the root directory already specifies the applicable license for all files
without and explicit license header.
The copyright header didn't contain an author which makes it invalid anyway. The git history is a
much more reliable source about the authors of any file.