### PR TITLE
fix(mps-model-adapters): fix MPSNode.replaceNode

### DIFF
--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
@@ -25,8 +25,11 @@ class ReplaceNodeTest : MpsAdaptersTestBase("SimpleProject") {
             val rootNode = model.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes).single() as IReplaceableNode
 
             val oldProperties = rootNode.getAllProperties().toSet()
+            check(oldProperties.isNotEmpty()) { "Test should replace node with properties." }
             val oldReferences = rootNode.getAllReferenceTargetRefs().toSet()
+            check(oldReferences.isNotEmpty()) { "Test should replace node with references." }
             val oldChildren = rootNode.allChildren.toList()
+            check(oldChildren.isNotEmpty()) { "Test should replace node with children." }
 
             val newConcept = ConceptReference("mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125")
             val newNode = rootNode.replaceNode(newConcept)

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
@@ -1,14 +1,23 @@
 package org.modelix.model.mpsadapters
 
+import jetbrains.mps.smodel.SNode
+import jetbrains.mps.smodel.adapter.MetaAdapterByDeclaration
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.ConceptReference
+import org.modelix.model.api.INode
 import org.modelix.model.api.IReplaceableNode
 
 class ReplaceNodeTest : MpsAdaptersTestBase("SimpleProject") {
 
-    fun `test replace node`() = runCommandOnEDT {
+    private val sampleConcept = MetaAdapterByDeclaration.asInstanceConcept(
+        MPSConcept.tryParseUID(BuiltinLanguages.jetbrains_mps_lang_core.BaseConcept.getUID())!!.concept,
+    )
+
+    fun `test replace node with parent and module (aka regular node)`() = runCommandOnEDT {
         val rootNode = getRootUnderTest()
         val nodeToReplace = rootNode.allChildren.first() as IReplaceableNode
+        val oldContainmentLink = nodeToReplace.getContainmentLink()
+        val nodesToKeep = rootNode.allChildren.drop(1)
         val oldProperties = nodeToReplace.getAllProperties().toSet()
         check(oldProperties.isNotEmpty()) { "Test should replace node with properties." }
         val oldReferences = nodeToReplace.getAllReferenceTargetRefs().toSet()
@@ -19,25 +28,62 @@ class ReplaceNodeTest : MpsAdaptersTestBase("SimpleProject") {
 
         val newNode = nodeToReplace.replaceNode(newConcept)
 
+        assertEquals(listOf(newNode) + nodesToKeep, rootNode.allChildren.toList())
+        assertEquals((nodeToReplace as MPSNode).node.nodeId, (newNode as MPSNode).node.nodeId)
+        assertEquals(oldContainmentLink, newNode.getContainmentLink())
+        assertEquals(newConcept, newNode.getConceptReference())
         assertEquals(oldProperties, newNode.getAllProperties().toSet())
         assertEquals(oldReferences, newNode.getAllReferenceTargetRefs().toSet())
         assertEquals(oldChildren, newNode.allChildren.toList())
+    }
+
+    fun `test replace node without parent but with module (aka root node)`() = runCommandOnEDT {
+        val rootNode = getRootUnderTest()
+        val oldContainmentLink = rootNode.getContainmentLink()
+        val model = getModelUnderTest()
+        val newConcept = ConceptReference("mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125")
+
+        val newNode = rootNode.replaceNode(newConcept)
+
+        assertEquals(listOf(newNode), model.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes))
+        assertEquals((rootNode as MPSNode).node.nodeId, (newNode as MPSNode).node.nodeId)
+        assertEquals(oldContainmentLink, newNode.getContainmentLink())
         assertEquals(newConcept, newNode.getConceptReference())
     }
 
-    fun `test fail to replace node without parent`() = runCommandOnEDT {
-        val rootNode = getRootUnderTest()
-        val oldChildren = rootNode.allChildren.toList()
-        check(oldChildren.isNotEmpty()) { "Test should replace node with children." }
+    fun `test replace node without parent and without module (aka free-floating node)`() = runCommandOnEDT {
+        val untouchedRootNode = getRootUnderTest()
+        val model = getModelUnderTest()
+        val freeFloatingSNode = SNode(sampleConcept)
+        val freeFloatingNode = MPSNode(freeFloatingSNode)
+        val oldContainmentLink = freeFloatingNode.getContainmentLink()
+        val newConcept = ConceptReference("mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125")
 
-        val newConcept = ConceptReference(BuiltinLanguages.jetbrains_mps_lang_core.BaseConcept.getUID())
+        val newNode = freeFloatingNode.replaceNode(newConcept)
 
-        val expectedMessage = "Cannot replace node `Class1` because it has no parent."
-        assertThrows(IllegalArgumentException::class.java, expectedMessage) {
-            rootNode.replaceNode(newConcept)
-        }
-        // Assert that precondition is check before children are deleted.
-        assertEquals(oldChildren, rootNode.allChildren.toList())
+        assertEquals(listOf(untouchedRootNode), model.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes))
+        assertEquals(freeFloatingNode.node.nodeId, (newNode as MPSNode).node.nodeId)
+        assertEquals(oldContainmentLink, newNode.getContainmentLink())
+        assertEquals(newConcept, newNode.getConceptReference())
+    }
+
+    fun `test replace node with parent but without module (aka descendant of free-floating node)`() = runCommandOnEDT {
+        val freeFloatingSNode = SNode(sampleConcept)
+        val freeFloatingNode = MPSNode(freeFloatingSNode)
+        val nodeToReplace = freeFloatingNode.addNewChild(
+            BuiltinLanguages.MPSRepositoryConcepts.Model.usedLanguages,
+            -1,
+            BuiltinLanguages.jetbrains_mps_lang_core.BaseConcept,
+        ) as IReplaceableNode
+        val oldContainmentLink = nodeToReplace.getContainmentLink()
+        val newConcept = ConceptReference("mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125")
+
+        val newNode = nodeToReplace.replaceNode(newConcept)
+
+        assertEquals(listOf(newNode), freeFloatingNode.allChildren.toList())
+        assertEquals((nodeToReplace as MPSNode).node.nodeId, (newNode as MPSNode).node.nodeId)
+        assertEquals(oldContainmentLink, newNode.getContainmentLink())
+        assertEquals(newConcept, newNode.getConceptReference())
     }
 
     fun `test fail to replace node with null concept`() = runCommandOnEDT {
@@ -61,11 +107,13 @@ class ReplaceNodeTest : MpsAdaptersTestBase("SimpleProject") {
         }
     }
 
-    private fun getRootUnderTest(): IReplaceableNode {
+    private fun getModelUnderTest(): INode {
         val repositoryNode = MPSRepositoryAsNode(mpsProject.repository)
         val module = repositoryNode.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Repository.modules)
             .single { it.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name) == "Solution1" }
-        val model = module.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Module.models).single()
-        return model.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes).single() as IReplaceableNode
+        return module.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Module.models).single()
     }
