### PR TITLE
fix(mps-sync-plugin): persist whether a connection should be used for a specific repository only

### DIFF
--- a/mps-sync-plugin3/src/test/kotlin/org/modelix/mps/sync3/ProjectSyncTest.kt
+++ b/mps-sync-plugin3/src/test/kotlin/org/modelix/mps/sync3/ProjectSyncTest.kt
@@ -549,7 +549,7 @@ class ProjectSyncTest : MPSTestBase() {
               <component name="modelix-sync">
                 <binding>
                   <enabled>true</enabled>
-                  <url>http://localhost:$port</url>
+                  <url repositoryScoped="false">http://localhost:$port</url>
                   <repository>${branchRef.repositoryId.id}</repository>
                   <branch>${branchRef.branchName}</branch>
                   <versionHash>${version1.getContentHash()}</versionHash>


### PR DESCRIPTION
When a new connection is added via `IModelSyncService.addServer` a repository ID can optionally be provided and then the connection is only used for that repository and the JWT token will usually also only be valid for that repository.
The `modelix.xml` previously didn't make this distinction and when the state was reloaded from disk a previously global connection turned into a repository scoped one.