### PR TITLE
fix(model-datastructure): no longer depend on the slf4j-binding logback-classic

### DIFF
--- a/model-datastructure/build.gradle.kts
+++ b/model-datastructure/build.gradle.kts
@@ -27,6 +27,10 @@ kotlin {
                 implementation(libs.trove4j)
                 implementation(libs.apache.commons.collections)
                 implementation(libs.kotlin.coroutines.core)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
                 implementation(libs.logback.classic)
             }
         }


### PR DESCRIPTION
libraries should not depend on slf4j-bindings to avoid https://www.slf4j.org/codes.html#multiple_bindings

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
