### PR TITLE
fix(mps-sync-plugin): properly check connection state when having multiple connections

### DIFF
--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
@@ -264,7 +264,7 @@ class ModelSyncService(val project: Project) :
         }
 
         override fun deactivate() {
-            connection.disconnect()
+            connection.disable()
         }
 
         override fun remove() {


### PR DESCRIPTION
So far, this job fell asleep as soon as any connection is requiring authorization. This resulted in a lack of connection checking for other connections.

This fixes the following issues:

- When opening one project without logging in; And opening another project, Then "Click to login" would not disappear even after clicking it and logging in
- Sometimes, The local server would already be stopped, resulting in being redirected to an error page at the end of the login workflow