### PR TITLE
fix(modelql): set `INodeResolutionScope` when running query on `INode`

### DIFF
--- a/modelql-untyped/build.gradle.kts
+++ b/modelql-untyped/build.gradle.kts
@@ -17,7 +17,9 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
+                implementation(project(":model-datastructure"))
                 implementation(kotlin("test"))
+                implementation(libs.kotlin.coroutines.test)
             }
         }
         val jvmMain by getting {

--- a/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/UntypedModelQL.kt
+++ b/modelql-untyped/src/commonMain/kotlin/org/modelix/modelql/untyped/UntypedModelQL.kt
@@ -64,7 +64,9 @@ fun INode.createQueryExecutor(): IQueryExecutor<INode> {
 }
 
 suspend fun <R> INode.query(body: (IMonoStep<INode>) -> IMonoStep<R>): R {
-    return buildQuery(body).execute().value
+    return this.getArea().runWithAdditionalScopeInCoroutine {
+        buildQuery(body).execute().value
+    }
 }
 
 suspend fun <R> INode.queryFlux(body: (IMonoStep<INode>) -> IFluxStep<R>): List<R> {

--- a/modelql-untyped/src/commonTest/kotlin/org/modelix/modelql/untyped/UntypedModelQLTest.kt
+++ b/modelql-untyped/src/commonTest/kotlin/org/modelix/modelql/untyped/UntypedModelQLTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modelix.modelql.untyped
+
+import kotlinx.coroutines.test.runTest
+import org.modelix.model.api.TreePointer
+import org.modelix.model.api.getRootNode
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.NonCachingObjectStore
+import org.modelix.model.persistent.MapBaseStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UntypedModelQLTest {
+    private val tree = CLTree(NonCachingObjectStore(MapBaseStore()))
+    private val branch = TreePointer(tree, IdGenerator.getInstance(1))
+    private val rootNode = branch.getRootNode()
+
+    @Test
+    fun nodeCanBeResolvedInQuery() = runTest {
+        val resolvedNode = rootNode.query { root ->
+            root.nodeReference().resolve()
+        }
+        assertEquals(rootNode.reference, resolvedNode.reference)
+    }
+}


### PR DESCRIPTION
Fixes https://issues.modelix.org/issue/MODELIX-997

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
