### PR TITLE
fix(model-datastructure): avoid stack overflows when adding many children at once

### DIFF
--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/async/AsyncTree.kt
@@ -366,7 +366,7 @@ open class AsyncTree(val treeData: CPTree, val store: IAsyncObjectStore) : IAsyn
             }.asSingle(nodesMap)
         }
 
-        val mapIncludingNewNodes = newIds.zip(concepts).asObservable().fold(originalMapAfterCheckForConflictingIds) { nodesMap, (childId, concept) ->
+        val mapIncludingNewNodes = newIds.zip(concepts).fold(originalMapAfterCheckForConflictingIds) { nodesMap, (childId, concept) ->
             val childData = CPNode.create(
                 childId,
                 concept.getUID().takeIf { it != NullConcept.getUID() },
@@ -381,7 +381,7 @@ open class AsyncTree(val treeData: CPTree, val store: IAsyncObjectStore) : IAsyn
             nodesMap.flatMap {
                 it.put(childData, store)
             }
-        }.flatten()
+        }
 
         val newParentData = insertChildrenIntoParentData(parentId, index, newIds, role)
 
@@ -512,7 +512,7 @@ open class AsyncTree(val treeData: CPTree, val store: IAsyncObjectStore) : IAsyn
 
     override fun deleteNodes(nodeIds: LongArray): Single<IAsyncMutableTree> {
         if (nodeIds.size == 1) return deleteNodeRecursive(nodeIds[0])
-        return nodeIds.asObservable().fold(singleOf(this)) { acc, nodeId -> acc.flatMap { it.deleteNodeRecursive(nodeId) } }.flatten()
+        return nodeIds.fold(singleOf(this)) { acc, nodeId -> acc.flatMap { it.deleteNodeRecursive(nodeId) } }
     }
 
     private fun deleteNodeRecursive(nodeId: Long): Single<AsyncTree> {

--- a/model-datastructure/src/commonTest/kotlin/org/modelix/model/async/AsyncAsSynchronousTreeTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/org/modelix/model/async/AsyncAsSynchronousTreeTest.kt
@@ -7,6 +7,7 @@ import org.modelix.model.lazy.NonCachingObjectStore
 import org.modelix.model.lazy.createNewTreeData
 import org.modelix.model.persistent.MapBasedStore
 import org.modelix.streams.StreamAssertionError
+import org.modelix.streams.count
 import org.modelix.streams.getSynchronous
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -52,5 +53,17 @@ class AsyncAsSynchronousTreeTest {
         }
 
         assertEquals("Node with ID 1 already exists.", exception.message)
+    }
+
+    @Test
+    fun largeNumberOfChildrenCanBeAdded() {
+        val largeNumber = 10_000
+        val concepts = Array(largeNumber) { NullConcept.getReference() }
+        val ids = concepts.mapIndexed { index, _ -> ITree.ROOT_ID + 1 + index }.toLongArray()
+
+        val newTree = tree.addNewChildren(ITree.ROOT_ID, NullChildLinkReference, 0, ids, concepts).getSynchronous()
+
+        val childCount = newTree.getAllChildren(ITree.ROOT_ID).count().getSynchronous()
+        assertEquals(largeNumber, childCount)
     }
 }

--- a/model-datastructure/src/commonTest/kotlin/org/modelix/model/async/AsyncAsSynchronousTreeTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/org/modelix/model/async/AsyncAsSynchronousTreeTest.kt
@@ -1,0 +1,56 @@
+package org.modelix.model.async
+
+import org.modelix.model.api.ITree
+import org.modelix.model.api.NullChildLinkReference
+import org.modelix.model.api.meta.NullConcept
+import org.modelix.model.lazy.NonCachingObjectStore
+import org.modelix.model.lazy.createNewTreeData
+import org.modelix.model.persistent.MapBasedStore
+import org.modelix.streams.StreamAssertionError
+import org.modelix.streams.getSynchronous
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AsyncAsSynchronousTreeTest {
+
+    private val asyncStore = NonCachingObjectStore(MapBasedStore()).getAsyncStore()
+    private val cpTree = createNewTreeData(asyncStore)
+    val tree = AsyncTree(cpTree, asyncStore)
+
+    @Test
+    fun failWhenDuplicateIDsAreSpecified() {
+        val concepts = arrayOf(NullConcept.getReference(), NullConcept.getReference())
+        val ids = longArrayOf(1L, 1L)
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            tree.addNewChildren(ITree.ROOT_ID, NullChildLinkReference, 0, ids, concepts).getSynchronous()
+        }
+
+        assertEquals("The specified IDs are not unique.", exception.message)
+    }
+
+    @Test
+    fun failWhenNotSameNumberOfIDsAndConceptsIsSpecified() {
+        val concepts = arrayOf(NullConcept.getReference(), NullConcept.getReference())
+        val ids: LongArray = longArrayOf(1L)
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            tree.addNewChildren(ITree.ROOT_ID, NullChildLinkReference, 0, ids, concepts).getSynchronous()
+        }
+
+        assertEquals("The number of IDs and concepts should be the same. 1 IDs and 2 concepts provided.", exception.message)
+    }
+
+    @Test
+    fun failWhenIdAlreadyExists() {
+        val concepts = arrayOf(NullConcept.getReference())
+        val ids: LongArray = longArrayOf(ITree.ROOT_ID)
+
+        val exception = assertFailsWith<StreamAssertionError> {
+            tree.addNewChildren(ITree.ROOT_ID, NullChildLinkReference, 0, ids, concepts).getSynchronous()
+        }
+
+        assertEquals("Node with ID 1 already exists.", exception.message)
+    }
+}


### PR DESCRIPTION
Avoid stack overflows when adding many children at once by executing reactive streams in Kotlin Flows.

* [ ] Check how `getAll` and `putAll` could be added to `CPHamtNode` so that no long chains of `flatMap`/`andThen` are needed in the first place.
* [ ] Check [performance impact](https://github.com/modelix/modelix.core/runs/35876345231) of changes.

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
