### PR TITLE
fix(mps-sync-plugin): model imports of target models not part of the synchronization

### DIFF
--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/RefreshTokenTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/RefreshTokenTest.kt
@@ -33,6 +33,7 @@ import org.modelix.model.oauth.IAuthRequestHandler
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @Serializable
 private data class TokenResponse2(
@@ -276,7 +277,7 @@ class RefreshTokenTest {
                 invalidateAccessToken()
                 val actualBranches2 = modelClient.listBranches(RepositoryId(expectedRepoId))
                 assertEquals(expectedBranches, actualBranches2)
-                assertEquals(3, nextTokenSuffix)
+                assertTrue(nextTokenSuffix >= 3, "No token refresh happened")
             }
         }
     }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/SingleThreadMutableModelTree.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/mutable/SingleThreadMutableModelTree.kt
@@ -3,6 +3,7 @@ package org.modelix.model.mutable
 import org.modelix.datastructures.model.IGenericModelTree
 import org.modelix.datastructures.model.MutationParameters
 import org.modelix.model.TreeId
+import org.modelix.model.api.IModel
 import org.modelix.model.api.IMutableModel
 import org.modelix.model.api.INodeReference
 import org.modelix.streams.getBlocking
@@ -58,3 +59,4 @@ class SingleThreadMutableModelTree<NodeId>(
 
 fun <T> IGenericModelTree<T>.asMutableSingleThreaded(): IGenericMutableModelTree<T> = SingleThreadMutableModelTree(this)
 fun IGenericModelTree<INodeReference>.asModelSingleThreaded(): IMutableModel = asMutableSingleThreaded().asModel()
+fun IGenericModelTree<INodeReference>.asReadOnlyModel(): IModel = asModelSingleThreaded()

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSModuleAsNode.kt
@@ -522,7 +522,7 @@ data class MPSDevkitAsNode(override val module: DevKit) : MPSModuleAsNode<DevKit
     override fun getConcept(): IConcept = BuiltinLanguages.MPSRepositoryConcepts.DevKit
 }
 
