### PR TITLE
feat(mps-sync-plugin): repositoryId can be passed to the token endpoint

### DIFF
--- a/model-client/build.gradle.kts
+++ b/model-client/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `maven-publish`
     `modelix-kotlin-multiplatform`
     alias(libs.plugins.npm.publish)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 val kotlinCoroutinesVersion: String by rootProject
@@ -70,6 +71,11 @@ kotlin {
             dependencies {
                 implementation(libs.logback.classic)
                 implementation(libs.testcontainers)
+                implementation(libs.ktor.server.test.host)
+                implementation(libs.ktor.server.auth)
+                implementation(libs.ktor.server.netty)
+                implementation(libs.ktor.server.content.negotiation)
+                implementation(libs.ktor.serialization.json)
             }
         }
         val jsMain by getting {

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -754,7 +754,7 @@ abstract class ModelClientV2Builder {
                     }
                 }
             }
-            authConfig?.let { ModelixAuthClient.installAuth(this, it) }
+            authConfig?.let { ModelixAuthClient().installAuth(this, it) }
         }
     }
 

--- a/model-client/src/commonMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -9,7 +9,7 @@ import io.ktor.client.plugins.auth.providers.bearer
  * Functions and states for authenticating to a model server.
  * Configuration differs for JS and JVM.
  */
