### PR TITLE
fix(mps-sync-plugin3): only work with current connections

### DIFF
--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
@@ -47,7 +47,14 @@ class ModelSyncService(val project: Project) :
 
     @Synchronized
     override fun getServerConnections(): List<IServerConnection> {
-        return AppLevelModelSyncService.getInstance().getConnections().map { Connection(it) }
+        val enabledBindingIds = loadedState.bindings
+            .filterValues { it.enabled }
+            .keys
+            .map { it.connectionProperties }
+
+        return AppLevelModelSyncService.getInstance().getConnections()
+            .filter { con -> enabledBindingIds.contains(con.properties)}
+            .map { Connection(it) }
     }
 
     @Synchronized


### PR DESCRIPTION
The info and the login tabs are only considering the connections of the active bindings now. Otherwise, it would open tabs to open into servers that are not needed.

TODO description of the PR

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