-private fun <T : SModel> Iterable<T>.withoutDescriptorModel(): List<T> {
+fun <T : SModel> Iterable<T>.withoutDescriptorModel(): List<T> {
     return filter { it.name.stereotype != "descriptor" }
 }
 

--- a/mps-sync-plugin3/testdata/model-dependencies/.mps/.gitignore
+++ b/mps-sync-plugin3/testdata/model-dependencies/.mps/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/mps-sync-plugin3/testdata/model-dependencies/.mps/migration.xml
+++ b/mps-sync-plugin3/testdata/model-dependencies/.mps/migration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="project.baseline.version" value="211" />
+  </component>
+</project>

--- a/mps-sync-plugin3/testdata/model-dependencies/.mps/modules.xml
+++ b/mps-sync-plugin3/testdata/model-dependencies/.mps/modules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules>
+      <modulePath path="$PROJECT_DIR$/devkits/NewDevkit/NewDevkit.devkit" folder="" />
+      <modulePath path="$PROJECT_DIR$/languages/NewLanguage/NewLanguage.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/NewRuntimeSolution/NewRuntimeSolution.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/NewSolution/NewSolution.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/ToBeDeleted/ToBeDeleted.msd" folder="" />
+    </projectModules>
+  </component>
+</project>

--- a/mps-sync-plugin3/testdata/model-dependencies/.mps/vcs.xml
+++ b/mps-sync-plugin3/testdata/model-dependencies/.mps/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/mps-sync-plugin3/testdata/model-dependencies/devkits/NewDevkit/NewDevkit.devkit
+++ b/mps-sync-plugin3/testdata/model-dependencies/devkits/NewDevkit/NewDevkit.devkit
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dev-kit name="NewDevkit" uuid="568b2514-a608-45b5-aea5-6ffd231cea1d">
+  <exported-language name="96c7c023-6829-44d0-b358-661f058f1c31(NewLanguage)" />
+  <extendedDevKits>
+    <extendedDevKit>fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)</extendedDevKit>
+  </extendedDevKits>
+  <exported-solutions>
+    <exported-solution>4eb87a8f-881e-4d34-9514-f5002000c363(NewRuntimeSolution)</exported-solution>
+    <exported-solution>6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</exported-solution>
+  </exported-solutions>
+</dev-kit>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/NewLanguage.mpl
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/NewLanguage.mpl
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="NewLanguage" uuid="96c7c023-6829-44d0-b358-661f058f1c31" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="NewLanguage.generator" uuid="6d5e9772-42f2-4376-adca-80393565af00">
+      <models>
+        <modelRoot contentPath="${module}/generator" type="default">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet type="java">
+          <classes generated="true" path="${module}/generator/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="96c7c023-6829-44d0-b358-661f058f1c31(NewLanguage)" version="0" />
+        <module reference="6d5e9772-42f2-4376-adca-80393565af00(NewLanguage.generator)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+    <generator alias="toBeDeletedGenerator" namespace="NewLanguage.generator01" uuid="a8303696-b490-4dad-9595-e52191c9dddf" generatorOutputPath="${module}/generator1/source_gen">
+      <models>
+        <modelRoot contentPath="${module}/generator1" type="default">
+          <sourceRoot location="templates" />
+        </modelRoot>
+      </models>
+      <facets>
+        <facet type="java">
+          <classes generated="true" path="${module}/generator1/classes_gen" />
+        </facet>
+      </facets>
+      <external-templates />
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="96c7c023-6829-44d0-b358-661f058f1c31(NewLanguage)" version="0" />
+        <module reference="a8303696-b490-4dad-9595-e52191c9dddf(NewLanguage.generator01)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
+    <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
+    <language slang="l:5dae8159-ab99-46bb-a40d-0cee30ee7018:jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <language slang="l:134c38d4-e3af-4d9e-b069-1c7df0a4005d:jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <language slang="l:3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7:jetbrains.mps.lang.context" version="0" />
+    <language slang="l:ea3159bf-f48e-4720-bde2-86dba75f0d34:jetbrains.mps.lang.context.defs" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:ad93155d-79b2-4759-b10c-55123e763903:jetbrains.mps.lang.messages" version="0" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="96c7c023-6829-44d0-b358-661f058f1c31(NewLanguage)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+  </dependencyVersions>
+  <extendedLanguages />
+</language>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/generator/templates/NewLanguage.generator.templates@generator.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/generator/templates/NewLanguage.generator.templates@generator.mps
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:59e10122-4a73-4f29-8d78-e2f39f37056d(NewLanguage.generator.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="mioq" ref="r:3467edfa-6d06-43c6-a5a6-c4c01110f8e6(NewLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="7bG66aOHu1W">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/generator1/templates/NewLanguage.generator01.templates@generator.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/generator1/templates/NewLanguage.generator01.templates@generator.mps
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:66f1bfcb-5e7d-4ad2-bd1a-495bfaf48ded(NewLanguage.generator01.templates@generator)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="mioq" ref="r:3467edfa-6d06-43c6-a5a6-c4c01110f8e6(NewLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="4OfPYN8Ll9G">
+    <property role="TrG5h" value="main" />
+  </node>
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.behavior.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.behavior.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:0984fa4e-ff52-4b3e-8f69-f18ba2263cb9(NewLanguage.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.constraints.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.constraints.mps
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:48b737a9-34d4-49ed-a7b3-c06d5838aa5a(NewLanguage.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
+    <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
+    <use id="e51810c5-7308-4642-bcb6-469e61b5dd18" name="jetbrains.mps.lang.constraints.msg.specification" version="0" />
+    <use id="134c38d4-e3af-4d9e-b069-1c7df0a4005d" name="jetbrains.mps.lang.constraints.rules.skeleton" version="0" />
+    <use id="b3551702-269c-4f05-ba61-58060cef4292" name="jetbrains.mps.lang.rulesAndMessages" version="0" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="3ad5badc-1d9c-461c-b7b1-fa2fcd0a0ae7" name="jetbrains.mps.lang.context" version="0" />
+    <use id="ad93155d-79b2-4759-b10c-55123e763903" name="jetbrains.mps.lang.messages" version="0" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports />
+  <registry />
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.editor.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.editor.mps
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:9782c417-1f9b-4ed0-8c7d-2bd4d51ee5f0(NewLanguage.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports />
+  <registry />
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.structure.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.structure.mps
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:3467edfa-6d06-43c6-a5a6-c4c01110f8e6(NewLanguage.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="7bG66aOHu1X">
+    <property role="EcuMT" value="8281020627045179517" />
+    <property role="TrG5h" value="MyRoot" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="7bG66aOHu1Z" role="1TKVEi">
+      <property role="IQ2ns" value="8281020627045179519" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="children" />
+      <ref role="20lvS9" node="7bG66aOHu1Y" resolve="MyChild" />
+    </node>
+    <node concept="PrWs8" id="7bG66aOHu21" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7bG66aOHu1Y">
+    <property role="EcuMT" value="8281020627045179518" />
+    <property role="TrG5h" value="MyChild" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="7bG66aOHFZW" role="1TKVEl">
+      <property role="IQ2nx" value="8281020627045236732" />
+      <property role="TrG5h" value="value" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+  </node>
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.typesystem.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/languages/NewLanguage/models/NewLanguage.typesystem.mps
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c6aeb147-46dd-4a08-9631-3d977cbfc627(NewLanguage.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports />
+  <registry />
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/NewRuntimeSolution/NewRuntimeSolution.msd
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/NewRuntimeSolution/NewRuntimeSolution.msd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="NewRuntimeSolution" uuid="4eb87a8f-881e-4d34-9514-f5002000c363" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="4eb87a8f-881e-4d34-9514-f5002000c363(NewRuntimeSolution)" version="0" />
+  </dependencyVersions>
+</solution>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/NewRuntimeSolution/models/NewRuntimeSolution.plugin.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/NewRuntimeSolution/models/NewRuntimeSolution.plugin.mps
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ae5ec9ea-07ab-4c3a-994f-dfe5abbefb2b(NewRuntimeSolution.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1204478074808" name="jetbrains.mps.lang.plugin.structure.ConceptFunctionParameter_MPSProject" flags="nn" index="1KvdUw" />
+    </language>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="481983775135178834" name="jetbrains.mps.lang.plugin.standalone.structure.ProjectPluginDeclaration" flags="ng" index="2uRRBy">
+        <child id="481983775135178836" name="initBlock" index="2uRRB$" />
+      </concept>
+      <concept id="481983775135178825" name="jetbrains.mps.lang.plugin.standalone.structure.ProjectPluginInitBlock" flags="in" index="2uRRBT" />
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2DaZZR" id="7bG66aOHu23" />
+  <node concept="2uRRBy" id="7bG66aOHu24">
+    <property role="TrG5h" value="MyProjectPlugin" />
+    <node concept="2uRRBT" id="7bG66aOHu25" role="2uRRB$">
+      <node concept="3clFbS" id="7bG66aOHu26" role="2VODD2">
+        <node concept="3clFbF" id="7bG66aOHx7w" role="3cqZAp">
+          <node concept="2OqwBi" id="7bG66aOHx7t" role="3clFbG">
+            <node concept="10M0yZ" id="7bG66aOHx7u" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="7bG66aOHx7v" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="7bG66aOHzbR" role="37wK5m">
+                <node concept="1KvdUw" id="7bG66aOHzeT" role="3uHU7w" />
+                <node concept="Xl_RD" id="7bG66aOHyAI" role="3uHU7B">
+                  <property role="Xl_RC" value="Hello Project " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/NewSolution.msd
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/NewSolution.msd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="NewSolution" uuid="471b29cb-3253-460b-9743-1e1443884a6b" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:96c7c023-6829-44d0-b358-661f058f1c31:NewLanguage" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="4eb87a8f-881e-4d34-9514-f5002000c363(NewRuntimeSolution)" version="0" />
+    <module reference="471b29cb-3253-460b-9743-1e1443884a6b(NewSolution)" version="0" />
+  </dependencyVersions>
+</solution>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/models/NewSolution.a_model.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/models/NewSolution.a_model.mps
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:cd78e6ac-0e34-490a-9b49-e5643f948d6d(NewSolution.a_model)">
+  <persistence version="9" />
+  <languages>
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="312cEu" id="7bG66aOHG9v">
+    <property role="TrG5h" value="MyClass" />
+    <node concept="3clFb_" id="7bG66aOHGar" role="jymVt">
+      <property role="TrG5h" value="plus" />
+      <node concept="37vLTG" id="1TA56gtftpq" role="3clF46">
+        <property role="TrG5h" value="a" />
+        <node concept="10Oyi0" id="1TA56gtftpN" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1TA56gtftqW" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="10Oyi0" id="1TA56gtftrm" role="1tU5fm" />
+      </node>
+      <node concept="10Oyi0" id="1TA56gtfumO" role="3clF45" />
+      <node concept="3Tm1VV" id="7bG66aOHGau" role="1B3o_S" />
+      <node concept="3clFbS" id="7bG66aOHGav" role="3clF47">
+        <node concept="3cpWs6" id="1TA56gtfts3" role="3cqZAp">
+          <node concept="3cpWs3" id="1TA56gtfu94" role="3cqZAk">
+            <node concept="37vLTw" id="1TA56gtfu9R" role="3uHU7w">
+              <ref role="3cqZAo" node="1TA56gtftqW" resolve="b" />
+            </node>
+            <node concept="37vLTw" id="1TA56gtftsC" role="3uHU7B">
+              <ref role="3cqZAo" node="1TA56gtftpq" resolve="a" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFb_" id="5HiKpWBfFXi" role="jymVt">
+      <property role="TrG5h" value="now" />
+      <node concept="3uibUv" id="5HiKpWBgaTj" role="3clF45">
+        <ref role="3uigEE" to="28m1:~Instant" resolve="Instant" />
+      </node>
+      <node concept="3Tm1VV" id="5HiKpWBfFXl" role="1B3o_S" />
+      <node concept="3clFbS" id="5HiKpWBfFXm" role="3clF47">
+        <node concept="3cpWs6" id="5HiKpWBfG0t" role="3cqZAp">
+          <node concept="2YIFZM" id="5HiKpWBgaS7" role="3cqZAk">
+            <ref role="37wK5l" to="28m1:~Instant.now()" resolve="now" />
+            <ref role="1Pybhc" to="28m1:~Instant" resolve="Instant" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7bG66aOHG9w" role="1B3o_S" />
+  </node>
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/models/NewSolution.b_model.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/models/NewSolution.b_model.mps
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:368d034d-6155-4955-9a72-127d324732cc(NewSolution.b_model)">
+  <persistence version="9" />
+  <languages>
+    <use id="96c7c023-6829-44d0-b358-661f058f1c31" name="NewLanguage" version="-1" />
+    <devkit ref="568b2514-a608-45b5-aea5-6ffd231cea1d(NewDevkit)" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="96c7c023-6829-44d0-b358-661f058f1c31" name="NewLanguage">
+      <concept id="8281020627045179518" name="NewLanguage.structure.MyChild" flags="ng" index="36mvws">
+        <property id="8281020627045236732" name="value" index="36mEuu" />
+      </concept>
+      <concept id="8281020627045179517" name="NewLanguage.structure.MyRoot" flags="ng" index="36mvwv">
+        <child id="8281020627045179519" name="children" index="36mvwt" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="36mvwv" id="7bG66aOHFZT">
+    <property role="TrG5h" value="MyRootAbc" />
+    <node concept="36mvws" id="7bG66aOHFZU" role="36mvwt">
+      <property role="36mEuu" value="123" />
+    </node>
+  </node>
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/models/NewSolution.toBeDeletedModel.mps
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/NewSolution/models/NewSolution.toBeDeletedModel.mps
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:a4778767-a741-4f8f-b8fb-5ba464dc5d4e(NewSolution.toBeDeletedModel)">
+  <persistence version="9" />
+  <languages />
+  <imports />
+  <registry />
+</model>

--- a/mps-sync-plugin3/testdata/model-dependencies/solutions/ToBeDeleted/ToBeDeleted.msd
+++ b/mps-sync-plugin3/testdata/model-dependencies/solutions/ToBeDeleted/ToBeDeleted.msd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="ToBeDeleted" uuid="24111875-73be-4652-9b59-c329dba36026" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <languageVersions />
+  <dependencyVersions>
+    <module reference="24111875-73be-4652-9b59-c329dba36026(ToBeDeleted)" version="0" />
+  </dependencyVersions>
+</solution>


### PR DESCRIPTION
Model imports were not synchronized if the target modes is not part of the synchronization (doesn't exist on the server).
The synchronizer tried to resolve the model node and read the model ID, but since we use the original IDs from MPS this information can also be derived from that ID.