### PR TITLE
ci: configure updating Node.js version in libs.versions.toml by Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,5 +13,19 @@
     "gradle-wrapper",
     "nvm",
     "github-actions",
+    "custom.regex"
   ],
+  customManagers: [
+    {
+      depNameTemplate: "Node.js",
+      // Custom manager for Docker image version in version.properties
+      customType: "regex",
+      fileMatch: ["^gradle/libs.versions.toml$"],
+      matchStrings: [
+        'node="(?<currentValue>.*?)"'
+      ],
+      datasourceTemplate: "node-version",
+      versioningTemplate: "node"
+    }
+  ]
 }


### PR DESCRIPTION
Configure updating Node.js version in `libs.versions.toml`.
Renovate will open PRs like https://github.com/odzhychko/modelix.core/pull/1 and https://github.com/odzhychko/modelix.core/pull/2.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
