### PR TITLE
fix(mps-sync-plugin): pending auth request weren't shown when connected

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -82,6 +82,7 @@ import org.modelix.model.mutable.INodeIdGenerator
 import org.modelix.model.mutable.ModelixIdGenerator
 import org.modelix.model.mutable.getRootNode
 import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import org.modelix.model.oauth.ITokenProvider
 import org.modelix.model.oauth.ModelixAuthClient
@@ -917,8 +918,8 @@ abstract class ModelClientV2Builder {
                 null
             } else {
                 object : IAuthRequestHandler {
-                    override fun browse(url: String) {
-                        browser(url)
+                    override fun browse(request: IAuthRequest) {
+                        browser(request.getUrl())
                     }
                 }
             },

--- a/model-client/src/commonMain/kotlin/org/modelix/model/oauth/OAuthConfig.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/oauth/OAuthConfig.kt
@@ -143,5 +143,11 @@ interface IAuthRequestHandler {
      * Open the URL where the user can log in. The OAuth server will redirect the user to a callback URL to transmit
      * the authorization code.
      */
-    fun browse(url: String)
+    fun browse(request: IAuthRequest)
+}
+
+interface IAuthRequest {
+    fun getUrl(): String
+    fun cancel()
+    fun isActive(): Boolean
 }

--- a/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
+++ b/model-client/src/jvmMain/kotlin/org/modelix/model/oauth/ModelixAuthClient.kt
@@ -28,105 +28,172 @@ import io.ktor.http.buildUrl
 import io.ktor.http.isSecure
 import io.ktor.http.takeFrom
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.modelix.kotlin.utils.runSynchronized
 import org.modelix.kotlin.utils.urlEncode
 import java.net.SocketException
 import java.net.SocketTimeoutException
+import java.util.Collections
 
 @Suppress("UndocumentedPublicClass") // already documented in the expected declaration
 actual class ModelixAuthClient {
     companion object {
         private val LOG = mu.KotlinLogging.logger { }
     }
-    private val httpTransport: HttpTransport = NetHttpTransport()
-    private val jsonFactory: JsonFactory = GsonFactory()
-    private var lastCredentials = HashMap<TokenCacheKey, Credential>()
 
-    @Synchronized
-    fun getTokens(config: OAuthConfig): Credential? {
-        return lastCredentials[config.getCacheKey()]?.takeIf { !it.isExpired() }
-    }
+    private class CachedTokens {
+        private val httpTransport: HttpTransport = NetHttpTransport()
+        private val jsonFactory: JsonFactory = GsonFactory()
+        private var lastCredentials: Credential? = null
+        private val authMutex = Mutex()
 
-    @Synchronized
-    private fun Credential.isExpired(): Boolean {
-        return (expiresInSeconds ?: return false) < 60
-    }
-
-    @Synchronized
-    private fun Credential.refreshIfExpired(): Credential? {
-        return if (isExpired()) {
-            alwaysRefresh()
-        } else {
-            this.takeIf { it.accessToken != null }
+        fun getTokens(config: OAuthConfig): Credential? {
+            return lastCredentials?.takeIf { !it.isExpired() }
         }
-    }
 
-    @Synchronized
-    fun Credential.alwaysRefresh(): Credential? {
-        for (attempt in 1..3) {
-            try {
-                val success = refreshToken()
-                if (success) return this
-            } catch (e: SocketTimeoutException) {
-                LOG.warn(e) { "Token refresh timed out" }
-            } catch (e: TokenResponseException) {
-                LOG.warn("Could not refresh the access token: ${e.details}")
-                break
+        fun getAndMaybeRefreshTokens(config: OAuthConfig): Credential? {
+            return lastCredentials?.refreshIfExpired()
+        }
+
+        suspend fun refreshTokensOrReauthorize(config: OAuthConfig): Credential? {
+            return lastCredentials?.alwaysRefresh() ?: authorize(config)
+        }
+
+        suspend fun authorize(config: OAuthConfig): Credential? {
+            lastCredentials = null
+            return withContext(Dispatchers.IO) {
+                authMutex.withLock {
+                    lastCredentials?.let { return@withLock it }
+                    val flow = AuthorizationCodeFlow.Builder(
+                        BearerToken.authorizationHeaderAccessMethod(),
+                        httpTransport,
+                        jsonFactory,
+                        GenericUrl(config.tokenUrl),
+                        ClientParametersAuthentication(config.clientId, config.clientSecret),
+                        config.clientId,
+                        config.authorizationUrl,
+                    )
+                        .setScopes(config.scopes)
+                        .enablePKCE()
+                        .build()
+
+                    repeat(100) { n ->
+                        val port = 26815 + n
+                        try {
+                            val receiver: LocalServerReceiver = LocalServerReceiver.Builder().setHost("localhost").setPort(port).build()
+                            val tokens = cancelable({ receiver.stop() }) {
+                                val scope = this
+                                val browser = config.authRequestHandler?.let {
+                                    AuthorizationCodeInstalledApp.Browser { url ->
+                                        it.browse(object : IAuthRequest {
+                                            override fun getUrl(): String = url
+                                            override fun cancel() = scope.cancel()
+                                            override fun isActive() = scope.isActive
+                                        })
+                                    }
+                                } ?: AuthorizationCodeInstalledApp.DefaultBrowser()
+                                AuthorizationCodeInstalledApp(flow, receiver, browser).authorize(null)
+                            }
+                            lastCredentials = tokens
+                            return@withContext tokens
+                        } catch (ex: SocketException) {
+                            LOG.info("Port $port already in use. Trying next one.")
+                            LOG.debug("Login failed with socket exception, which is expected, if we can not open the callback port.", ex)
+                        }
+                    }
+                    throw IllegalStateException("Couldn't find an available port for the redirect URL")
+                }
             }
         }
-        return null
+
+        private fun Credential.isExpired(): Boolean {
+            return (expiresInSeconds ?: return false) < 60
+        }
+
+        private fun Credential.refreshIfExpired(): Credential? {
+            return if (isExpired()) {
+                alwaysRefresh()
+            } else {
+                this.takeIf { it.accessToken != null }
+            }
+        }
+
+        private fun Credential.alwaysRefresh(): Credential? {
+            for (attempt in 1..3) {
+                try {
+                    val success = refreshToken()
+                    if (success) return this
+                } catch (e: SocketTimeoutException) {
+                    LOG.warn(e) { "Token refresh timed out" }
+                } catch (e: TokenResponseException) {
+                    LOG.warn("Could not refresh the access token: ${e.details}")
+                    break
+                }
+            }
+            return null
+        }
+
+        /**
+         * [blockingCall] is expected to be uninterruptible by typical platform mechanisms, but by some special call done
+         * by [onCancel].
+         */
+        private suspend fun <R> cancelable(onCancel: suspend () -> Unit, blockingCall: CoroutineScope.() -> R): R {
+            return coroutineScope {
+                var cancellationEx: CancellationException? = null
+                var blockingCallReturned = false
+                val cancellationHandlerJob = launch(Dispatchers.IO) {
+                    try {
+                        awaitCancellation()
+                    } catch (ex: CancellationException) {
+                        if (!blockingCallReturned) {
+                            cancellationEx = ex
+                            onCancel()
+                        }
+                    }
+                }
+                withContext(Dispatchers.IO) {
+                    try {
+                        return@withContext blockingCall()
+                    } catch (ex: Throwable) {
+                        throw cancellationEx ?: ex
+                    } finally {
+                        blockingCallReturned = true
+                        cancellationHandlerJob.cancel()
+                    }
+                }
+            }
+        }
     }
 
-    @Synchronized
+    private val cachedTokens: MutableMap<TokenCacheKey, CachedTokens> = Collections.synchronizedMap(HashMap<TokenCacheKey, CachedTokens>())
+
+    private fun getCachedTokens(config: OAuthConfig) = runSynchronized(cachedTokens) {
+        cachedTokens.getOrPut(config.getCacheKey()) { CachedTokens() }
+    }
+
+    fun getTokens(config: OAuthConfig): Credential? {
+        return getCachedTokens(config).getTokens(config)
+    }
+
     fun getAndMaybeRefreshTokens(config: OAuthConfig): Credential? {
-        return lastCredentials[config.getCacheKey()]?.refreshIfExpired()
+        return getCachedTokens(config).getAndMaybeRefreshTokens(config)
     }
 
     suspend fun refreshTokensOrReauthorize(config: OAuthConfig): Credential? {
-        return runSynchronized(this) { lastCredentials[config.getCacheKey()]?.alwaysRefresh() } ?: authorize(config)
+        return getCachedTokens(config).refreshTokensOrReauthorize(config)
     }
 
     suspend fun authorize(config: OAuthConfig): Credential? {
-        return withContext(Dispatchers.IO) {
-            val flow = AuthorizationCodeFlow.Builder(
-                BearerToken.authorizationHeaderAccessMethod(),
-                httpTransport,
-                jsonFactory,
-                GenericUrl(config.tokenUrl),
-                ClientParametersAuthentication(config.clientId, config.clientSecret),
-                config.clientId,
-                config.authorizationUrl,
-            )
-                .setScopes(config.scopes)
-                .enablePKCE()
-                .build()
-
-            repeat(100) { n ->
-                val port = 26815 + n
-                try {
-                    val receiver: LocalServerReceiver = LocalServerReceiver.Builder().setHost("localhost").setPort(port).build()
-                    val browser = config.authRequestHandler?.let {
-                        AuthorizationCodeInstalledApp.Browser { url -> it.browse(url) }
-                    } ?: AuthorizationCodeInstalledApp.DefaultBrowser()
-                    val tokens = cancelable({ receiver.stop() }) {
-                        AuthorizationCodeInstalledApp(flow, receiver, browser).authorize(null)
-                    }
-                    runSynchronized(this@ModelixAuthClient) {
-                        lastCredentials[config.getCacheKey()] = tokens
-                    }
-                    return@withContext tokens
-                } catch (ex: SocketException) {
-                    LOG.info("Port $port already in use. Trying next one.")
-                    LOG.debug("Login failed with socket exception, which is expected, if we can not open the callback port.", ex)
-                }
-            }
-            throw IllegalStateException("Couldn't find an available port for the redirect URL")
-        }
+        return getCachedTokens(config).authorize(config)
     }
 
     @Suppress("UndocumentedPublicFunction") // already documented in the expected declaration
@@ -235,36 +302,5 @@ actual class ModelixAuthClient {
                 else -> protocol
             }
         }.toString()
-    }
-
-    /**
-     * [blockingCall] is expected to be uninterruptible by typical platform mechanisms, but by some special call done
-     * by [onCancel].
-     */
-    private suspend fun <R> cancelable(onCancel: suspend () -> Unit, blockingCall: () -> R): R {
-        return coroutineScope {
-            var cancellationEx: CancellationException? = null
-            var blockingCallReturned = false
-            val cancellationHandlerJob = launch(Dispatchers.IO) {
-                try {
-                    awaitCancellation()
-                } catch (ex: CancellationException) {
-                    if (!blockingCallReturned) {
-                        cancellationEx = ex
-                        onCancel()
-                    }
-                }
-            }
-            withContext(Dispatchers.IO) {
-                try {
-                    return@withContext blockingCall()
-                } catch (ex: Throwable) {
-                    throw cancellationEx ?: ex
-                } finally {
-                    blockingCallReturned = true
-                    cancellationHandlerJob.cancel()
-                }
-            }
-        }
     }
 }

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/ModelixAuthClientTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/ModelixAuthClientTest.kt
@@ -3,6 +3,7 @@ package org.modelix.model.client2
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import org.modelix.model.oauth.ModelixAuthClient
 import org.modelix.model.oauth.OAuthConfig
@@ -30,7 +31,7 @@ class ModelixAuthClientTest {
                         tokenUrl = "http://localhost/token",
                         authorizationUrl = "http://localhost/auth",
                         authRequestHandler = object : IAuthRequestHandler {
-                            override fun browse(url: String) {
+                            override fun browse(request: IAuthRequest) {
                                 browseCalled = true
                             }
                         },

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/OAuthTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/OAuthTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.modelix.model.api.ITree
 import org.modelix.model.lazy.RepositoryId
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
@@ -37,9 +38,9 @@ class OAuthTest {
             .oauth {
                 clientId("external-mps")
                 authRequestHandler(object : IAuthRequestHandler {
-                    override fun browse(url: String) {
+                    override fun browse(request: IAuthRequest) {
                         runBlocking {
-                            handleOAuthLogin(url, "user1", "abc")
+                            handleOAuthLogin(request.getUrl(), "user1", "abc")
                         }
                     }
                 })

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/RefreshTokenTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/RefreshTokenTest.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.Serializable
 import org.modelix.kotlin.utils.filterNotNullValues
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import java.net.BindException
 import kotlin.random.Random
@@ -138,9 +139,9 @@ class RefreshTokenTest {
             ModelClientV2.builder().url("http://localhost:$port").authConfig(
                 IAuthConfig.oauth {
                     authRequestHandler(object : IAuthRequestHandler {
-                        override fun browse(url: String) {
+                        override fun browse(request: IAuthRequest) {
                             // https://localhost/realms/modelix/protocol/openid-connect/auth?client_id=my-client-id&code_challenge=YzBhqU2-lRzCkoSLVc0BGN3_AlwU5YUpYS1_m_6FMbI&code_challenge_method=S256&redirect_uri=http://127.0.0.1:64186/Callback&response_type=code&scope=email
-                            val redirectUri = Url(url).parameters["redirect_uri"]!!
+                            val redirectUri = Url(request.getUrl()).parameters["redirect_uri"]!!
                             val callbackWithCode = buildUrl {
                                 takeFrom(redirectUri)
                                 parameters.append("code", "abc")
@@ -259,11 +260,11 @@ class RefreshTokenTest {
                 IAuthConfig.oauth {
                     authRequestHandler(object : IAuthRequestHandler {
                         var loginAlreadyRequested = false
-                        override fun browse(url: String) {
+                        override fun browse(request: IAuthRequest) {
                             check(!loginAlreadyRequested) { "Should use refresh token to fetch new tokens" }
                             loginAlreadyRequested = true
                             // https://localhost/realms/modelix/protocol/openid-connect/auth?client_id=my-client-id&code_challenge=YzBhqU2-lRzCkoSLVc0BGN3_AlwU5YUpYS1_m_6FMbI&code_challenge_method=S256&redirect_uri=http://127.0.0.1:64186/Callback&response_type=code&scope=email
-                            val redirectUri = Url(url).parameters["redirect_uri"]!!
+                            val redirectUri = Url(request.getUrl()).parameters["redirect_uri"]!!
                             val callbackWithCode = buildUrl {
                                 takeFrom(redirectUri)
                                 parameters.append("code", "abc")

--- a/model-client/src/jvmTest/kotlin/org/modelix/model/client2/TokenEndpointTest.kt
+++ b/model-client/src/jvmTest/kotlin/org/modelix/model/client2/TokenEndpointTest.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.Serializable
 import org.modelix.kotlin.utils.filterNotNullValues
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import kotlin.random.Random
 import kotlin.test.Test
@@ -100,9 +101,9 @@ class TokenEndpointTest {
             val modelClient = ModelClientV2.builder().url("http://localhost:$port").authConfig(
                 IAuthConfig.oauth {
                     authRequestHandler(object : IAuthRequestHandler {
-                        override fun browse(url: String) {
+                        override fun browse(request: IAuthRequest) {
                             // https://localhost/realms/modelix/protocol/openid-connect/auth?client_id=my-client-id&code_challenge=YzBhqU2-lRzCkoSLVc0BGN3_AlwU5YUpYS1_m_6FMbI&code_challenge_method=S256&redirect_uri=http://127.0.0.1:64186/Callback&response_type=code&scope=email
-                            val redirectUri = io.ktor.http.Url(url).parameters["redirect_uri"]!!
+                            val redirectUri = io.ktor.http.Url(request.getUrl()).parameters["redirect_uri"]!!
                             val callbackWithCode = buildUrl {
                                 takeFrom(redirectUri)
                                 parameters.append("code", "abc")

--- a/model-server/src/test/kotlin/org/modelix/model/server/TokenManagementTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/TokenManagementTest.kt
@@ -26,6 +26,7 @@ import org.modelix.authorization.createModelixAccessToken
 import org.modelix.model.client2.ModelClientV2
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import org.modelix.model.oauth.ITokenProvider
 import org.modelix.model.oauth.TokenParameters
@@ -167,9 +168,9 @@ class TokenManagementTest {
                 .authConfig(
                     IAuthConfig.oauth {
                         authRequestHandler(object : IAuthRequestHandler {
-                            override fun browse(url: String) {
+                            override fun browse(request: IAuthRequest) {
                                 // https://localhost/realms/modelix/protocol/openid-connect/auth?client_id=my-client-id&code_challenge=YzBhqU2-lRzCkoSLVc0BGN3_AlwU5YUpYS1_m_6FMbI&code_challenge_method=S256&redirect_uri=http://127.0.0.1:64186/Callback&response_type=code&scope=email
-                                val redirectUri = io.ktor.http.Url(url).parameters["redirect_uri"]!!
+                                val redirectUri = io.ktor.http.Url(request.getUrl()).parameters["redirect_uri"]!!
                                 val callbackWithCode = buildUrl {
                                     takeFrom(redirectUri)
                                     parameters.append("code", "abc")

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/AppLevelModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/AppLevelModelSyncService.kt
@@ -7,13 +7,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import org.modelix.model.api.runSynchronized
 import org.modelix.model.client2.IModelClientV2
 import org.modelix.model.client2.ModelClientV2
 import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.IAuthRequestHandler
 import org.modelix.model.oauth.OAuthConfig
 import org.modelix.model.oauth.OAuthConfigBuilder
 import org.modelix.model.oauth.TokenParameters
+import java.util.Collections
 
 @Service(Service.Level.APP)
 class AppLevelModelSyncService() : Disposable {
@@ -77,7 +80,6 @@ class AppLevelModelSyncService() : Disposable {
             try {
                 getClient().getServerId()
                 connected = true
-                authRequestHandler.clear()
             } catch (ex: Throwable) {
                 connected = false
             }
@@ -103,7 +105,7 @@ class AppLevelModelSyncService() : Disposable {
 
         fun disconnect() {
             checkDisposed()
-            authRequestHandler.clear()
+            authRequestHandler.cancelAll()
             runBlocking {
                 client.updateValue {
                     it?.close()
@@ -125,9 +127,9 @@ class AppLevelModelSyncService() : Disposable {
             runBlocking { client.updateValue { null } }
         }
 
-        fun getPendingAuthRequest(): String? {
+        fun getPendingAuthRequest(): List<IAuthRequest> {
             checkDisposed()
-            return authRequestHandler.getPendingRequest()
+            return authRequestHandler.getPendingRequests()
         }
 
         fun dispose() {
@@ -140,15 +142,25 @@ class AppLevelModelSyncService() : Disposable {
 }
 
 private class AsyncAuthRequestHandler : IAuthRequestHandler {
-    private var pendingUrl: String? = null
+    private val pendingRequests = Collections.synchronizedCollection(LinkedHashSet<IAuthRequest>())
 
-    override fun browse(url: String) {
-        pendingUrl = url
+    private fun cleanup() {
+        runSynchronized(pendingRequests) {
+            pendingRequests.removeIf { !it.isActive() }
+        }
     }
 
-    fun getPendingRequest(): String? = pendingUrl
+    override fun browse(request: IAuthRequest) {
+        cleanup()
+        pendingRequests.add(request)
+    }
 
-    fun clear() {
-        pendingUrl = null
+    fun getPendingRequests(): List<IAuthRequest> {
+        cleanup()
+        return pendingRequests.toList()
+    }
+
+    fun cancelAll() {
+        pendingRequests.filter { it.isActive() }.forEach { it.cancel() }
     }
 }

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/IModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/IModelSyncService.kt
@@ -10,6 +10,7 @@ import org.modelix.model.IVersion
 import org.modelix.model.client2.IModelClientV2
 import org.modelix.model.lazy.BranchReference
 import org.modelix.model.mpsadapters.toModelix
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.ITokenProvider
 import org.modelix.model.oauth.OAuthConfigBuilder
 import org.modelix.mps.multiplatform.model.MPSModuleReference
@@ -62,7 +63,7 @@ interface IServerConnection : Closeable {
     fun deactivate()
     fun remove()
     fun getStatus(): Status
-    fun getPendingAuthRequest(): String?
+    fun getPendingAuthRequests(): List<IAuthRequest>
 
     override fun close() = deactivate()
 

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ModelSyncService.kt
@@ -23,6 +23,7 @@ import org.modelix.model.lazy.BranchReference
 import org.modelix.model.mpsadapters.MPSProjectAsNode
 import org.modelix.model.mpsadapters.toMPS
 import org.modelix.model.oauth.IAuthConfig
+import org.modelix.model.oauth.IAuthRequest
 import org.modelix.model.oauth.ITokenProvider
 import org.modelix.model.oauth.OAuthConfigBuilder
 import org.modelix.model.oauth.TokenProvider
@@ -279,16 +280,16 @@ class ModelSyncService(val project: Project) :
         }
 
         override fun getStatus(): IServerConnection.Status {
-            return if (connection.isConnected()) {
-                IServerConnection.Status.CONNECTED
-            } else if (connection.getPendingAuthRequest() != null) {
+            return if (connection.getPendingAuthRequest().isNotEmpty()) {
                 IServerConnection.Status.AUTHORIZATION_REQUIRED
+            } else if (connection.isConnected()) {
+                IServerConnection.Status.CONNECTED
             } else {
                 IServerConnection.Status.DISCONNECTED
             }
         }
 
-        override fun getPendingAuthRequest(): String? {
+        override fun getPendingAuthRequests(): List<IAuthRequest> {
             return connection.getPendingAuthRequest()
         }
 

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
@@ -61,13 +61,13 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
     init {
         object : ClickListener() {
             override fun onClick(e: MouseEvent, clickCount: Int): Boolean {
-                val urls = IModelSyncService.getInstance(project).getUsedServerConnections()
-                    .mapNotNull { it.getPendingAuthRequest() }.toSet()
-                if (urls.isNotEmpty()) {
+                val authRequests = IModelSyncService.getInstance(project).getUsedServerConnections()
+                    .flatMap { it.getPendingAuthRequests() }.toSet()
+                if (authRequests.isNotEmpty()) {
                     val desktop = Desktop.getDesktop()
                     if (desktop.isSupported(Desktop.Action.BROWSE)) {
-                        for (url in urls) {
-                            desktop.browse(URI.create(url))
+                        for (authRequest in authRequests) {
+                            desktop.browse(URI.create(authRequest.getUrl()))
                         }
                     }
                     return true
@@ -123,7 +123,9 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
     }
 
     private fun authorizationRequired(): Boolean {
-        return IModelSyncService.getInstance(project).getUsedServerConnections().any { it.getPendingAuthRequest() != null }
+        return IModelSyncService.getInstance(project)
+            .getUsedServerConnections()
+            .any { it.getPendingAuthRequests().isNotEmpty() }
     }
 
     override fun getPresentation(): StatusBarWidget.WidgetPresentation? {
@@ -167,14 +169,14 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
                                     +connection.getStatus().toString()
                                 }
                             }
-                            connection.getPendingAuthRequest()?.let { url ->
+                            connection.getPendingAuthRequests().forEach { request ->
                                 tr {
                                     td {
                                         styleX = "font-weight: bold"
                                         +"Authorization URL: "
                                     }
                                     td {
-                                        +url
+                                        +request.getUrl()
                                     }
                                 }
                             }


### PR DESCRIPTION
With a previous change the client now requests multiple tokens, a separate one for each branch. The sync plugin didn't show the pending requests for the other tokens after a successfully using the first one.

It's still an open issue is that the user even has to authorize the client multiple times. This will be fixed later.