### PR TITLE
fix(mps-model-adapters): avoid PersistenceFacade$IncorrectModelRefere…

### DIFF
--- a/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ModelReferenceParsingTest.kt
+++ b/mps-model-adapters-plugin/src/test/kotlin/org/modelix/model/mpsadapters/ModelReferenceParsingTest.kt
@@ -1,0 +1,33 @@
+package org.modelix.model.mpsadapters
+
+import jetbrains.mps.smodel.SModelId
+import jetbrains.mps.smodel.SModelReference
+import org.jetbrains.mps.openapi.persistence.PersistenceFacade
+import java.util.UUID
+import kotlin.test.assertFailsWith
+
+class ModelReferenceParsingTest : MpsAdaptersTestBase("SimpleProject") {
+
+    fun `test model reference can be serialized and deserialized`() {
+        val originalReference = SModelReference(null, SModelId.regular(UUID.fromString("9858ad24-9b93-4fb4-b55d-1d5b38a5d03b")), "my.model")
+        val referenceWithoutName = SModelReference(null, SModelId.regular(UUID.fromString("9858ad24-9b93-4fb4-b55d-1d5b38a5d03b")), "")
+        assertEquals("r:9858ad24-9b93-4fb4-b55d-1d5b38a5d03b()", referenceWithoutName.toString())
+
+        // MPS fails to parse a reference that it serialized itself.
+        // This can be considered an MPS bug, but we have to compensate for that.
+        // This check ensures that we found the correct cause for this exception.
+        assertFailsWith(PersistenceFacade.IncorrectModelReferenceFormatException::class) {
+            PersistenceFacade.getInstance().createModelReference(referenceWithoutName.toString())
+        }
+
+        // Modelix is expected to remove the name, because MPS ignores the name when comparing two model references.
+        // By not storing the name in Modelix we avoid any inconsistent behavior after a model renaming.
+        assertEquals("mps-model:r:9858ad24-9b93-4fb4-b55d-1d5b38a5d03b", originalReference.toModelix().serialize())
+
+        // Ensure a reference is still parsable by MPS after it was converted to and from Modelix.
+        assertEquals(
+            "r:9858ad24-9b93-4fb4-b55d-1d5b38a5d03b(unknown)",
+            PersistenceFacade.getInstance().createModelReference(originalReference.toModelix().toMPS().toString()).toString(),
+        )
+    }
+}

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferences.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSReferences.kt
@@ -2,6 +2,7 @@ package org.modelix.model.mpsadapters
 
 import jetbrains.mps.smodel.SNodePointer
 import jetbrains.mps.util.StringUtil
+import org.jetbrains.mps.openapi.model.SModelName
 import org.jetbrains.mps.openapi.model.SModelReference
 import org.jetbrains.mps.openapi.model.SNodeReference
 import org.jetbrains.mps.openapi.module.SModuleId
@@ -23,7 +24,7 @@ fun SModelReference.toModelix() = MPSModelReference(moduleReference?.toModelix()
 fun MPSModelReference.toMPS(): SModelReference = PersistenceFacade.getInstance().createModelReference(
     moduleReference?.toMPS(),
     PersistenceFacade.getInstance().createModelId(modelId),
-    "",
+    SModelName("unknown"), // we need a non-empty model name here to avoid PersistenceFacade$IncorrectModelReferenceFormatException: Incomplete model reference, the presentation part is absent
 )
 
 fun SNodeReference.toModelix() = MPSNodeReference(


### PR DESCRIPTION
avoid PersistenceFacade$IncorrectModelReferenceFormatException

- using an empty string as model name caused the exception
- this implementation will add the name of dependant models to the json and fall back to "unknown" if no model name was provided