### PR TITLE
ci: Use Renovate to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,11 +24,6 @@ updates:
     directory: "/model-server"
     schedule:
       interval: "daily"
-  - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 20
-    directory: "/"
-    schedule:
-      interval: "daily"
   # We use the default versioning strategy for npm (increase for apps and widen for libraries),
   # so that clients are free to select an appropriate version from the allowed range, when they use one of the libraries.
   - package-ecosystem: "npm"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
 
     permissions:
@@ -84,7 +84,7 @@ jobs:
           category: detekt
 
   test-model-api-gen-gradle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
@@ -104,7 +104,7 @@ jobs:
         run: model-api-gen-gradle-test/ci.sh
 
   test-model-client-js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
@@ -124,7 +124,7 @@ jobs:
         run: model-client-js-test/ci.sh
 
   test-bulk-model-sync-gradle:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,7 @@ on:
       - '[0-9]+.[0-9]+.0'  # New Major or Minor Releases
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint-commits:
     name: Lint PR commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -16,7 +16,7 @@ jobs:
 
   test-release:
     name: Dry-run semantic-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,7 +21,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   openapi-linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
         continue-on-error: true
 
   openapi-breaking-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/mps-compatibility.yaml
+++ b/.github/workflows/mps-compatibility.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-mps-components:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
 
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   newRelease:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Run semantic release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,5 +12,6 @@
     "pre-commit",
     "gradle-wrapper",
     "nvm",
+    "github-actions",
   ],
 }


### PR DESCRIPTION
Compared to Dependabot Renovate:

* updates the versions of GitHub runners[^1]
* pins the version of actions[^2]

## To be verified by reviewers

[^1]: https://github.com/odzhychko/modelix.core/pull/8
[^2]: https://github.com/odzhychko/modelix.core/pull/7

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
