### PR TITLE
test(bulk-model-sync-lib): fix flaky test `can handle random changes`

### DIFF
--- a/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/AbstractModelSyncTest.kt
+++ b/bulk-model-sync-lib/src/commonTest/kotlin/org/modelix/model/sync/bulk/AbstractModelSyncTest.kt
@@ -592,7 +592,7 @@ abstract class AbstractModelSyncTest {
     @Test
     @JsName("can_handle_random_changes")
     fun `can handle random changes`() {
-        for (seed in (1..100)) {
+        for (seed in (1..30)) {
             runRandomTest(seed + 6787456)
         }
     }


### PR DESCRIPTION
On CI it still runs into the 60s timeout sometimes.