### PR TITLE
feat(model-server): repository can be migrated from int64 to string IDs

### DIFF
--- a/model-api/src/commonMain/kotlin/org/modelix/model/data/ModelData.kt
+++ b/model-api/src/commonMain/kotlin/org/modelix/model/data/ModelData.kt
@@ -1,12 +1,12 @@
 package org.modelix.model.data
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.modelix.model.api.ConceptReference
 import org.modelix.model.api.IBranch
 import org.modelix.model.api.INode
 import org.modelix.model.api.IPropertyReference
+import org.modelix.model.api.IReadableNode
 import org.modelix.model.api.ITree
 import org.modelix.model.api.IWriteTransaction
 import org.modelix.model.api.PNodeReference
@@ -127,6 +127,8 @@ data class NodeData(
 
         @Deprecated("Use ID_PROPERTY_KEY", replaceWith = ReplaceWith("ID_PROPERTY_KEY"))
         const val idPropertyKey = ID_PROPERTY_KEY
+
+        fun fromJson(serialized: String): NodeData = Json.decodeFromString(serialized)
     }
 }
 
@@ -136,6 +138,8 @@ fun NodeData.uid(model: ModelData): String {
         (id ?: throw IllegalArgumentException("Node has no ID"))
 }
 fun ModelData.nodeUID(node: NodeData): String = node.uid(this)
