### PR TITLE
fix(model-datastructure): handle conflict between operations that add the same node

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeReference.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/api/PNodeReference.kt
@@ -3,6 +3,8 @@ package org.modelix.model.api
 import org.modelix.model.area.IArea
 
 data class PNodeReference(val id: Long, val treeId: String) : INodeReference() {
+    constructor(treeId: String, nodeId: Long) : this(nodeId, treeId)
+
     @Deprecated("Renamed to treeId", ReplaceWith("treeId"))
     val branchId: String get() = treeId
 

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/model/GenericModelTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/model/GenericModelTree.kt
@@ -190,7 +190,9 @@ abstract class GenericModelTree<NodeId>(
             .distinct()
             .map { IReferenceLinkReference.fromString(it) }
             .forEach { role: IReferenceLinkReference ->
-                if (oldNode.getReferenceTarget(role) != newNode.getReferenceTarget(role)) {
+                val oldTarget = oldNode.getReferenceTarget(role)?.let { oldTree.toGlobalNodeReference(it) }
+                val newTarget = newNode.getReferenceTarget(role)?.let { toGlobalNodeReference(it) }
+                if (oldTarget != newTarget) {
                     changes += ReferenceChangedEvent(newNode.id, role)
                 }
             }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/AutoTransactionsModelTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/AutoTransactionsModelTree.kt
@@ -57,6 +57,10 @@ class AutoTransactionsModelTree<NodeId>(val mutableTree: IGenericMutableModelTre
             mutableTree.runWrite { it.mutate(parameters) }
         }
 
+        override fun getIdGenerator(): INodeIdGenerator<NodeId> {
+            return mutableTree.getIdGenerator()
+        }
+
         override var tree: IGenericModelTree<NodeId>
             get() = mutableTree.runRead { it.tree }
             set(value) { mutableTree.runWrite { it.tree = value } }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/INodeIdGenerator.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/INodeIdGenerator.kt
@@ -1,0 +1,28 @@
+package org.modelix.model.mutable
+
+import org.modelix.model.TreeId
+import org.modelix.model.api.IIdGenerator
+import org.modelix.model.api.INodeReference
+import org.modelix.model.api.PNodeReference
+
+interface INodeIdGenerator<NodeId> {
+    fun generate(parentNode: NodeId): NodeId
+}
+
+class DummyIdGenerator<NodeId>() : INodeIdGenerator<NodeId> {
+    override fun generate(parentNode: NodeId): NodeId {
+        throw UnsupportedOperationException("Creating nodes with new ID is not supported")
+    }
+}
+
+class ModelixIdGenerator(val int64Generator: IIdGenerator, val treeId: TreeId) : INodeIdGenerator<INodeReference> {
+    override fun generate(parentNode: INodeReference): INodeReference {
+        return PNodeReference(int64Generator.generate(), treeId.id)
+    }
+}
+
+class Int64IdGenerator(val int64Generator: IIdGenerator) : INodeIdGenerator<Long> {
+    override fun generate(parentNode: Long): Long {
+        return int64Generator.generate()
+    }
+}

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/VersionedModelTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/VersionedModelTree.kt
@@ -168,6 +168,10 @@ class VersionedModelTree(
                 throw UnsupportedOperationException()
             }
 
+        override fun getIdGenerator(): INodeIdGenerator<INodeReference> {
+            return t.getIdGenerator()
+        }
+
         override fun mutate(parameters: MutationParameters<INodeReference>) {
             when (parameters) {
                 is MutationParameters.AddNew<INodeReference> -> {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AddNewChildOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/AddNewChildOp.kt
@@ -2,10 +2,13 @@ package org.modelix.model.operations
 
 import org.modelix.datastructures.model.IModelTree
 import org.modelix.datastructures.model.MutationParameters
+import org.modelix.datastructures.model.getAncestors
 import org.modelix.datastructures.model.toGlobal
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.INodeReference
 import org.modelix.model.mutable.IMutableModelTree
+import org.modelix.streams.IStream
+import org.modelix.streams.contains
 import org.modelix.streams.getBlocking
 
 class AddNewChildOp(
@@ -66,11 +69,51 @@ open class AddNewChildrenOp(val position: PositionInRole, val childIdsAndConcept
 
     inner class Intend(val capturedPosition: CapturedInsertPosition) : IOperationIntend {
         override fun restoreIntend(tree: IModelTree): List<IOperation> {
-            if (tree.containsNode(position.nodeId.toGlobal(tree.getId())).getBlocking(tree)) {
-                val newIndex = capturedPosition.findIndex(tree.getChildren(position.nodeId.toGlobal(tree.getId()), position.role).toList().getBlocking(tree))
-                return listOf(withPosition(position.withIndex(newIndex)))
+            val parentExists = tree.containsNode(position.nodeId.toGlobal(tree.getId())).getBlocking(tree)
+            val childExists = IStream.many(childIdsAndConcepts).flatMap { tree.containsNode(it.first) }.toList().getBlocking(tree)
+            val targetPosition = if (parentExists) {
+                val newIndex = if (position.index < 0) {
+                    position.index
+                } else {
+                    capturedPosition.findIndex(
+                        tree.getChildren(position.nodeId.toGlobal(tree.getId()), position.role).toList().getBlocking(tree),
+                        position.index,
+                    )
+                }
+                position.withIndex(newIndex)
             } else {
-                return listOf(withPosition(getDetachedNodesEndPosition(tree)))
+                getDetachedNodesEndPosition(tree)
+            }
+            return if (childExists.none { it }) {
+                // default behaviour
+                listOf(withPosition(targetPosition))
+            } else {
+                // handle already existing child IDs
+                childIdsAndConcepts.zip(childExists).asReversed().flatMap { (idAndConcept, exists) ->
+                    val (childId, childConcept) = idAndConcept
+                    val currentContainment = tree.getContainment(childId).getBlocking(tree)
+
+                    // If the containment is correct, ignore the index to avoid unnecessary changes. As part of the
+                    // conflict resolution algorithm we are allowed to make any decision. There are no right or wrong
+                    // transformations.
+                    if (position.index < 0 &&
+                        currentContainment != null &&
+                        currentContainment.first == targetPosition.nodeId &&
+                        currentContainment.second.matches(targetPosition.role)
+                    ) {
+                        return@flatMap emptyList()
+                    }
+
+                    if (exists) {
+                        if (tree.getAncestors(targetPosition.nodeId.toGlobal(tree.getId()), false).contains(childId.toGlobal(tree.getId())).getBlocking(tree)) {
+                            emptyList()
+                        } else {
+                            listOf(MoveNodeOp(childId, targetPosition))
+                        }
+                    } else {
+                        listOf(AddNewChildOp(targetPosition, childId, childConcept))
+                    }
+                }
             }
         }
 

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/CapturedInsertPosition.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/CapturedInsertPosition.kt
@@ -9,7 +9,18 @@ class CapturedInsertPosition(val siblingsBefore: List<INodeReference>, val sibli
     )
 
     fun findIndex(children: List<INodeReference>): Int {
-        if (children == (siblingsBefore + siblingsAfter)) return siblingsBefore.size
+        return findIndexRange(children).last
+    }
+
+    fun findIndex(children: List<INodeReference>, preferredIndex: Int): Int {
+        val range = findIndexRange(children)
+        if (range.contains(preferredIndex)) return preferredIndex
+        if (preferredIndex <= range.first) return range.first
+        return range.last
+    }
+
+    fun findIndexRange(children: List<INodeReference>): IntRange {
+        if (children == (siblingsBefore + siblingsAfter)) return siblingsBefore.size..siblingsBefore.size
 
         var leftIndex = 0
         var rightIndex = children.size
@@ -30,6 +41,10 @@ class CapturedInsertPosition(val siblingsBefore: List<INodeReference>, val sibli
             }
         }
 
-        return if (leftIndex < rightIndex) rightIndex else leftIndex
+        return if (leftIndex < rightIndex) {
+            leftIndex..rightIndex
+        } else {
+            leftIndex..leftIndex
+        }
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/LegacyBranchAsMutableModelTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/LegacyBranchAsMutableModelTree.kt
@@ -78,6 +78,10 @@ class LegacyBranchAsMutableModelTree(val branch: IBranch) : IGenericMutableModel
             get() = t.tree.asModelTree().withIdTranslation()
             set(value) { TODO() }
 
+        override fun getIdGenerator(): INodeIdGenerator<INodeReference> {
+            throw UnsupportedOperationException()
+        }
+
         override fun mutate(parameters: MutationParameters<INodeReference>) {
             when (parameters) {
                 is MutationParameters.AddNew<INodeReference> -> {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/MoveNodeOp.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/operations/MoveNodeOp.kt
@@ -51,17 +51,18 @@ class MoveNodeOp(val childId: INodeReference, val targetPosition: PositionInRole
 
     inner class Intend(val capturedTargetPosition: CapturedInsertPosition) : IOperationIntend {
         override fun restoreIntend(tree: IModelTree): List<IOperation> {
-            if (!tree.containsNode(childId.toGlobal(tree.getId())).getBlocking(tree)) return listOf(NoOp())
+            if (!tree.containsNode(childId.toGlobal(tree.getId())).getBlocking(tree)) return emptyList()
             val newSourcePosition = getNodePosition(tree, childId.toGlobal(tree.getId()))
             if (!tree.containsNode(targetPosition.nodeId.toGlobal(tree.getId())).getBlocking(tree)) {
                 return listOf(
                     withPos(getDetachedNodesEndPosition(tree)),
                 )
             }
-            if (tree.getAncestors(targetPosition.nodeId.toGlobal(tree.getId()), false).contains(childId.toGlobal(tree.getId())).getBlocking(tree)) return listOf(NoOp())
+            if (tree.getAncestors(targetPosition.nodeId.toGlobal(tree.getId()), false).contains(childId.toGlobal(tree.getId())).getBlocking(tree)) return emptyList()
             val newTargetPosition = if (tree.containsNode(targetPosition.nodeId.toGlobal(tree.getId())).getBlocking(tree)) {
                 val newTargetIndex = capturedTargetPosition.findIndex(
                     tree.getChildren(targetPosition.nodeId.toGlobal(tree.getId()), targetPosition.role).toList().getBlocking(tree),
+                    targetPosition.index,
                 )
                 targetPosition.withIndex(newTargetIndex)
             } else {

--- a/model-datastructure/src/commonTest/kotlin/DuplicateImportConflictTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/DuplicateImportConflictTest.kt
@@ -1,0 +1,173 @@
+import org.modelix.datastructures.model.ChildrenChangedEvent
+import org.modelix.datastructures.model.IGenericModelTree
+import org.modelix.datastructures.model.ReferenceChangedEvent
+import org.modelix.datastructures.objects.FullyLoadedObjectGraph
+import org.modelix.model.IVersion
+import org.modelix.model.TreeId
+import org.modelix.model.VersionMerger
+import org.modelix.model.api.IChildLinkReference
+import org.modelix.model.api.INodeReference
+import org.modelix.model.api.PNodeReference
+import org.modelix.model.api.meta.NullConcept
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.lazy.runWriteOnTree
+import org.modelix.model.mutable.IGenericMutableModelTree
+import org.modelix.model.mutable.ModelixIdGenerator
+import org.modelix.model.mutable.addNewChild
+import org.modelix.model.mutable.getRootNodeId
+import org.modelix.model.mutable.removeNode
+import org.modelix.model.mutable.treeId
+import org.modelix.streams.getBlocking
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * This simulates the case when two instances of the mps-sync-plugin synchronize the same state of an MPS project
+ * concurrently.
+ */
+class DuplicateImportConflictTest : TreeTestBase() {
+
+    @Test
+    fun `add new child`() = duplicateImportTest(
+        {},
+        {
+            it.getWriteTransaction().addNewChild(
+                it.getTransaction().getRootNodeId(),
+                IChildLinkReference.fromName("role1"),
+                -1,
+                PNodeReference(it.getTransaction().treeId().id, 2),
+                NullConcept.getReference(),
+            )
+        },
+    )
+
+    @Test
+    fun `remove node`() = duplicateImportTest(
+        {
+            val t = it.getWriteTransaction()
+            t.addNewChild(
+                t.getRootNodeId(),
+                IChildLinkReference.fromName("role1"),
+                -1,
+                PNodeReference(t.treeId().id, 2),
+                NullConcept.getReference(),
+            )
+        },
+        {
+            val t = it.getWriteTransaction()
+            t.removeNode(PNodeReference(t.treeId().id, 2))
+        },
+    )
+
+    @Test fun `random changes 1`() = runRadomChangesTest(100, 1000, 498935, 92730)
+
+    @Test fun `random changes 2`() = runRadomChangesTest(100, 100, 1002, 3002)
+
+    @Test fun `random changes 3`() = runRadomChangesTest(100, 100, 1003, 3003)
+
+    @Test fun `random changes 4`() = runRadomChangesTest(100, 100, 1004, 3004)
+
+    @Test fun `random changes 5`() = runRadomChangesTest(100, 100, 1005, 3005)
+
+    @Test fun `random changes 6`() = runRadomChangesTest(100, 100, 1006, 3006)
+
+    @Test fun `random changes 7`() = runRadomChangesTest(100, 100, 1007, 3007)
+
+    @Test fun `random changes 8`() = runRadomChangesTest(100, 100, 1008, 3008)
+
+    @Test fun `random changes 9`() = runRadomChangesTest(100, 100, 1009, 3009)
+
+    @Test fun `random changes 10`() = runRadomChangesTest(100, 100, 1010, 3010)
+
+    @Test fun `random changes 11`() = runRadomChangesTest(100, 100, 1011, 3011)
+
+    @Test fun `random changes 12`() = runRadomChangesTest(100, 100, 1012, 3012)
+
+    @Test fun `random changes 13`() = runRadomChangesTest(100, 100, 1013, 3013)
+
+    @Test fun `random changes 14`() = runRadomChangesTest(100, 100, 1014, 3014)
+
+    @Test fun `random changes 15`() = runRadomChangesTest(100, 100, 1015, 3015)
+
+    @Test fun `random changes 16`() = runRadomChangesTest(100, 100, 1016, 3016)
+
+    @Test fun `random changes 17`() = runRadomChangesTest(100, 100, 1017, 3017)
+
+    @Test fun `random changes 18`() = runRadomChangesTest(100, 100, 1018, 3018)
+
+    @Test fun `random changes 19`() = runRadomChangesTest(100, 100, 1019, 3019)
+
+    @Test fun `random changes 20`() = runRadomChangesTest(100, 100, 1020, 3020)
+
+    fun runRadomChangesTest(initialChanges: Int, importChanges: Int, seed1: Int, seed2: Int) = duplicateImportTest(
+        { mutableTree ->
+            val randomTreeChangeGenerator = RandomTreeChangeGenerator(IdGenerator.newInstance(4), Random(seed1)).growingOperationsOnly()
+            repeat(initialChanges) {
+                randomTreeChangeGenerator.applyRandomChange(mutableTree, null)
+            }
+        },
+        { mutableTree ->
+            val randomTreeChangeGenerator = RandomTreeChangeGenerator(IdGenerator.newInstance(5), Random(seed2))
+            repeat(importChanges) {
+                randomTreeChangeGenerator.applyRandomChange(mutableTree, null)
+            }
+        },
+    )
+
+    fun duplicateImportTest(
+        baseChanges: (IGenericMutableModelTree<INodeReference>) -> Unit,
+        importChanges: (IGenericMutableModelTree<INodeReference>) -> Unit,
+    ) {
+        val merger = VersionMerger()
+        val emptyTree = IGenericModelTree.builder()
+            .withInt64Ids()
+            .treeId(TreeId.fromUUID("69dcb381-3dba-4251-b3ae-7aafe587c28e"))
+            .graph(FullyLoadedObjectGraph())
+            .build()
+        val emptyVersion = IVersion.builder().tree(emptyTree).build()
+        val baseVersion = emptyVersion.runWriteOnTree(ModelixIdGenerator(IdGenerator.newInstance(1), emptyTree.getId()), author = "base") {
+            baseChanges(it)
+        }
+        val import1Version = baseVersion.runWriteOnTree(ModelixIdGenerator(IdGenerator.newInstance(3), emptyTree.getId()), author = "importer1") {
+            importChanges(it)
+        }
+        val import2Version = baseVersion.runWriteOnTree(ModelixIdGenerator(IdGenerator.newInstance(3), emptyTree.getId()), author = "importer2") {
+            importChanges(it)
+        }
+        val mergedVersion = merger.mergeChange(import1Version, import2Version)
+
+        assertEquals<IVersion?>(import1Version, mergedVersion.getMergedVersion1())
+        assertEquals<IVersion?>(import2Version, mergedVersion.getMergedVersion2())
+        assertSameTree(import1Version.getModelTree(), import2Version.getModelTree())
+        assertSameTree(import1Version.getModelTree(), mergedVersion.getModelTree())
+    }
+
+    private fun <NodeId> assertSameTree(tree1: IGenericModelTree<NodeId>, tree2: IGenericModelTree<NodeId>) {
+        val changes = tree2.getChanges(tree1, false).toList().getBlocking(tree2)
+
+        for (changeEvent in changes) {
+            when (changeEvent) {
+                is ChildrenChangedEvent<NodeId> -> {
+                    val children1 = tree1.getChildren(changeEvent.nodeId, changeEvent.role).toList().getBlocking(tree1)
+                    val children2 = tree2.getChildren(changeEvent.nodeId, changeEvent.role).toList().getBlocking(tree2)
+                    println(changeEvent)
+                    println("    children1: $children1")
+                    println("    children2: $children2")
+                }
+                is ReferenceChangedEvent<NodeId> -> {
+                    val target1 = tree1.getReferenceTarget(changeEvent.nodeId, changeEvent.role).getBlocking(tree1)
+                    val target2 = tree2.getReferenceTarget(changeEvent.nodeId, changeEvent.role).getBlocking(tree2)
+                    println(changeEvent)
+                    println("    target1: $target1")
+                    println("    target2: $target2")
+                }
+                else -> {
+                    println(changeEvent)
+                }
+            }
+        }
+
+        assertEquals(listOf(), changes, "Trees are not the same: " + changes.joinToString("\n"))
+    }
+}

--- a/model-datastructure/src/commonTest/kotlin/RandomTreeChangeGenerator.kt
+++ b/model-datastructure/src/commonTest/kotlin/RandomTreeChangeGenerator.kt
@@ -1,11 +1,29 @@
+import org.modelix.datastructures.model.asLegacyTree
+import org.modelix.datastructures.model.extractInt64Id
+import org.modelix.datastructures.model.withIdTranslation
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.IBranch
+import org.modelix.model.api.IChildLinkReference
 import org.modelix.model.api.IConcept
+import org.modelix.model.api.IConceptReference
 import org.modelix.model.api.IIdGenerator
+import org.modelix.model.api.INodeReference
+import org.modelix.model.api.IPropertyReference
+import org.modelix.model.api.IReferenceLinkReference
 import org.modelix.model.api.ITree
 import org.modelix.model.api.IWriteTransaction
 import org.modelix.model.api.LocalPNodeReference
 import org.modelix.model.api.PBranch
+import org.modelix.model.api.PNodeReference
+import org.modelix.model.api.upcast
+import org.modelix.model.mutable.IGenericMutableModelTree
+import org.modelix.model.mutable.addNewChild
+import org.modelix.model.mutable.moveChild
+import org.modelix.model.mutable.removeNode
+import org.modelix.model.mutable.setConcept
+import org.modelix.model.mutable.setProperty
+import org.modelix.model.mutable.setReferenceTarget
+import org.modelix.streams.getBlocking
 import kotlin.random.Random
 
 class RandomTreeChangeGenerator(private val idGenerator: IIdGenerator, private val rand: Random) {
@@ -132,5 +150,171 @@ class RandomTreeChangeGenerator(private val idGenerator: IIdGenerator, private v
             val t = branch.writeTransaction
             operations[rand.nextInt(operations.size)](t, expectedTree)
         }
+    }
+
+    fun applyRandomChange(mutableTree: IGenericMutableModelTree<INodeReference>, expectedTree: ExpectedTreeData?) {
+        mutableTree.runWrite {
+            val t = TransactionAdapter(it)
+            operations[rand.nextInt(operations.size)](t, expectedTree)
+        }
+    }
+}
+
+private class TransactionAdapter(val transaction: IGenericMutableModelTree.WriteTransaction<INodeReference>) : IWriteTransaction {
+    private fun Long.translate() = PNodeReference(transaction.tree.getId().id, this)
+    private fun INodeReference.translate() = extractInt64Id(transaction.tree.getId())
+
+    override var tree: ITree
+        get() = transaction.tree.withIdTranslation().asLegacyTree()
+        set(value) {
+            throw UnsupportedOperationException()
+        }
+
+    override fun setProperty(nodeId: Long, role: String, value: String?) {
+        transaction.setProperty(nodeId.translate(), IPropertyReference.fromString(role), value)
+    }
+
+    override fun setReferenceTarget(
+        sourceId: Long,
+        role: String,
+        target: INodeReference?,
+    ) {
+        transaction.setReferenceTarget(sourceId.translate(), IReferenceLinkReference.fromString(role), target)
+    }
+
+    override fun moveChild(
+        newParentId: Long,
+        newRole: String?,
+        newIndex: Int,
+        childId: Long,
+    ) {
+        transaction.moveChild(newParentId.translate(), IChildLinkReference.fromString(newRole), newIndex, childId.translate())
+    }
+
+    override fun addNewChild(
+        parentId: Long,
+        role: String?,
+        index: Int,
+        concept: IConcept?,
+    ): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun addNewChild(
+        parentId: Long,
+        role: String?,
+        index: Int,
+        concept: IConceptReference?,
+    ): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun addNewChild(
+        parentId: Long,
+        role: String?,
+        index: Int,
+        childId: Long,
+        concept: IConcept?,
+    ) {
+        transaction.addNewChild(
+            parentId.translate(),
+            IChildLinkReference.fromString(role),
+            index,
+            childId.translate(),
+            concept?.getReference().upcast(),
+        )
+    }
+
+    override fun addNewChild(
+        parentId: Long,
+        role: String?,
+        index: Int,
+        childId: Long,
+        concept: IConceptReference?,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addNewChildren(
+        parentId: Long,
+        role: String?,
+        index: Int,
+        concepts: Array<IConceptReference?>,
+    ): LongArray {
+        TODO("Not yet implemented")
+    }
+
+    override fun addNewChildren(
+        parentId: Long,
+        role: String?,
+        index: Int,
+        childIds: LongArray,
+        concepts: Array<IConceptReference?>,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setConcept(nodeId: Long, concept: IConceptReference?) {
+        transaction.setConcept(nodeId.translate(), concept.upcast())
+    }
+
+    override fun deleteNode(nodeId: Long) {
+        transaction.removeNode(nodeId.translate())
+    }
+
+    override val branch: IBranch
+        get() = TODO("Not yet implemented")
+
+    override fun containsNode(nodeId: Long): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getConcept(nodeId: Long): IConcept? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getConceptReference(nodeId: Long): IConceptReference? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParent(nodeId: Long): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRole(nodeId: Long): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getProperty(nodeId: Long, role: String): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getReferenceTarget(sourceId: Long, role: String): INodeReference? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getChildren(parentId: Long, role: String?): Iterable<Long> {
+        return transaction.tree.getChildren(parentId.translate(), IChildLinkReference.fromString(role))
+            .map { it.translate() }.toList().getBlocking(transaction.tree)
+    }
+
+    override fun getAllChildren(parentId: Long): Iterable<Long> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getReferenceRoles(sourceId: Long): Iterable<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPropertyRoles(sourceId: Long): Iterable<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUserObject(key: Any): Any? {
+        TODO("Not yet implemented")
+    }
+
+    override fun putUserObject(key: Any, value: Any?) {
+        TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
After preserving the identity of nodes during an import by the mps-sync-plugin it can happen that two imports both create a AddNewChildOp with the same child ID. During a merge this is a new type of conflict that wasn't handled yet.