### PR TITLE
fix(mps-sync-plugin): initial sync was trying to checkout an empty repository

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/SimpleConcept.kt
@@ -16,7 +16,7 @@ open class SimpleConcept(
 
     override fun getUID(): String = uid ?: getLongName()
 
-    override fun getReference(): IConceptReference {
+    override fun getReference(): ConceptReference {
         return ConceptReference(getUID())
     }
 

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
@@ -30,6 +30,7 @@ import org.modelix.model.api.getRootNode
 import org.modelix.model.async.IAsyncObjectStore
 import org.modelix.model.async.ObjectRequest
 import org.modelix.model.historyDiff
+import org.modelix.model.mutable.IMutableModelTree
 import org.modelix.model.mutable.INodeIdGenerator
 import org.modelix.model.mutable.VersionedModelTree
 import org.modelix.model.mutable.getRootNode
@@ -446,10 +447,18 @@ fun IVersion.runWriteOnModel(
     author: String?,
     body: (IWritableNode) -> Unit,
 ): IVersion {
+    return runWriteOnTree(nodeIdGenerator, author) { body(it.getRootNode()) }
+}
+
+fun IVersion.runWriteOnTree(
+    nodeIdGenerator: INodeIdGenerator<INodeReference>,
+    author: String?,
+    body: (IMutableModelTree) -> Unit,
+): IVersion {
     val baseVersion = this as CLVersion
     val mutableTree = VersionedModelTree(baseVersion, nodeIdGenerator)
     mutableTree.runWrite {
-        body(mutableTree.getRootNode())
+        body(mutableTree)
     }
     return mutableTree.createVersion(author) ?: baseVersion
 }


### PR DESCRIPTION
If a repository was already initialized, but didn't contain any data yet, the plugin still ignored the local project and tried to check out the remote version, which failed.