+
+fun IReadableNode.asData(): NodeData = asLegacyNode().asData()
 
 fun INode.asData(): NodeData = NodeData(
     id = reference.serialize(),

--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/IModelClientV2.kt
@@ -39,6 +39,14 @@ interface IModelClientV2 {
     suspend fun initRepositoryWithLegacyStorage(repository: RepositoryId): IVersion
 
     suspend fun initRepository(config: RepositoryConfig): IVersion
+    suspend fun getRepositoryConfig(repository: RepositoryId): RepositoryConfig
+
+    /**
+     * Migrate the repository to a different configuration.
+     * Should only be used when there are no active clients.
+     * There are no guarantees how a client behaves during a config change.
+     */
+    suspend fun changeRepositoryConfig(config: RepositoryConfig): RepositoryConfig
 
     suspend fun listRepositories(): List<RepositoryId>
     suspend fun deleteRepository(repository: RepositoryId): Boolean

--- a/model-server-openapi/specifications/model-server-v2.yaml
+++ b/model-server-openapi/specifications/model-server-v2.yaml
@@ -60,6 +60,39 @@ paths:
           $ref: '#/components/responses/200'
         default:
           $ref: '#/components/responses/GeneralError'
+  /repositories/{repository}/config:
+    get:
+      tags:
+        - v2
+      operationId: getRepositoryConfig
+      parameters:
+        - name: repository
+          in: "path"
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: '#/components/responses/200json'
+        default:
+          $ref: '#/components/responses/GeneralError'
+    post:
+      tags:
+        - v2
+      operationId: changeRepositoryConfig
+      parameters:
+        - name: repository
+          in: "path"
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: '#/components/responses/200json'
+        "403":
+          $ref: '#/components/responses/403'
+        default:
+          $ref: '#/components/responses/GeneralError'
   /repositories/{repository}/objects:
     put:
       tags:

--- a/model-server/src/main/kotlin/org/modelix/model/server/handlers/IRepositoriesManager.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/handlers/IRepositoriesManager.kt
@@ -73,6 +73,12 @@ interface IRepositoriesManager {
 
     fun getStoreManager(): StoreManager
     fun getTransactionManager(): ITransactionManager
+
+    @RequiresTransaction
+    fun migrateRepository(newConfig: RepositoryConfig, author: String?)
+
+    @RequiresTransaction
+    fun getConfig(repositoryId: RepositoryId): RepositoryConfig
 }
 
 @Deprecated("Provide a RepositoryConfig")

--- a/model-server/src/test/kotlin/org/modelix/model/server/RepositoryMigrationTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/RepositoryMigrationTest.kt
@@ -1,0 +1,164 @@
+package org.modelix.model.server
+
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.test.runTest
+import org.modelix.model.ObjectDeltaFilter
+import org.modelix.model.api.ITree
+import org.modelix.model.api.PNodeReference
+import org.modelix.model.api.meta.NullConcept
+import org.modelix.model.client.IdGenerator
+import org.modelix.model.client2.ModelClientV2
+import org.modelix.model.client2.runWrite
+import org.modelix.model.client2.runWriteOnBranch
+import org.modelix.model.data.ModelData
+import org.modelix.model.data.NodeData
+import org.modelix.model.data.asData
+import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.mutable.asModelSingleThreaded
+import org.modelix.model.server.api.RepositoryConfig
+import org.modelix.model.server.api.RepositoryConfig.NodeIdType
+import org.modelix.model.server.handlers.IdsApiImpl
+import org.modelix.model.server.handlers.ModelReplicationServer
+import org.modelix.model.server.handlers.RepositoriesManager
+import org.modelix.model.server.store.InMemoryStoreClient
+import org.modelix.model.server.store.RequiresTransaction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RepositoryMigrationTest {
+    val config = RepositoryConfig(
+        nodeIdType = NodeIdType.INT64,
+        modelId = "d9330ca8-2145-4d1f-9b50-8f5aed1804cf",
+        repositoryId = "d9330ca8-2145-4d1f-9b50-8f5aed1804cf",
+        repositoryName = "my-repo",
+    )
+
+    val modelData = ModelData(
+        root = NodeData(
+            id = PNodeReference(config.modelId, ITree.ROOT_ID).serialize(),
+            concept = NullConcept.getReference().getUID(),
+            children = listOf(
+                NodeData(
+                    id = "id1",
+                    concept = "concept1",
+                    role = "role2",
+                    references = mapOf("ref1" to "id2"),
+                ),
+                NodeData(
+                    id = "id2",
+                    concept = "concept2",
+                    role = "role2",
+                    references = mapOf("ref1" to "id1"),
+                ),
+            ),
+        ),
+    )
+
+    // A repository configured with int64 IDs is expected to generate new IDs and store the provided ID in the
+    // #originalRef# property.
+    // language=json
+    val expectedImportData = NodeData.fromJson(
+        """
+        {
+            "id": "modelix:d9330ca8-2145-4d1f-9b50-8f5aed1804cf/1",
+            "concept": "null",
+            "children": [
+                {
+                    "id": "modelix:d9330ca8-2145-4d1f-9b50-8f5aed1804cf/1c800000001",
+                    "concept": "concept1",
+                    "role": "role2",
+                    "properties": {
+                        "#originalRef#": "id1"
+                    },
+                    "references": {
+                        "ref1": "modelix:d9330ca8-2145-4d1f-9b50-8f5aed1804cf/1c800000002"
+                    }
+                },
+                {
+                    "id": "modelix:d9330ca8-2145-4d1f-9b50-8f5aed1804cf/1c800000002",
+                    "concept": "concept2",
+                    "role": "role2",
+                    "properties": {
+                        "#originalRef#": "id2"
+                    },
+                    "references": {
+                        "ref1": "modelix:d9330ca8-2145-4d1f-9b50-8f5aed1804cf/1c800000001"
+                    }
+                }
+            ],
+            "properties": {
+                "#originalRef#": "modelix:d9330ca8-2145-4d1f-9b50-8f5aed1804cf/1"
+            }
+        }
+        """,
+    ).toJson()
+
+    @Test
+    fun `migrate int64 to string IDs`() = runTest {
+        val repositoryManager = RepositoriesManager(InMemoryStoreClient())
+
+        @OptIn(RequiresTransaction::class)
+        val version1 = repositoryManager.getTransactionManager().runWrite {
+            val emptyVersion = repositoryManager.createRepository(
+                config,
+                null,
+            )
+            emptyVersion.runWrite(IdGenerator.newInstance(456), author = null) {
+                modelData.load(it)
+            }!!.also { repositoryManager.mergeChanges(RepositoryId(config.repositoryId).getBranchReference(), it.getContentHash()) }
+        }
+
+        assertEquals(
+            expectedImportData,
+            version1.getModelTree().asModelSingleThreaded().getRootNode().asData().toJson(),
+        )
+
+        @OptIn(RequiresTransaction::class)
+        val version2 = repositoryManager.getTransactionManager().runWrite {
+            repositoryManager.migrateRepository(
+                config.copy(nodeIdType = NodeIdType.STRING),
+                null,
+            )
+            repositoryManager.getVersion(RepositoryId(config.repositoryId).getBranchReference())!!
+        }
+
+        // After migration the repository should use the IDs that were provided in the import data.
+        assertEquals(modelData.root.toJson(), version2.getModelTree().asModelSingleThreaded().getRootNode().asData().toJson())
+    }
+
+    @Test
+    fun `migrate int64 to string IDs via client`() = testApplication {
+        application {
+            try {
+                installDefaultServerPlugins()
+                val repoManager = RepositoriesManager(InMemoryStoreClient())
+                ModelReplicationServer(repoManager).init(this)
+                IdsApiImpl(repoManager).init(this)
+            } catch (ex: Throwable) {
+                ex.printStackTrace()
+            }
+        }
+
+        val repositoryId = RepositoryId(config.repositoryId)
+        val modelClient = ModelClientV2.builder().url("http://localhost/v2").client(client).build().also { it.init() }
+        val version0 = modelClient.initRepository(config)
+        modelClient.runWriteOnBranch(repositoryId.getBranchReference()) {
+            modelData.load(it)
+        }
+
+        modelClient.changeRepositoryConfig(modelClient.getRepositoryConfig(repositoryId).copy(nodeIdType = NodeIdType.STRING))
+        val version2 = modelClient.pull(
+            repositoryId.getBranchReference(),
+            null,
+            filter = ObjectDeltaFilter(
+                knownVersions = emptySet(),
+                includeOperations = false,
+                includeHistory = false,
+                includeTrees = true,
+            ),
+        )
+
+        // After migration the repository should use the IDs that were provided in the import data.
+        assertEquals(modelData.root.toJson(), version2.getModelTree().asModelSingleThreaded().getRootNode().asData().toJson())
+    }
+}

--- a/mps-sync-plugin3/src/test/kotlin/org/modelix/mps/sync3/ProjectSyncTest.kt
+++ b/mps-sync-plugin3/src/test/kotlin/org/modelix/mps/sync3/ProjectSyncTest.kt
@@ -16,6 +16,7 @@ import org.modelix.model.api.BuiltinLanguages
 import org.modelix.model.api.INodeReference
 import org.modelix.model.api.getDescendants
 import org.modelix.model.client2.ModelClientV2
+import org.modelix.model.client2.computeWriteOnModel
 import org.modelix.model.client2.runWriteOnModel
 import org.modelix.model.client2.runWriteOnTree
 import org.modelix.model.data.NodeData
@@ -378,7 +379,7 @@ class ProjectSyncTest : MPSTestBase() {
 
         // ... and then a non-MPS client adds a new node ...
         val client = ModelClientV2.builder().url("http://localhost:$port").lazyAndBlockingQueries().build().also { it.init() }
-        val newNodeIdOnServer = client.runWriteOnModel(branchRef, { MPSIdGenerator(client.getIdGenerator(), it) }) { rootNode ->
+        val (_, newNodeIdOnServer) = client.computeWriteOnModel(branchRef, { MPSIdGenerator(client.getIdGenerator(), it) }) { rootNode ->
             val node = rootNode.getDescendants(true)
                 .first { it.getPropertyValue(nameProperty.toReference()) == "MyClass" }
             val node2 = node.getParent()!!.addNewChild(node.getContainmentLink(), -1, node.getConceptReference())


### PR DESCRIPTION
The mps-sync-plugin only supports repositories that use string node IDs. Existing repositories that still use int64 IDs can now be migrated.