+
+    private fun getRootUnderTest(): IReplaceableNode = getModelUnderTest()
+        .getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes).single() as IReplaceableNode
 }

--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ReplaceNodeTest.kt
@@ -1,43 +1,71 @@
 package org.modelix.model.mpsadapters
 
-import org.junit.Ignore
 import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.ConceptReference
-import org.modelix.model.api.INode
 import org.modelix.model.api.IReplaceableNode
 
-@Ignore("Replacing a node through MPS-model-adapters is broken. See MODELIX-920")
 class ReplaceNodeTest : MpsAdaptersTestBase("SimpleProject") {
 
-    fun testReplaceNode() {
-        readAction {
-            assertEquals(1, mpsProject.projectModules.size)
+    fun `test replace node`() = runCommandOnEDT {
+        val rootNode = getRootUnderTest()
+        val nodeToReplace = rootNode.allChildren.first() as IReplaceableNode
+        val oldProperties = nodeToReplace.getAllProperties().toSet()
+        check(oldProperties.isNotEmpty()) { "Test should replace node with properties." }
+        val oldReferences = nodeToReplace.getAllReferenceTargetRefs().toSet()
+        check(oldReferences.isNotEmpty()) { "Test should replace node with references." }
+        val oldChildren = nodeToReplace.allChildren.toList()
+        check(oldChildren.isNotEmpty()) { "Test should replace node with children." }
+        val newConcept = ConceptReference("mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125")
+
+        val newNode = nodeToReplace.replaceNode(newConcept)
+
+        assertEquals(oldProperties, newNode.getAllProperties().toSet())
+        assertEquals(oldReferences, newNode.getAllReferenceTargetRefs().toSet())
+        assertEquals(oldChildren, newNode.allChildren.toList())
+        assertEquals(newConcept, newNode.getConceptReference())
+    }
+
+    fun `test fail to replace node without parent`() = runCommandOnEDT {
+        val rootNode = getRootUnderTest()
+        val oldChildren = rootNode.allChildren.toList()
+        check(oldChildren.isNotEmpty()) { "Test should replace node with children." }
+
+        val newConcept = ConceptReference(BuiltinLanguages.jetbrains_mps_lang_core.BaseConcept.getUID())
+
+        val expectedMessage = "Cannot replace node `Class1` because it has no parent."
+        assertThrows(IllegalArgumentException::class.java, expectedMessage) {
+            rootNode.replaceNode(newConcept)
         }
+        // Assert that precondition is check before children are deleted.
+        assertEquals(oldChildren, rootNode.allChildren.toList())
+    }
 
-        val repositoryNode: INode = MPSRepositoryAsNode(mpsProject.repository)
+    fun `test fail to replace node with null concept`() = runCommandOnEDT {
+        val rootNode = getRootUnderTest()
+        val nodeToReplace = rootNode.allChildren.first() as IReplaceableNode
 
-        runCommandOnEDT {
-            val module = repositoryNode.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Repository.modules)
-                .single { it.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name) == "Solution1" }
-            val model = module.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Module.models)
-                .single { it.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name) == "Solution1.model1" }
-
-            val rootNode = model.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes).single() as IReplaceableNode
-
-            val oldProperties = rootNode.getAllProperties().toSet()
-            check(oldProperties.isNotEmpty()) { "Test should replace node with properties." }
-            val oldReferences = rootNode.getAllReferenceTargetRefs().toSet()
-            check(oldReferences.isNotEmpty()) { "Test should replace node with references." }
-            val oldChildren = rootNode.allChildren.toList()
-            check(oldChildren.isNotEmpty()) { "Test should replace node with children." }
-
-            val newConcept = ConceptReference("mps:f3061a53-9226-4cc5-a443-f952ceaf5816/1083245097125")
-            val newNode = rootNode.replaceNode(newConcept)
-
-            assertEquals(oldProperties, newNode.getAllProperties().toSet())
-            assertEquals(oldReferences, newNode.getAllReferenceTargetRefs().toSet())
-            assertEquals(oldChildren, newNode.allChildren.toList())
-            assertEquals(newConcept, newNode.getConceptReference())
+        val expectedMessage = "Cannot replace node `method1` with a null concept. Explicitly specify a concept (e.g., `BaseConcept`)."
+        assertThrows(IllegalArgumentException::class.java, expectedMessage) {
+            nodeToReplace.replaceNode(null)
         }
