### PR TITLE
fix(model-client): new versions have the current time set

### DIFF
--- a/model-client-js-test/replicated-model-test/package-lock.json
+++ b/model-client-js-test/replicated-model-test/package-lock.json
@@ -23,7 +23,7 @@
       "version": "1.3.2-kernelf.4.dirty-SNAPSHOT",
       "license": "Apache 2.0",
       "devDependencies": {
-        "@types/node": "^22.15.21",
+        "@types/node": "^22.15.29",
         "dukat": "^0.5.8-rc.4",
         "husky": "^9.1.7",
         "shx": "^0.4.0",
@@ -1225,13 +1225,13 @@
       }
     },
     "node_modules/@modelix/model-client": {
-      "version": "14.5.1",
+      "version": "2.6.0-4-g4eec68a.dirty-SNAPSHOT",
       "resolved": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-oYJ4UabFzkhIL8A4qCHE00q8IU7tg7D2h4PPW0GYeJ7SiO54TbeCYxd2RNqIhCPdt/fVWxuJoCVSgMiXPLNIjQ==",
+      "integrity": "sha512-eGVGN40tbfBM8fIMZY+3uO6ZtEeZ0pBF7JtFGvCcscLetWqM1ZE4/KdRWZnt9zX4JbpnUKwgVyqTECoZfdYJMw==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",
-        "@modelix/ts-model-api": "14.5.1",
+        "@modelix/ts-model-api": "2.6.0-4-g4eec68a.dirty-SNAPSHOT",
         "format-util": "^1.0.5",
         "js-base64": "^3.4.5",
         "js-sha256": "^0.9.0",

--- a/model-client-js-test/replicated-model-test/src/ReplicatedModelJS.test.ts
+++ b/model-client-js-test/replicated-model-test/src/ReplicatedModelJS.test.ts
@@ -4,53 +4,69 @@ import { GenericContainer } from "testcontainers";
 import type { StartedTestContainer } from "testcontainers";
 import IdSchemeJS = org.modelix.model.client2.IdSchemeJS;
 
-const connectClient = org.modelix.model.client2.connectClient
-type ClientJS = org.modelix.model.client2.ClientJS
-type ReplicatedModelJS = org.modelix.model.client2.ReplicatedModelJS
+const connectClient = org.modelix.model.client2.connectClient;
+type ClientJS = org.modelix.model.client2.ClientJS;
+type ReplicatedModelJS = org.modelix.model.client2.ReplicatedModelJS;
+type VersionInformationJS = org.modelix.model.client2.VersionInformationJS;
 
 let client: ClientJS | undefined;
 let replicatedModel: ReplicatedModelJS | undefined;
 let container: StartedTestContainer;
 
-jest.setTimeout(60000)
+jest.setTimeout(60000);
 
 beforeAll(async () => {
   container = await new GenericContainer("modelix/model-server:test")
-      .withExposedPorts(28101)
-      .withCommand(["--inmemory"])
-      .start();
-})
+    .withExposedPorts(28101)
+    .withCommand(["--inmemory"])
+    .start();
+});
 afterAll(async () => {
   await container.stop();
-})
+});
 
 beforeEach(async () => {
-  const repositoryId = randomUUID()
-  client = await connectClient(`http://localhost:${container.getMappedPort(28101)}/v2`)
-  await client.initRepository(repositoryId)
-  replicatedModel = await client.startReplicatedModel(repositoryId, "master", IdSchemeJS.READONLY)
-})
+  const repositoryId = randomUUID();
+  client = await connectClient(
+    `http://localhost:${container.getMappedPort(28101)}/v2`,
+  );
+  await client.initRepository(repositoryId);
+  replicatedModel = await client.startReplicatedModel(
+    repositoryId,
+    "master",
+    IdSchemeJS.READONLY,
+  );
+});
 
 afterEach(() => {
-  client?.dispose()
-  replicatedModel?.dispose()
-})
+  client?.dispose();
+  replicatedModel?.dispose();
+});
 
+describe("a new merged version", () => {
+  const userId = "aAuthor";
+  let versionInformation: VersionInformationJS;
+  beforeEach(async () => {
+    client!.setClientProvidedUserId(userId);
+    const rootNode = replicatedModel!.getBranch().rootNode;
 
-test("replicated model uses user set in client", async () => {
-  const userId = "aAuthor"
-  client!.setClientProvidedUserId(userId)
-  const rootNode = replicatedModel!.getBranch().rootNode
+    rootNode.setPropertyValue("aProperty", "aValue");
 
-  rootNode.setPropertyValue("aProperty", "aValue")
+    versionInformation = await replicatedModel!.getCurrentVersionInformation();
+  });
 
-  const versionInformation = await replicatedModel!.getCurrentVersionInformation()
-  const lastAuthor = versionInformation.author
-  expect(lastAuthor).toBe(userId);
-}, );
+  test("uses user set in client", async () => {
+    expect(versionInformation.author).toBe(userId);
+  });
 
-test("replicated model returns user set in client", async () => {
-  const versionInformation = await replicatedModel!.getCurrentVersionInformation()
-  const lastTimestamp = versionInformation.time
-  expect(lastTimestamp).toBeTruthy()
+  test("has the current time", async () => {
+    expect(versionInformation.time).toBeTruthy();
+  });
+});
+
+test("replicated model returns time set in client", async () => {
+  const versionInformation =
+    await replicatedModel!.getCurrentVersionInformation();
+  const lastTimestamp = versionInformation.time;
+  expect(lastTimestamp).toBeTruthy();
 });

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -299,6 +299,7 @@ private class LocalModel(initialVersion: CLVersion, val versionIdGenerator: IIdG
         val newVersion = CLVersion.builder()
             .regularUpdate(baseVersion)
             .author(author())
+            .currentTime()
             .tree(tree)
             .operations(ops.map { it.getOriginalOp() })
             .buildLegacy()

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/VersionMerger.kt
@@ -115,6 +115,7 @@ constructor(private val idGenerator: IIdGenerator?) {
                 .tree(mutableTree.getTransaction().tree)
                 .autoMerge(commonBase.obj.ref, leftVersion.obj.ref, rightVersion.obj.ref)
                 .operations(appliedOps.map { it.getOriginalOp() })
+                .currentTime()
                 .buildLegacy()
         }
         if (mergedVersion == null) {


### PR DESCRIPTION
- the time seems to have been missing on both, merged and local versions when using the replicated model
- updated the test to check for timestamp in merged versions
- there is no automated test for the timestamp of local versions


## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
