### PR TITLE
fix(mps-sync-plugin): use refresh token, if access token is expired

### DIFF
--- a/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -114,7 +114,7 @@ actual class ModelixAuthClient {
                     return@withContext tokens
                 } catch (ex: SocketException) {
                     LOG.info("Port $port already in use. Trying next one.")
-                    LOG.debug(ex)
+                    LOG.debug("Login failed with socket exception, which is expected, if we can not open the callback port.", ex)
                 }
             }
             throw IllegalStateException("Couldn't find an available port for the redirect URL")


### PR DESCRIPTION
The refresh token should be used to get new access tokens when they expire. `getTokens` gives only tokens, if the access token is not expired.
Fix avoids the expiration check and use the internal field directly.