### PR TITLE
ci: disable globalization support when running @microsoft/sarif-multitool

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,15 @@ jobs:
       - name: Combine SARIF files
         run: |
           npx @microsoft/sarif-multitool merge --merge-runs --output-file merged.sarif  $(find . -iname '*.sarif*')
+        env:
+          # Disables globalization support.
+          # This makes the @microsoft/sarif-multitool work without ICU package installed.
+          # If not disabled, we get the following error:
+          # > Process terminated.
+          # > Couldn't find a valid ICU package installed on the system.
+          # > Set the configuration flag System.Globalization.Invariant to true
+          # > if you want to run with no globalization support.
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
The action started failing because `ubuntu-latest` change from `ubuntu-22.04` to `ubuntu-24.04` and does not have packages for ICU installed by default.

Because we do not need globalization support, we can just disable it.

Fixes https://github.com/modelix/modelix.core/actions/runs/12399750050/job/34617726915

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