+    }
+
+    fun `test fail to replace node with non mps concept`() = runCommandOnEDT {
+        val rootNode = getRootUnderTest()
+        val nodeToReplace = rootNode.allChildren.first() as IReplaceableNode
+        val newConcept = ConceptReference("notMpsConcept")
+
+        val expectedMessage = "Concept UID `notMpsConcept` cannot be parsed as MPS concept."
+        assertThrows(IllegalArgumentException::class.java, expectedMessage) {
+            nodeToReplace.replaceNode(newConcept)
+        }
+    }
+
+    private fun getRootUnderTest(): IReplaceableNode {
+        val repositoryNode = MPSRepositoryAsNode(mpsProject.repository)
+        val module = repositoryNode.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Repository.modules)
+            .single { it.getPropertyValue(BuiltinLanguages.jetbrains_mps_lang_core.INamedConcept.name) == "Solution1" }
+        val model = module.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Module.models).single()
+        return model.getChildren(BuiltinLanguages.MPSRepositoryConcepts.Model.rootNodes).single() as IReplaceableNode
     }
 }

--- a/mps-model-adapters-plugin/testdata/SimpleProject/solutions/Solution1/models/Solution1.model1.mps
+++ b/mps-model-adapters-plugin/testdata/SimpleProject/solutions/Solution1/models/Solution1.model1.mps
@@ -14,9 +14,11 @@
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS" />
-      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -33,7 +35,7 @@
     <property role="TrG5h" value="Class1" />
     <node concept="3clFb_" id="3cIAtmcX1Te" role="jymVt">
       <property role="TrG5h" value="method1" />
-      <node concept="3cqZAl" id="3cIAtmcX1Tg" role="3clF45" />
+      <ref role="3uigEE" node="3cIAtmcX1Sw" resolve="Class1" />
       <node concept="3Tm1VV" id="3cIAtmcX1Th" role="1B3o_S" />
       <node concept="3clFbS" id="3cIAtmcX1Ti" role="3clF47" />
     </node>


### PR DESCRIPTION
* correctly parse concept UID
* check preconditions before making changes
* remove child from parent before moving to new parent
* correctly call `SNode.insertChildBefore`

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
