### PR TITLE
feat(model-datastructure): a version can now contain multiple trees

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/IModel.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/IModel.kt
@@ -6,18 +6,21 @@ import org.modelix.model.area.IAreaReference
 
 interface IModel : ITransactionManager {
     fun getRootNode(): IReadableNode
+    fun getRootNodes(): List<IReadableNode>
     fun resolveNode(ref: INodeReference): IReadableNode?
 }
 
 interface IMutableModel : IModel {
     fun asArea(): IArea = ModelAsArea(this)
     override fun getRootNode(): IWritableNode
+    override fun getRootNodes(): List<IWritableNode>
     override fun resolveNode(ref: INodeReference): IWritableNode?
 }
 
 data class AreaAsModel(val area: IArea) : IMutableModel {
     override fun asArea(): IArea = area
     override fun getRootNode(): IWritableNode = area.getRoot().asWritableNode()
+    override fun getRootNodes(): List<IWritableNode> = listOf(getRootNode())
     override fun resolveNode(ref: INodeReference): IWritableNode? = area.resolveNode(ref)?.asWritableNode()
     override fun <R> executeRead(body: () -> R): R = area.executeRead(body)
     override fun <R> executeWrite(body: () -> R): R = area.executeWrite(body)

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/IVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/IVersion.kt
@@ -1,8 +1,28 @@
 package org.modelix.model
 
 import org.modelix.model.api.ITree
+import kotlin.jvm.JvmInline
 
 interface IVersion {
     fun getContentHash(): String
     fun getTree(): ITree
+    fun getTrees(): Map<TreeType, ITree>
+}
+
+@JvmInline
+value class TreeType(val name: String) {
+    init {
+        for (c in name) {
+            if (!('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9')) {
+                throw IllegalArgumentException("Name contains illegal characters: $name")
+            }
+        }
+    }
+
+    override fun toString(): String = name.ifEmpty { "<main>" }
+
+    companion object {
+        val MAIN = TreeType("")
+        val META = TreeType("meta")
+    }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/persistent/CPVersion.kt
@@ -1,5 +1,6 @@
 package org.modelix.model.persistent
 
+import org.modelix.model.TreeType
 import org.modelix.model.lazy.CLVersion.Companion.INLINED_OPS_LIMIT
 import org.modelix.model.objects.IObjectData
 import org.modelix.model.objects.IObjectDeserializer
@@ -17,7 +18,7 @@ data class CPVersion(
     val time: String?,
     val author: String?,
 
-    val treeRef: ObjectReference<CPTree>,
+    val treeRefs: Map<TreeType, ObjectReference<CPTree>>,
     val previousVersion: ObjectReference<CPVersion>?,
 
     /**
@@ -36,7 +37,6 @@ data class CPVersion(
 ) : IObjectData {
 
     init {
-        requireNotNull(treeRef) { "No tree hash provided" }
         if ((operations == null) == (operationsHash == null)) {
             throw RuntimeException("Only one of 'operations' and 'operationsHash' can be provided")
         }
@@ -48,6 +48,10 @@ data class CPVersion(
         }
     }
 
+    fun getTree(type: TreeType): ObjectReference<CPTree> {
+        return checkNotNull(treeRefs[type]) { "Version $this doesn't contain a $type tree" }
+    }
+
     override fun serialize(): String {
         val opsPart: String = operationsHash?.getHash()?.toString()
             ?: if (operations!!.isEmpty()) {
@@ -55,11 +59,18 @@ data class CPVersion(
             } else {
                 operations.joinToString(Separators.OPS) { OperationSerializer.INSTANCE.serialize(it) }
             }
+        val serializedTrees = treeRefs.entries.sortedBy { it.key.name }.joinToString(Separators.LEVEL2) {
+            if (it.key == TreeType.MAIN) {
+                it.value.getHashString()
+            } else {
+                it.key.name + Separators.MAPPING + it.value.getHashString()
+            }
+        }
         val s = Separators.LEVEL1
         return longToHex(id) +
             s + escape(time) +
             s + escape(author) +
-            s + nullAsEmptyString(treeRef.getHashString()) +
+            s + serializedTrees +
             s + nullAsEmptyString(baseVersion?.getHashString()) +
             s + nullAsEmptyString(mergedVersion1?.getHashString()) +
             s + nullAsEmptyString(mergedVersion2?.getHashString()) +
@@ -69,14 +80,13 @@ data class CPVersion(
 
     override fun getContainmentReferences(): List<ObjectReference<out IObjectData>> {
         return listOfNotNull(
-            treeRef,
             previousVersion,
             originalVersion,
             baseVersion,
             mergedVersion1,
             mergedVersion2,
             operationsHash,
-        )
+        ) + treeRefs.values
     }
 
     override fun getNonContainmentReferences(): List<ObjectReference<IObjectData>> {
@@ -104,14 +114,24 @@ data class CPVersion(
                             .filter { cs -> cs.isNotEmpty() }
                             .map { OperationSerializer.INSTANCE.deserialize(it, referenceFactory) }
                     }
+
+                    val treeHashes = checkNotNull(emptyStringAsNull(parts[3])) { "Tree hash empty in $serialized" }
+                        .split(Separators.LEVEL2)
+                        .associate {
+                            it.split(Separators.MAPPING).let {
+                                when (it.size) {
+                                    1 -> TreeType.MAIN to referenceFactory(it[0], CPTree)
+                                    2 -> TreeType(it[0]) to referenceFactory(it[1], CPTree)
+                                    else -> throw IllegalArgumentException("Invalid tree reference $it in $serialized")
+                                }
+                            }
+                        }
+
                     val data = CPVersion(
                         longFromHex(parts[0]),
                         unescape(parts[1]),
                         unescape(parts[2]),
-                        treeRef = referenceFactory.fromHashString(
-                            checkNotNull(emptyStringAsNull(parts[3])) { "Tree hash empty in $serialized" },
-                            CPTree.DESERIALIZER,
-                        ),
+                        treeRefs = treeHashes,
                         previousVersion = null,
                         originalVersion = null,
                         baseVersion = emptyStringAsNull(parts[4])?.let { referenceFactory(it, CPVersion) },
@@ -123,6 +143,8 @@ data class CPVersion(
                     )
                     return data
                 } else {
+                    // legacy serialization format
+
                     var opsHash: String? = null
                     var ops: List<IOperation>? = null
                     if (HashUtil.isSha256(parts[5])) {
@@ -142,10 +164,7 @@ data class CPVersion(
                         id = longFromHex(parts[0]),
                         time = unescape(parts[1]),
                         author = unescape(parts[2]),
-                        treeRef = referenceFactory(
-                            checkNotNull(emptyStringAsNull(parts[3])) { "Tree hash empty in $serialized" },
-                            CPTree.DESERIALIZER,
-                        ),
+                        treeRefs = mapOf(TreeType.MAIN to referenceFactory(checkNotNull(emptyStringAsNull(parts[3])) { "Tree hash empty in $serialized" }, CPTree.DESERIALIZER)),
                         previousVersion = emptyStringAsNull(parts[4])?.let { referenceFactory(it, DESERIALIZER) },
                         originalVersion = if (parts.size > 7) {
                             emptyStringAsNull(parts[7])?.let { referenceFactory(it, DESERIALIZER) }


### PR DESCRIPTION
Having a separate tree for the metamodel instead of putting model and metamodel into the same tree makes the diffing faster. You can more quickly detect that the metamodel didn't change by just comparing the hash of the tree. Some listener that processes metamodel changes then doesn't have to process and ignore all the unrelated model changes.