-expect object ModelixAuthClient {
+expect class ModelixAuthClient() {
     /**
      * Function to configure the authentication for an HTTP client.
      *

--- a/model-client/src/commonMain/kotlin/org/modelix/model/oauth/OAuthConfig.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/oauth/OAuthConfig.kt
@@ -1,5 +1,7 @@
 package org.modelix.model.oauth
 
+import org.modelix.model.lazy.RepositoryId
+
 sealed interface IAuthConfig {
     companion object {
         fun fromTokenProvider(provider: TokenProvider): IAuthConfig {
@@ -19,6 +21,7 @@ data class OAuthConfig(
     val clientSecret: String? = null,
     val authorizationUrl: String? = null,
     val tokenUrl: String? = null,
+    val repositoryId: RepositoryId? = null,
     val scopes: Set<String> = emptySet(),
     val authRequestHandler: IAuthRequestHandler? = null,
 ) : IAuthConfig
@@ -36,6 +39,7 @@ class OAuthConfigBuilder(initial: OAuthConfig?) {
     fun additionalScope(scope: String) = additionalScopes(setOf(scope))
     fun authorizationUrl(url: String) = also { config = config.copy(authorizationUrl = url) }
     fun tokenUrl(url: String) = also { config = config.copy(tokenUrl = url) }
+    fun repositoryId(repositoryId: RepositoryId) = also { config = config.copy(repositoryId = repositoryId) }
     fun oidcUrl(url: String) = authorizationUrl(url.trimEnd('/') + "/auth").tokenUrl(url.trimEnd('/') + "/token")
     fun authRequestHandler(handler: IAuthRequestHandler?) = also { config = config.copy(authRequestHandler = handler) }
 

--- a/model-client/src/jsMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -3,7 +3,7 @@ package org.modelix.model.oauth
 import io.ktor.client.HttpClientConfig
 
 @Suppress("UndocumentedPublicClass") // already documented in the expected declaration
-actual object ModelixAuthClient {
+actual class ModelixAuthClient {
     @Suppress("UndocumentedPublicFunction") // already documented in the expected declaration
     actual fun installAuth(
         config: HttpClientConfig<*>,

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/client/RestWebModelClient.kt
@@ -148,12 +148,13 @@ class RestWebModelClient @JvmOverloads constructor(
                 },
             )
         }
+        val modelixAuthClient = ModelixAuthClient()
         install(Auth) {
             bearer {
                 loadTokens {
                     val tp = authTokenProvider
                     if (tp == null) {
-                        ModelixAuthClient.getTokens()?.let { BearerTokens(it.accessToken, it.refreshToken) }
+                        modelixAuthClient.getTokens()?.let { BearerTokens(it.accessToken, it.refreshToken) }
                     } else {
                         val token = tp()
                         if (token == null) {

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
 import org.modelix.kotlin.utils.urlEncode
 
 @Suppress("UndocumentedPublicClass") // already documented in the expected declaration
-actual object ModelixAuthClient {
+actual class ModelixAuthClient {
     private var DATA_STORE_FACTORY: DataStoreFactory = MemoryDataStoreFactory()
     private val HTTP_TRANSPORT: HttpTransport = NetHttpTransport()
     private val JSON_FACTORY: JsonFactory = GsonFactory()

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/OAuthTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/OAuthTest.kt
@@ -30,7 +30,7 @@ import kotlin.time.toJavaDuration
 class OAuthTest {
 
     @Test
-    fun test() = runWithModelServer { url ->
+    fun `client automatically authenticates using oauth`() = runWithModelServer { url ->
         val client = ModelClientV2.builder()
             .url(url)
             .retries(1U)

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/TokenEndpointTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/TokenEndpointTest.kt
@@ -1,0 +1,125 @@
+package org.modelix.model.client2
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.buildUrl
+import io.ktor.http.takeFrom
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.auth.UnauthorizedResponse
+import io.ktor.server.auth.parseAuthorizationHeader
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.modelix.kotlin.utils.filterNotNullValues
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequestHandler
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Serializable
+private data class TokenResponse(
+    @SerialName("access_token")
+    val accessToken: String,
+)
+
+class TokenEndpointTest {
+
+    @Test
+    fun `repository is passed to token endpoint`() = runTest {
+        var tokenEndpointWasCalled = false
+        val expectedRepoId = "my-repo"
+        val expectedToken = "my-token"
+        val expectedBranches = listOf(
+            RepositoryId(expectedRepoId).getBranchReference("a"),
+            RepositoryId(expectedRepoId).getBranchReference("b"),
+        )
+
+        suspend fun runWithServer(body: suspend (port: Int) -> Unit) {
+            // real server need instead of ktor.test because the PKCE flow is implemented by a non-ktor client
+            val server = embeddedServer(Netty, port = Random.nextInt(20000, 60000)) {
+                install(io.ktor.server.plugins.contentnegotiation.ContentNegotiation) {
+                    json()
+                }
+                routing {
+                    post("/token") {
+                        tokenEndpointWasCalled = true
+                        val repositoryId = call.queryParameters["repository-id"]
+                        assertEquals(expectedRepoId, repositoryId)
+                        call.respond(
+                            TokenResponse(
+                                accessToken = expectedToken,
+                            ),
+                        )
+                    }
+
+                    get("/v2/repositories/{repository-id}/branches") {
+                        val authHeader = call.request.parseAuthorizationHeader()
+                        if (authHeader is HttpAuthHeader.Single && authHeader.authScheme == "Bearer" && authHeader.blob == expectedToken) {
+                            call.respondText(expectedBranches.joinToString("\n") { it.branchName })
+                        } else {
+                            val port = engine.resolvedConnectors().single().port
+                            call.respond(
+                                UnauthorizedResponse(
+                                    HttpAuthHeader.Parameterized(
+                                        "Bearer",
+                                        mapOf(
+                                            HttpAuthHeader.Parameters.Realm to "modelix",
+                                            "error" to "invalid_token",
+                                            "authorization_uri" to "http://localhost:$port/auth",
+                                            "token_uri" to "http://localhost:$port/token?repository-id={repositoryId}",
+                                        ).filterNotNullValues(),
+                                    ),
+                                ),
+                            )
+                        }
+                    }
+                }
+            }.startSuspend()
+            try {
+                body(server.engine.resolvedConnectors().single().port)
+            } finally {
+                server.stop()
+            }
+        }
+
+        runWithServer { port ->
+            val modelClient = ModelClientV2.builder().url("http://localhost:$port").authConfig(
+                IAuthConfig.oauth {
+                    authRequestHandler(object : IAuthRequestHandler {
+                        override fun browse(url: String) {
+                            // https://localhost/realms/modelix/protocol/openid-connect/auth?client_id=my-client-id&code_challenge=YzBhqU2-lRzCkoSLVc0BGN3_AlwU5YUpYS1_m_6FMbI&code_challenge_method=S256&redirect_uri=http://127.0.0.1:64186/Callback&response_type=code&scope=email
+                            val redirectUri = io.ktor.http.Url(url).parameters["redirect_uri"]!!
+                            val callbackWithCode = buildUrl {
+                                takeFrom(redirectUri)
+                                parameters.append("code", "abc")
+                            }
+                            runBlocking {
+                                HttpClient(CIO).get(callbackWithCode)
+                            }
+                        }
+                    })
+                    clientId("my-client-id")
+                    repositoryId(RepositoryId(expectedRepoId))
+                },
+            ).build()
+
+            val actualBranches = modelClient.listBranches(RepositoryId(expectedRepoId))
+            assertEquals(expectedBranches, actualBranches)
+            assertTrue(tokenEndpointWasCalled, "Token endpoint was not called")
+        }
+    }
+}

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/IModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/IModelSyncService.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import org.modelix.model.IVersion
 import org.modelix.model.client2.IModelClientV2
 import org.modelix.model.lazy.BranchReference
+import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.oauth.OAuthConfigBuilder
 import java.io.Closeable
 
@@ -24,7 +25,7 @@ interface IModelSyncService {
         }
     }
 
-    fun addServer(url: String): IServerConnection
+    fun addServer(url: String, repositoryId: RepositoryId? = null): IServerConnection
     fun getServerConnections(): List<IServerConnection>
     fun getBindings(): List<IBinding>
 }

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
@@ -41,8 +41,8 @@ class ModelSyncService(val project: Project) :
     private val coroutinesScope = CoroutineScope(Dispatchers.IO)
 
     @Synchronized
-    override fun addServer(url: String): Connection {
-        return AppLevelModelSyncService.getInstance().addConnection(url).let { Connection(it) }
+    override fun addServer(url: String, repositoryId: RepositoryId?): Connection {
+        return AppLevelModelSyncService.getInstance().addConnection(url, repositoryId).let { Connection(it) }
     }
 
     @Synchronized
@@ -166,7 +166,7 @@ class ModelSyncService(val project: Project) :
             BindingWorker(
                 coroutinesScope,
                 mpsProject,
-                serverConnection = addServer(id.url),
+                serverConnection = addServer(id.url, id.branchRef.repositoryId),
                 branchRef = id.branchRef,
                 initialVersionHash = state?.versionHash,
                 continueOnError = { IModelSyncService.continueOnError ?: true },


### PR DESCRIPTION
A token URL can now contain a placeholder `{repositoryId}` which is replaced with the repository ID the sync plugin tries to access.