### PR TITLE
feat(model-client): stamp version attributes on ReplicatedModel commits and expose them in history queries

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ReplicatedModel.kt
@@ -59,6 +59,9 @@ import org.modelix.model.mutable.asModel
  * @property branchRef the model server branch to fetch the data from
  * @property providedScope the CoroutineScope to use for the suspendable tasks
  * @property initialRemoteVersion the last version on the server from which we want to start the synchronization
+ * @property versionAttributes supplier invoked once per new local version to obtain the attributes to stamp on it.
+ *   The returned map is snapshotted at version-build time. The supplier must be cheap and thread-safe
+ *   because it is called from a write-locked coroutine on every commit.
  */
 class ReplicatedModel(
     val client: IModelClientV2,
@@ -66,6 +69,7 @@ class ReplicatedModel(
     val idGenerator: (TreeId) -> INodeIdGenerator<INodeReference>,
     private val providedScope: CoroutineScope? = null,
     initialRemoteVersion: CLVersion? = null,
+    private val versionAttributes: () -> Map<String, String> = { emptyMap() },
 ) : Closeable {
     private val scope = providedScope ?: CoroutineScope(Dispatchers.Default)
     private var state = State.New
@@ -75,7 +79,7 @@ class ReplicatedModel(
 
     init {
         if (initialRemoteVersion != null) {
-            localModel = LocalModel(initialRemoteVersion, client.getIdGenerator(), idGenerator(initialRemoteVersion.getModelTree().getId())) { client.getUserId() }
+            localModel = LocalModel(initialRemoteVersion, client.getIdGenerator(), idGenerator(initialRemoteVersion.getModelTree().getId()), { client.getUserId() }, versionAttributes)
         }
     }
 
@@ -93,7 +97,7 @@ class ReplicatedModel(
 
         if (localModel == null) {
             val initialVersion = remoteVersion.pull()
-            localModel = LocalModel(initialVersion, client.getIdGenerator(), idGenerator(initialVersion.getModelTree().getId())) { client.getUserId() }
+            localModel = LocalModel(initialVersion, client.getIdGenerator(), idGenerator(initialVersion.getModelTree().getId()), { client.getUserId() }, versionAttributes)
         }
 
         // receive changes from the server
@@ -205,18 +209,26 @@ class ReplicatedModel(
     }
 }
 
-fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, idGenerator: (TreeId) -> INodeIdGenerator<INodeReference>): ReplicatedModel {
-    return ReplicatedModel(this, branchRef, idGenerator)
+/**
+ * @param versionAttributes supplier invoked once per new local version. Must be cheap and thread-safe.
+ * @see ReplicatedModel
+ */
+fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, idGenerator: (TreeId) -> INodeIdGenerator<INodeReference>, versionAttributes: () -> Map<String, String> = { emptyMap() }): ReplicatedModel {
+    return ReplicatedModel(this, branchRef, idGenerator, versionAttributes = versionAttributes)
 }
 
-fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, idGenerator: (TreeId) -> INodeIdGenerator<INodeReference>, scope: CoroutineScope): ReplicatedModel {
-    return ReplicatedModel(this, branchRef, idGenerator, scope)
+/**
+ * @param versionAttributes supplier invoked once per new local version. Must be cheap and thread-safe.
+ * @see ReplicatedModel
+ */
+fun IModelClientV2.getReplicatedModel(branchRef: BranchReference, idGenerator: (TreeId) -> INodeIdGenerator<INodeReference>, scope: CoroutineScope, versionAttributes: () -> Map<String, String> = { emptyMap() }): ReplicatedModel {
+    return ReplicatedModel(this, branchRef, idGenerator, scope, versionAttributes = versionAttributes)
 }
 
 /**
  * Manages the locks during the creation and merge of versions.
  */
-private class LocalModel(initialVersion: CLVersion, val versionIdGenerator: IIdGenerator, val idGenerator: INodeIdGenerator<INodeReference>, val author: () -> String?) {
+private class LocalModel(initialVersion: CLVersion, val versionIdGenerator: IIdGenerator, val idGenerator: INodeIdGenerator<INodeReference>, val author: () -> String?, val versionAttributes: () -> Map<String, String> = { emptyMap() }) {
 
     /**
      * The state of the local model is the state of localVersion.getTree() plus the pending changes in
@@ -302,6 +314,7 @@ private class LocalModel(initialVersion: CLVersion, val versionIdGenerator: IIdG
             .currentTime()
             .tree(tree)
             .operations(ops.map { it.getOriginalOp() })
+            .also { builder -> versionAttributes().forEach { (k, v) -> builder.attribute(k, v) } }
             .buildLegacy()
         localVersion = newVersion
         return newVersion

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
@@ -223,6 +223,12 @@ data class ReplicatedModelParameters(
     val idScheme: IdSchemeJS,
     val readonly: Boolean = false,
     val versionHash: String? = null,
+    /**
+     * Supplier invoked once per new local version to obtain the attributes to stamp on it.
+     * Called from a write-locked coroutine on every commit — must be cheap and thread-safe.
+     * Return an empty array to stamp no attributes.
+     */
+    val versionAttributes: () -> Array<AttributeEntryJS> = { emptyArray() },
 ) {
     init {
         require((branchId != null) xor (versionHash != null)) { "Exactly one of branchId or versionHash must be provided" }
@@ -230,6 +236,36 @@ data class ReplicatedModelParameters(
             require(readonly) { "versionHash requires readonly=true" }
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ReplicatedModelParameters) return false
+        return repositoryId == other.repositoryId &&
+            branchId == other.branchId &&
+            idScheme == other.idScheme &&
+            readonly == other.readonly &&
+            versionHash == other.versionHash &&
+            versionAttributes === other.versionAttributes
+    }
+
+    override fun hashCode(): Int {
+        var result = repositoryId.hashCode()
+        result = 31 * result + branchId.hashCode()
+        result = 31 * result + idScheme.hashCode()
+        result = 31 * result + readonly.hashCode()
+        result = 31 * result + versionHash.hashCode()
+        result = 31 * result + versionAttributes.hashCode()
+        return result
+    }
+}
+
+private fun buildVersionAttributesMap(entries: Array<AttributeEntryJS>): Map<String, String> {
+    val map = LinkedHashMap<String, String>(entries.size)
+    for (entry in entries) {
+        require(!map.containsKey(entry.key)) { "Duplicate version attribute key" }
+        map[entry.key] = entry.value
+    }
+    return map
 }
 
 internal class ClientJSImpl(private val modelClient: ModelClientV2) : ClientJS {
@@ -315,17 +351,18 @@ internal class ClientJSImpl(private val modelClient: ModelClientV2) : ClientJS {
                     IdSchemeJS.MODELIX -> { treeId -> ModelixIdGenerator(modelClient.getIdGenerator(), treeId) }
                     IdSchemeJS.MPS -> { treeId -> MPSIdGenerator(modelClient.getIdGenerator(), treeId) }
                 }
+                val versionAttributes: () -> Map<String, String> = { buildVersionAttributesMap(parameters.versionAttributes()) }
                 if (branchReference == null) {
                     if (parameters.versionHash != null) {
                         modelClient.loadVersion(repositoryId, parameters.versionHash, null)
                             .let { IReplicatedOrReadonlyModel.Readonly(it) }
                     } else {
-                        modelClient.getReplicatedModel(repositoryId.getBranchReference(), idGenerator)
+                        modelClient.getReplicatedModel(repositoryId.getBranchReference(), idGenerator, versionAttributes = versionAttributes)
                             .also { it.start() }
                             .let { IReplicatedOrReadonlyModel.Replicated(it) }
                     }
                 } else {
-                    modelClient.getReplicatedModel(branchReference, idGenerator)
+                    modelClient.getReplicatedModel(branchReference, idGenerator, versionAttributes = versionAttributes)
                         .also { it.start() }
                         .let { IReplicatedOrReadonlyModel.Replicated(it) }
                 }
@@ -342,6 +379,7 @@ internal class ClientJSImpl(private val modelClient: ModelClientV2) : ClientJS {
                     version.getAuthor(),
                     version.getTimestamp()?.toJSDate(),
                     version.getContentHash(),
+                    version.getAttributes().toAttributeEntriesJS(),
                 ),
                 MutableModelTreeJsImpl(version.getModelTree().asMutableReadonly()),
             )
@@ -366,6 +404,7 @@ internal class ClientJSImpl(private val modelClient: ModelClientV2) : ClientJS {
                         it.author,
                         it.time.toJSDate(),
                         it.versionHash.toString(),
+                        it.attributes.toAttributeEntriesJS(),
                     )
                 }
                 .toTypedArray()

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ReplicatedModelJSImpl.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ReplicatedModelJSImpl.kt
@@ -35,9 +35,6 @@ internal class ReplicatedModelJSImpl(private val models: List<IReplicatedOrReado
     }
 
     private fun IVersion.toVersionInformationJS(): VersionInformationJS {
-        val currentVersion = this
-        val currentVersionAuthor = currentVersion.getAuthor()
-        val currentVersionTime = currentVersion.getTimestamp()?.toJSDate()
-        return VersionInformationJS(currentVersionAuthor, currentVersionTime, currentVersion.getContentHash())
+        return VersionInformationJS(getAuthor(), getTimestamp()?.toJSDate(), getContentHash(), getAttributes().toAttributeEntriesJS())
     }
 }

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/VersionInformationJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/VersionInformationJS.kt
@@ -25,7 +25,55 @@ data class VersionInformationJS(
      * hash string of the version
      */
     val versionHash: String?,
-)
+
+    /**
+     * Attributes stored on this version.
+     */
+    val attributes: Array<AttributeEntryJS> = emptyArray(),
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VersionInformationJS) return false
+        return author == other.author &&
+            time == other.time &&
+            versionHash == other.versionHash &&
+            attributes.asMap() == other.attributes.asMap()
+    }
+
+    override fun hashCode(): Int {
+        var result = author.hashCode()
+        result = 31 * result + time.hashCode()
+        result = 31 * result + versionHash.hashCode()
+        result = 31 * result + attributes.asMap().hashCode()
+        return result
+    }
+}
+
+/**
+ * A single key-value attribute, used for writing attributes to a version.
+ */
+@JsExport
+class AttributeEntryJS(val key: String, val value: String) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AttributeEntryJS) return false
+        return key == other.key && value == other.value
+    }
+
+    override fun hashCode(): Int = 31 * key.hashCode() + value.hashCode()
+}
+
+internal fun Array<AttributeEntryJS>.asMap(): Map<String, String> = associate { it.key to it.value }
+
+internal fun Map<String, String>.toAttributeEntriesJS(): Array<AttributeEntryJS> =
+    entries.map { AttributeEntryJS(it.key, it.value) }.toTypedArray()
+
+/**
+ * An aggregated attribute entry from a history interval, where multiple versions may have
+ * contributed different values for the same key.
+ */
+@JsExport
+class AggregatedAttributeEntryJS(val key: String, val values: Array<String>)
 
 @JsExport
 class HistoryIntervalJS(
@@ -38,6 +86,11 @@ class HistoryIntervalJS(
     val minTime: Date,
     val maxTime: Date,
     val authors: Array<String>,
+    /**
+     * Aggregated attributes from all versions in this interval.
+     * Each entry contains all distinct values seen for that key across all versions.
+     */
+    val attributes: Array<AggregatedAttributeEntryJS>,
 )
 
 fun HistoryInterval.toJS() = HistoryIntervalJS(
@@ -47,4 +100,5 @@ fun HistoryInterval.toJS() = HistoryIntervalJS(
     minTime = minTime.toJSDate(),
     maxTime = maxTime.toJSDate(),
     authors = authors.toTypedArray(),
+    attributes = attributes.entries.map { AggregatedAttributeEntryJS(it.key, it.value.toTypedArray()) }.toTypedArray(),
 )

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/VersionInformationJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/VersionInformationJS.kt
@@ -73,7 +73,7 @@ internal fun Map<String, String>.toAttributeEntriesJS(): Array<AttributeEntryJS>
  * contributed different values for the same key.
  */
 @JsExport
-class AggregatedAttributeEntryJS(val key: String, val values: Array<String>)
+class AggregatedAttributeEntryJS(val key: String, val firstValues: Array<String>, val lastValues: Array<String>)
 
 @JsExport
 class HistoryIntervalJS(
@@ -100,5 +100,7 @@ fun HistoryInterval.toJS() = HistoryIntervalJS(
     minTime = minTime.toJSDate(),
     maxTime = maxTime.toJSDate(),
     authors = authors.toTypedArray(),
-    attributes = attributes.entries.map { AggregatedAttributeEntryJS(it.key, it.value.toTypedArray()) }.toTypedArray(),
+    attributes = attributes.getEntries().map {
+        AggregatedAttributeEntryJS(it.key, it.value.first.toTypedArray(), it.value.last.toTypedArray())
+    }.toTypedArray(),
 )

--- a/model-client/src/jsTest/kotlin/org/modelix/model/client2/ReplicatedModelParametersTest.kt
+++ b/model-client/src/jsTest/kotlin/org/modelix/model/client2/ReplicatedModelParametersTest.kt
@@ -1,7 +1,10 @@
 package org.modelix.model.client2
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
 
 class ReplicatedModelParametersTest {
 
@@ -60,5 +63,43 @@ class ReplicatedModelParametersTest {
                 versionHash = "hash",
             )
         }
+    }
+
+    @Test
+    fun test_equals_same_versionAttributes_supplier() {
+        val supplier: () -> Array<AttributeEntryJS> = { arrayOf(AttributeEntryJS("env", "ci")) }
+        val a = ReplicatedModelParameters(
+            repositoryId = "repo",
+            branchId = "branch",
+            idScheme = IdSchemeJS.MODELIX,
+            versionAttributes = supplier,
+        )
+        val b = ReplicatedModelParameters(
+            repositoryId = "repo",
+            branchId = "branch",
+            idScheme = IdSchemeJS.MODELIX,
+            versionAttributes = supplier,
+        )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertSame(a.versionAttributes, b.versionAttributes)
+    }
+
+    @Test
+    fun test_not_equals_different_versionAttributes_suppliers() {
+        // Two distinct lambdas with the same body are not equal — reference equality applies.
+        val a = ReplicatedModelParameters(
+            repositoryId = "repo",
+            branchId = "branch",
+            idScheme = IdSchemeJS.MODELIX,
+            versionAttributes = { arrayOf(AttributeEntryJS("env", "ci")) },
+        )
+        val b = ReplicatedModelParameters(
+            repositoryId = "repo",
+            branchId = "branch",
+            idScheme = IdSchemeJS.MODELIX,
+            versionAttributes = { arrayOf(AttributeEntryJS("env", "ci")) },
+        )
+        assertNotEquals(a, b)
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/AttributesAggregation.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/AttributesAggregation.kt
@@ -1,0 +1,82 @@
+package org.modelix.datastructures.history
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AttributesAggregation(val attributes: Map<String, AttributeValuesAggregation>) {
+    fun getEntries() = attributes.entries
+
+    operator fun get(key: String) = getValues(key)
+
+    fun getValues(key: String): AttributeValuesAggregation {
+        return attributes[key] ?: AttributeValuesAggregation.EMPTY
+    }
+
+    fun merge(other: AttributesAggregation): AttributesAggregation {
+        return AttributesAggregation(
+            (attributes.keys + other.attributes.keys).associateWith { getValues(it).merge(other.getValues(it)) },
+        )
+    }
+
+    fun isEmpty() = attributes.isEmpty()
+
+    operator fun plus(other: AttributesAggregation) = merge(other)
+
+    override fun toString(): String {
+        return attributes.toString()
+    }
+
+    companion object {
+        val EMPTY = AttributesAggregation(emptyMap())
+
+        fun of(entries: Map<String, String>): AttributesAggregation {
+            return AttributesAggregation(entries.mapValues { AttributeValuesAggregation.of(it.value) })
+        }
+    }
+}
+
+@Serializable
+data class AttributeValuesAggregation(val first: Set<String>, val last: Set<String>) {
+    init {
+        require(last.intersect(first).isEmpty()) {
+            "Duplicate values: $this"
+        }
+    }
+
+    fun merge(other: AttributeValuesAggregation): AttributeValuesAggregation {
+        return of(first + other.first + last + other.last)
+    }
+
+    override fun toString(): String {
+        return if (first.size + last.size <= MAX_VALUES) {
+            (first.sorted() + last.sorted()).joinToString(", ")
+        } else {
+            first.sorted().joinToString(", ") + ", ..., " + last.sorted().joinToString(", ")
+        }
+    }
+
+    companion object {
+        val MAX_VALUES = 20
+        val MAX_VALUES_START = MAX_VALUES / 2
+        val MAX_VALUES_END = MAX_VALUES / 2
+        val EMPTY = AttributeValuesAggregation(emptySet(), emptySet())
+
+        fun of(values: Set<String>): AttributeValuesAggregation {
+            val sorted = values.sorted()
+            val size2 = (sorted.size / 2).coerceAtMost(MAX_VALUES_END)
+            val size1 = (sorted.size - size2).coerceAtMost(MAX_VALUES_START)
+            return AttributeValuesAggregation(
+                first = sorted.take(size1).toSet(),
+                last = sorted.takeLast(size2).toSet(),
+            )
+        }
+
+        fun of(vararg value: String): AttributeValuesAggregation {
+            return of(value.toSet())
+        }
+
+        fun of(value: String): AttributeValuesAggregation {
+            return AttributeValuesAggregation(setOf(value), emptySet())
+        }
+    }
+}

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryEntry.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryEntry.kt
@@ -9,4 +9,5 @@ data class HistoryEntry(
     val versionHash: ObjectHash,
     val time: Instant,
     val author: String?,
+    val attributes: Map<String, String> = emptyMap(),
 )

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryIndexNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryIndexNode.kt
@@ -28,6 +28,7 @@ sealed class HistoryIndexNode : IObjectData {
     abstract val firstVersion: ObjectReference<CPVersion>
     abstract val lastVersion: ObjectReference<CPVersion>
     abstract val authors: Set<String>
+    abstract val attributes: Map<String, Set<String>>
     abstract val size: Long
     abstract val height: Long
     abstract val minTime: Instant
@@ -60,6 +61,7 @@ sealed class HistoryIndexNode : IObjectData {
             firstVersion = firstVersion,
             lastVersion = other.lastVersion,
             authors = authors + other.authors,
+            attributes = unionAttributes(attributes, other.attributes),
             size = size + other.size,
             height = max(height, other.height) + 1,
             minTime = minTime,
@@ -97,6 +99,7 @@ sealed class HistoryIndexNode : IObjectData {
                         maxTime = times.getOrElse(1) { times[0] },
                         child1 = referenceFactory.fromHashString(parts[6], HistoryIndexNode),
                         child2 = referenceFactory.fromHashString(parts[7], HistoryIndexNode),
+                        attributes = parts.getOrNull(8)?.let { deserializeAttributes(it) } ?: emptyMap(),
                     )
                 }
                 "L" -> {
@@ -105,6 +108,7 @@ sealed class HistoryIndexNode : IObjectData {
                             .map { referenceFactory.fromHashString(it, CPVersion) },
                         authors = parts[2].split(Separators.LEVEL2).mapNotNull { it.urlDecode() }.toSet(),
                         time = Instant.fromEpochSeconds(parts[3].toLong()),
+                        attributes = parts.getOrNull(4)?.let { deserializeAttributes(it) } ?: emptyMap(),
                     )
                 }
                 else -> error("Unknown type: " + parts[0])
@@ -117,11 +121,49 @@ sealed class HistoryIndexNode : IObjectData {
                 versions = listOf(version.ref),
                 authors = setOfNotNull(version.data.author),
                 time = time,
+                attributes = version.data.attributes.mapValues { setOf(it.value) },
             )
         }
 
         fun of(version1: Object<CPVersion>, version2: Object<CPVersion>): HistoryIndexNode {
             return of(version1).asObject(version1.graph).merge(of(version2).asObject(version2.graph)).getBlocking(version1.graph).data
+        }
+
+        /**
+         * Serializes `Map<String, Set<String>>` as a LEVEL2-separated list of `urlEncode(key)=urlEncode(val1);urlEncode(val2)` entries.
+         * Returns empty string for an empty map.
+         */
+        internal fun serializeAttributes(attributes: Map<String, Set<String>>): String {
+            if (attributes.isEmpty()) return ""
+            return attributes.entries.sortedBy { it.key }.joinToString(Separators.LEVEL2) { (key, values) ->
+                key.urlEncode() + Separators.MAPPING + values.sorted().joinToString(Separators.LEVEL3) { it.urlEncode() }
+            }
+        }
+
+        /**
+         * Deserializes the output of [serializeAttributes]. Returns empty map for an empty string.
+         */
+        internal fun deserializeAttributes(serialized: String): Map<String, Set<String>> {
+            if (serialized.isEmpty()) return emptyMap()
+            return serialized.split(Separators.LEVEL2).mapNotNull { entry ->
+                val eqIdx = entry.indexOf(Separators.MAPPING)
+                if (eqIdx < 0) return@mapNotNull null
+                val key = entry.substring(0, eqIdx).urlDecode() ?: return@mapNotNull null
+                val values = entry.substring(eqIdx + 1)
+                    .split(Separators.LEVEL3)
+                    .mapNotNull { it.urlDecode() }
+                    .toSet()
+                key to values
+            }.toMap()
+        }
+
+        internal fun unionAttributes(
+            a: Map<String, Set<String>>,
+            b: Map<String, Set<String>>,
+        ): Map<String, Set<String>> {
+            if (a.isEmpty()) return b
+            if (b.isEmpty()) return a
+            return (a.keys + b.keys).associateWith { key -> (a[key] ?: emptySet()) + (b[key] ?: emptySet()) }
         }
     }
 }
@@ -135,6 +177,7 @@ data class HistoryIndexLeafNode(
     val versions: List<ObjectReference<CPVersion>>,
     override val authors: Set<String>,
     val time: Instant,
+    override val attributes: Map<String, Set<String>> = emptyMap(),
 ) : HistoryIndexNode() {
     override val size: Long get() = versions.size.toLong()
     override val height: Long get() = 1
@@ -167,6 +210,7 @@ data class HistoryIndexLeafNode(
                         versions = listOf(it.ref),
                         authors = setOfNotNull(it.data.author),
                         time = time,
+                        attributes = it.data.attributes.mapValues { (_, v) -> setOf(v) },
                     )
                 }
         }
@@ -188,10 +232,12 @@ data class HistoryIndexLeafNode(
     }
 
     override fun serialize(): String {
+        val attrPart = HistoryIndexNode.serializeAttributes(attributes)
         return "L" +
             Separators.LEVEL1 + versions.joinToString(Separators.LEVEL2) { it.getHashString() } +
             Separators.LEVEL1 + authors.joinToString(Separators.LEVEL2) { it.urlEncode() } +
-            Separators.LEVEL1 + time.epochSeconds.toString()
+            Separators.LEVEL1 + time.epochSeconds.toString() +
+            if (attrPart.isNotEmpty()) Separators.LEVEL1 + attrPart else ""
     }
 
     override fun merge(
@@ -208,6 +254,7 @@ data class HistoryIndexLeafNode(
                         versions = (versions + other.versions).distinctBy { it.getHash() }.toList(),
                         authors = authors + other.authors,
                         time = time,
+                        attributes = unionAttributes(attributes, other.attributes),
                     ).asObject(self.graph).let { IStream.of(it) }
                 }
             }
@@ -253,6 +300,12 @@ data class HistoryIndexRangeNode(
 
     val child1: ObjectReference<HistoryIndexNode>,
     val child2: ObjectReference<HistoryIndexNode>,
+
+    /**
+     * Aggregated attributes from all versions in this subtree.
+     * Maps each attribute key to the set of all distinct values seen across versions.
+     */
+    override val attributes: Map<String, Set<String>> = emptyMap(),
 ) : HistoryIndexNode() {
 
     init {
@@ -412,6 +465,7 @@ data class HistoryIndexRangeNode(
     }
 
     override fun serialize(): String {
+        val attrPart = HistoryIndexNode.serializeAttributes(attributes)
         return "R" +
             Separators.LEVEL1 + firstVersion.getHashString() + Separators.LEVEL2 + lastVersion.getHashString() +
             Separators.LEVEL1 + authors.joinToString(Separators.LEVEL2) { it.urlEncode() } +
@@ -419,7 +473,8 @@ data class HistoryIndexRangeNode(
             Separators.LEVEL1 + height +
             Separators.LEVEL1 + minTime.epochSeconds.toString() + Separators.LEVEL2 + maxTime.epochSeconds +
             Separators.LEVEL1 + child1.getHashString() +
-            Separators.LEVEL1 + child2.getHashString()
+            Separators.LEVEL1 + child2.getHashString() +
+            if (attrPart.isNotEmpty()) Separators.LEVEL1 + attrPart else ""
     }
 }
 

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryIndexNode.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryIndexNode.kt
@@ -28,7 +28,7 @@ sealed class HistoryIndexNode : IObjectData {
     abstract val firstVersion: ObjectReference<CPVersion>
     abstract val lastVersion: ObjectReference<CPVersion>
     abstract val authors: Set<String>
-    abstract val attributes: Map<String, Set<String>>
+    abstract val attributes: AttributesAggregation
     abstract val size: Long
     abstract val height: Long
     abstract val minTime: Instant
@@ -61,7 +61,7 @@ sealed class HistoryIndexNode : IObjectData {
             firstVersion = firstVersion,
             lastVersion = other.lastVersion,
             authors = authors + other.authors,
-            attributes = unionAttributes(attributes, other.attributes),
+            attributes = attributes + other.attributes,
             size = size + other.size,
             height = max(height, other.height) + 1,
             minTime = minTime,
@@ -89,7 +89,7 @@ sealed class HistoryIndexNode : IObjectData {
                     val versionRefs = parts[1].split(Separators.LEVEL2)
                         .map { referenceFactory.fromHashString(it, CPVersion) }
                     val times = parts[5].split(Separators.LEVEL2).map { Instant.fromEpochSeconds(it.toLong()) }
-                    return HistoryIndexRangeNode(
+                    HistoryIndexRangeNode(
                         firstVersion = versionRefs[0],
                         lastVersion = versionRefs.getOrElse(1) { versionRefs[0] },
                         authors = parts[2].split(Separators.LEVEL2).mapNotNull { it.urlDecode() }.toSet(),
@@ -99,7 +99,7 @@ sealed class HistoryIndexNode : IObjectData {
                         maxTime = times.getOrElse(1) { times[0] },
                         child1 = referenceFactory.fromHashString(parts[6], HistoryIndexNode),
                         child2 = referenceFactory.fromHashString(parts[7], HistoryIndexNode),
-                        attributes = parts.getOrNull(8)?.let { deserializeAttributes(it) } ?: emptyMap(),
+                        attributes = parts.getOrNull(8)?.let { deserializeAttributes(it) } ?: AttributesAggregation.EMPTY,
                     )
                 }
                 "L" -> {
@@ -108,7 +108,7 @@ sealed class HistoryIndexNode : IObjectData {
                             .map { referenceFactory.fromHashString(it, CPVersion) },
                         authors = parts[2].split(Separators.LEVEL2).mapNotNull { it.urlDecode() }.toSet(),
                         time = Instant.fromEpochSeconds(parts[3].toLong()),
-                        attributes = parts.getOrNull(4)?.let { deserializeAttributes(it) } ?: emptyMap(),
+                        attributes = parts.getOrNull(4)?.let { deserializeAttributes(it) } ?: AttributesAggregation.EMPTY,
                     )
                 }
                 else -> error("Unknown type: " + parts[0])
@@ -121,7 +121,7 @@ sealed class HistoryIndexNode : IObjectData {
                 versions = listOf(version.ref),
                 authors = setOfNotNull(version.data.author),
                 time = time,
-                attributes = version.data.attributes.mapValues { setOf(it.value) },
+                attributes = AttributesAggregation.of(version.data.attributes),
             )
         }
 
@@ -133,37 +133,39 @@ sealed class HistoryIndexNode : IObjectData {
          * Serializes `Map<String, Set<String>>` as a LEVEL2-separated list of `urlEncode(key)=urlEncode(val1);urlEncode(val2)` entries.
          * Returns empty string for an empty map.
          */
-        internal fun serializeAttributes(attributes: Map<String, Set<String>>): String {
+        internal fun serializeAttributes(attributes: AttributesAggregation): String {
             if (attributes.isEmpty()) return ""
-            return attributes.entries.sortedBy { it.key }.joinToString(Separators.LEVEL2) { (key, values) ->
-                key.urlEncode() + Separators.MAPPING + values.sorted().joinToString(Separators.LEVEL3) { it.urlEncode() }
+            return attributes.getEntries().sortedBy { it.key }.joinToString(Separators.LEVEL2) { (key, values) ->
+                key.urlEncode() +
+                    Separators.MAPPING +
+                    values.first.sorted().joinToString(Separators.LEVEL4) { it.urlEncode() } +
+                    Separators.LEVEL3 +
+                    values.last.sorted().joinToString(Separators.LEVEL4) { it.urlEncode() }
             }
         }
 
         /**
          * Deserializes the output of [serializeAttributes]. Returns empty map for an empty string.
          */
-        internal fun deserializeAttributes(serialized: String): Map<String, Set<String>> {
-            if (serialized.isEmpty()) return emptyMap()
+        internal fun deserializeAttributes(serialized: String): AttributesAggregation {
+            if (serialized.isEmpty()) return AttributesAggregation.EMPTY
             return serialized.split(Separators.LEVEL2).mapNotNull { entry ->
                 val eqIdx = entry.indexOf(Separators.MAPPING)
                 if (eqIdx < 0) return@mapNotNull null
                 val key = entry.substring(0, eqIdx).urlDecode() ?: return@mapNotNull null
-                val values = entry.substring(eqIdx + 1)
-                    .split(Separators.LEVEL3)
+                val firstAndLast = entry.substring(eqIdx + 1).split(Separators.LEVEL3)
+                val firstValues = firstAndLast[0]
+                    .split(Separators.LEVEL4)
+                    .filter { it.isNotEmpty() }
                     .mapNotNull { it.urlDecode() }
                     .toSet()
-                key to values
-            }.toMap()
-        }
-
-        internal fun unionAttributes(
-            a: Map<String, Set<String>>,
-            b: Map<String, Set<String>>,
-        ): Map<String, Set<String>> {
-            if (a.isEmpty()) return b
-            if (b.isEmpty()) return a
-            return (a.keys + b.keys).associateWith { key -> (a[key] ?: emptySet()) + (b[key] ?: emptySet()) }
+                val lastValues = firstAndLast[1]
+                    .split(Separators.LEVEL4)
+                    .filter { it.isNotEmpty() }
+                    .mapNotNull { it.urlDecode() }
+                    .toSet()
+                key to AttributeValuesAggregation(firstValues, lastValues)
+            }.toMap().let { AttributesAggregation(it) }
         }
     }
 }
@@ -177,7 +179,7 @@ data class HistoryIndexLeafNode(
     val versions: List<ObjectReference<CPVersion>>,
     override val authors: Set<String>,
     val time: Instant,
-    override val attributes: Map<String, Set<String>> = emptyMap(),
+    override val attributes: AttributesAggregation,
 ) : HistoryIndexNode() {
     override val size: Long get() = versions.size.toLong()
     override val height: Long get() = 1
@@ -210,7 +212,7 @@ data class HistoryIndexLeafNode(
                         versions = listOf(it.ref),
                         authors = setOfNotNull(it.data.author),
                         time = time,
-                        attributes = it.data.attributes.mapValues { (_, v) -> setOf(v) },
+                        attributes = AttributesAggregation.of(it.data.attributes),
                     )
                 }
         }
@@ -254,7 +256,7 @@ data class HistoryIndexLeafNode(
                         versions = (versions + other.versions).distinctBy { it.getHash() }.toList(),
                         authors = authors + other.authors,
                         time = time,
-                        attributes = unionAttributes(attributes, other.attributes),
+                        attributes = attributes + other.attributes,
                     ).asObject(self.graph).let { IStream.of(it) }
                 }
             }
@@ -305,7 +307,7 @@ data class HistoryIndexRangeNode(
      * Aggregated attributes from all versions in this subtree.
      * Maps each attribute key to the set of all distinct values seen across versions.
      */
-    override val attributes: Map<String, Set<String>> = emptyMap(),
+    override val attributes: AttributesAggregation,
 ) : HistoryIndexNode() {
 
     init {

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryInterval.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryInterval.kt
@@ -22,5 +22,5 @@ data class HistoryInterval(
      * Aggregated attributes from all versions in this interval.
      * Maps each attribute key to the set of all distinct values seen across versions.
      */
-    val attributes: Map<String, Set<String>> = emptyMap(),
+    val attributes: AttributesAggregation = AttributesAggregation.EMPTY,
 )

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryInterval.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryInterval.kt
@@ -18,4 +18,9 @@ data class HistoryInterval(
     val minTime: Instant,
     val maxTime: Instant,
     val authors: Set<String>,
+    /**
+     * Aggregated attributes from all versions in this interval.
+     * Maps each attribute key to the set of all distinct values seen across versions.
+     */
+    val attributes: Map<String, Set<String>> = emptyMap(),
 )

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryQueries.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryQueries.kt
@@ -28,29 +28,31 @@ class HistoryQueries(val historyIndex: suspend () -> Object<HistoryIndexNode>) :
         val interval = delay / 2
 
         runUntilLimit {
-            index.data.splitAtInterval(EquidistantIntervalsSpec(interval).withTimeRangeFilter(timeRange)).iterateSuspending(index.graph) {
-                if (previousMinTime - it.maxTime >= delay) {
+            index.data.splitAtInterval(EquidistantIntervalsSpec(interval).withTimeRangeFilter(timeRange)).iterateSuspending(index.graph) { node ->
+                if (previousMinTime - node.maxTime >= delay) {
                     if (sessions.lastIndex >= pagination.asRange().last) throw LimitReached()
                     sessions += HistoryInterval(
-                        firstVersionHash = it.firstVersion.getHash(),
-                        lastVersionHash = it.lastVersion.getHash(),
-                        size = it.size,
-                        minTime = it.minTime,
-                        maxTime = it.maxTime,
-                        authors = it.authors,
+                        firstVersionHash = node.firstVersion.getHash(),
+                        lastVersionHash = node.lastVersion.getHash(),
+                        size = node.size,
+                        minTime = node.minTime,
+                        maxTime = node.maxTime,
+                        authors = node.authors,
+                        attributes = node.attributes,
                     )
                 } else {
                     val entry = sessions[sessions.lastIndex]
                     sessions[sessions.lastIndex] = HistoryInterval(
-                        firstVersionHash = it.firstVersion.getHash(),
+                        firstVersionHash = node.firstVersion.getHash(),
                         lastVersionHash = entry.lastVersionHash,
-                        size = entry.size + it.size,
-                        minTime = minOf(entry.minTime, it.minTime),
-                        maxTime = maxOf(entry.maxTime, it.maxTime),
-                        authors = entry.authors + it.authors,
+                        size = entry.size + node.size,
+                        minTime = minOf(entry.minTime, node.minTime),
+                        maxTime = maxOf(entry.maxTime, node.maxTime),
+                        authors = entry.authors + node.authors,
+                        attributes = HistoryIndexNode.unionAttributes(entry.attributes, node.attributes),
                     )
                 }
-                previousMinTime = it.minTime
+                previousMinTime = node.minTime
             }
         }
 
@@ -74,29 +76,31 @@ class HistoryQueries(val historyIndex: suspend () -> Object<HistoryIndexNode>) :
         var previousIntervalId: Long = Long.MAX_VALUE
 
         runUntilLimit {
-            index.data.splitAtInterval(intervalsSpec).iterateSuspending(index.graph) {
-                val intervalId = intervalsSpec.getIntervalIndex(it.maxTime)
+            index.data.splitAtInterval(intervalsSpec).iterateSuspending(index.graph) { node ->
+                val intervalId = intervalsSpec.getIntervalIndex(node.maxTime)
                 check(intervalId <= previousIntervalId)
                 if (intervalId == previousIntervalId) {
                     val entry = mergedEntries[mergedEntries.lastIndex]
                     mergedEntries[mergedEntries.lastIndex] = HistoryInterval(
-                        firstVersionHash = it.firstVersion.getHash(),
+                        firstVersionHash = node.firstVersion.getHash(),
                         lastVersionHash = entry.lastVersionHash,
-                        size = entry.size + it.size,
-                        minTime = minOf(entry.minTime, it.minTime),
-                        maxTime = maxOf(entry.maxTime, it.maxTime),
-                        authors = entry.authors + it.authors,
+                        size = entry.size + node.size,
+                        minTime = minOf(entry.minTime, node.minTime),
+                        maxTime = maxOf(entry.maxTime, node.maxTime),
+                        authors = entry.authors + node.authors,
+                        attributes = HistoryIndexNode.unionAttributes(entry.attributes, node.attributes),
                     )
                 } else {
                     if (mergedEntries.lastIndex >= pagination.asRange().last) throw LimitReached()
                     previousIntervalId = intervalId
                     mergedEntries += HistoryInterval(
-                        firstVersionHash = it.firstVersion.getHash(),
-                        lastVersionHash = it.lastVersion.getHash(),
-                        size = it.size,
-                        minTime = it.minTime,
-                        maxTime = it.maxTime,
-                        authors = it.authors,
+                        firstVersionHash = node.firstVersion.getHash(),
+                        lastVersionHash = node.lastVersion.getHash(),
+                        size = node.size,
+                        minTime = node.minTime,
+                        maxTime = node.maxTime,
+                        authors = node.authors,
+                        attributes = node.attributes,
                     )
                 }
             }
@@ -121,6 +125,7 @@ class HistoryQueries(val historyIndex: suspend () -> Object<HistoryIndexNode>) :
                     versionHash = it.getHash(),
                     time = version.getTimestamp() ?: Instant.fromEpochSeconds(0L),
                     author = version.getAuthor(),
+                    attributes = version.getAttributes(),
                 )
             }
             .toList()

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryQueries.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/datastructures/history/HistoryQueries.kt
@@ -49,7 +49,7 @@ class HistoryQueries(val historyIndex: suspend () -> Object<HistoryIndexNode>) :
                         minTime = minOf(entry.minTime, node.minTime),
                         maxTime = maxOf(entry.maxTime, node.maxTime),
                         authors = entry.authors + node.authors,
-                        attributes = HistoryIndexNode.unionAttributes(entry.attributes, node.attributes),
+                        attributes = entry.attributes + node.attributes,
                     )
                 }
                 previousMinTime = node.minTime
@@ -88,7 +88,7 @@ class HistoryQueries(val historyIndex: suspend () -> Object<HistoryIndexNode>) :
                         minTime = minOf(entry.minTime, node.minTime),
                         maxTime = maxOf(entry.maxTime, node.maxTime),
                         authors = entry.authors + node.authors,
-                        attributes = HistoryIndexNode.unionAttributes(entry.attributes, node.attributes),
+                        attributes = entry.attributes + node.attributes,
                     )
                 } else {
                     if (mergedEntries.lastIndex >= pagination.asRange().last) throw LimitReached()

--- a/model-datastructure/src/commonTest/kotlin/HistoryIndexNodeAttributesTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/HistoryIndexNodeAttributesTest.kt
@@ -1,0 +1,141 @@
+import kotlinx.datetime.Instant
+import org.modelix.datastructures.history.HistoryIndexNode
+import org.modelix.datastructures.history.merge
+import org.modelix.datastructures.model.IGenericModelTree
+import org.modelix.datastructures.objects.FullyLoadedObjectGraph
+import org.modelix.datastructures.objects.asObject
+import org.modelix.model.IVersion
+import org.modelix.model.TreeId
+import org.modelix.model.lazy.CLVersion
+import org.modelix.streams.getBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class HistoryIndexNodeAttributesTest {
+
+    private fun createInitialVersion(attrs: Map<String, String> = emptyMap()): CLVersion {
+        val graph = FullyLoadedObjectGraph()
+        val tree = IGenericModelTree.builder()
+            .withInt64Ids()
+            .treeId(TreeId.fromUUID("69dcb381-3dba-4251-b3ae-7aafe587c28f"))
+            .graph(graph)
+            .build()
+        val builder = IVersion.builder()
+            .tree(tree)
+            .time(Instant.fromEpochMilliseconds(1757582404000L))
+        attrs.forEach { (k, v) -> builder.attribute(k, v) }
+        return builder.build() as CLVersion
+    }
+
+    private fun newVersion(
+        base: CLVersion,
+        attrs: Map<String, String> = emptyMap(),
+        timeDeltaSeconds: Long = 1L,
+    ): CLVersion {
+        val builder = IVersion.builder()
+            .tree(base.getModelTree())
+            .time(base.getTimestamp()!!.plus(timeDeltaSeconds.seconds))
+        attrs.forEach { (k, v) -> builder.attribute(k, v) }
+        return builder.build() as CLVersion
+    }
+
+    // --- of() ---
+
+    @Test
+    fun `of() populates attributes from version`() {
+        val v = createInitialVersion(mapOf("env" to "ci", "run" to "42"))
+        val node = HistoryIndexNode.of(v.obj)
+        assertEquals(mapOf("env" to setOf("ci"), "run" to setOf("42")), node.attributes)
+    }
+
+    @Test
+    fun `of() produces empty attributes when version has none`() {
+        val v = createInitialVersion()
+        val node = HistoryIndexNode.of(v.obj)
+        assertEquals(emptyMap(), node.attributes)
+    }
+
+    // --- aggregation through merge/concat ---
+
+    @Test
+    fun `attributes are unioned when two leaf nodes at different times are merged`() {
+        val v1 = createInitialVersion(mapOf("env" to "staging"))
+        val v2 = newVersion(v1, mapOf("env" to "prod", "run" to "1"))
+        val graph = v1.graph
+        val node = HistoryIndexNode.of(v1.obj).asObject(graph)
+            .merge(HistoryIndexNode.of(v2.obj).asObject(graph))
+            .getBlocking(graph)
+        assertEquals(setOf("staging", "prod"), node.data.attributes["env"])
+        assertEquals(setOf("1"), node.data.attributes["run"])
+    }
+
+    @Test
+    fun `attributes are unioned when two leaf nodes at the same time are merged`() {
+        val v1 = createInitialVersion(mapOf("env" to "a"))
+        val v2 = createInitialVersion(mapOf("env" to "b", "run" to "1"))
+        // Same time: both leaves collapse into one leaf
+        val graph = v1.graph
+        val node = HistoryIndexNode.of(v1.obj).asObject(graph)
+            .merge(HistoryIndexNode.of(v2.obj).asObject(graph))
+            .getBlocking(graph)
+        assertEquals(setOf("a", "b"), node.data.attributes["env"])
+        assertEquals(setOf("1"), node.data.attributes["run"])
+    }
+
+    // --- serialization round-trip ---
+
+    @Test
+    fun `leaf node with attributes survives serialize-deserialize round trip`() {
+        val v = createInitialVersion(mapOf("env" to "ci", "run" to "99"))
+        val graph = v.graph
+        val original = HistoryIndexNode.of(v.obj).asObject(graph)
+        val serialized = original.data.serialize()
+        val restored = HistoryIndexNode.deserialize(serialized, graph)
+        assertEquals(original.data.attributes, restored.attributes)
+    }
+
+    @Test
+    fun `range node attributes field survives serialize-deserialize round trip`() {
+        val v1 = createInitialVersion(mapOf("env" to "ci"))
+        val v2 = newVersion(v1, mapOf("env" to "prod"))
+        val graph = v1.graph
+        val original = HistoryIndexNode.of(v1.obj).asObject(graph)
+            .merge(HistoryIndexNode.of(v2.obj).asObject(graph))
+            .getBlocking(graph)
+        val serialized = original.data.serialize()
+        // Range node serializes attributes in field index 8 (0-based, LEVEL1-delimited).
+        // Extract and deserialize just that field rather than the full node, because the full
+        // deserialization requires the child HistoryIndexNode objects to be resolvable in the graph.
+        val parts = serialized.split("/")
+        val attrPart = parts.getOrNull(8) ?: ""
+        val restoredAttrs = HistoryIndexNode.deserializeAttributes(attrPart)
+        assertEquals(original.data.attributes, restoredAttrs)
+    }
+
+    @Test
+    fun `leaf node without attributes field (legacy format) deserializes as empty`() {
+        val v = createInitialVersion()
+        val graph = v.graph
+        val serialized = HistoryIndexNode.of(v.obj).serialize()
+        // When attributes are empty, no trailing field is added — deserialization returns empty map
+        val restored = HistoryIndexNode.deserialize(serialized, graph)
+        assertEquals(emptyMap(), restored.attributes)
+    }
+
+    @Test
+    fun `attributes with separator characters are round-tripped safely`() {
+        // Keys and values that contain every Separators character must survive urlEncode/urlDecode
+        val v = createInitialVersion(
+            mapOf(
+                "key/with/slashes" to "val,with,commas",
+                "key=with=equals" to "val;with;semicolons",
+            ),
+        )
+        val graph = v.graph
+        val node = HistoryIndexNode.of(v.obj)
+        val serialized = node.serialize()
+        val deserialized = HistoryIndexNode.deserialize(serialized, graph)
+        assertEquals(node.attributes, deserialized.attributes)
+    }
+}

--- a/model-datastructure/src/commonTest/kotlin/HistoryIndexNodeAttributesTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/HistoryIndexNodeAttributesTest.kt
@@ -1,4 +1,6 @@
 import kotlinx.datetime.Instant
+import org.modelix.datastructures.history.AttributeValuesAggregation
+import org.modelix.datastructures.history.AttributesAggregation
 import org.modelix.datastructures.history.HistoryIndexNode
 import org.modelix.datastructures.history.merge
 import org.modelix.datastructures.model.IGenericModelTree
@@ -46,14 +48,14 @@ class HistoryIndexNodeAttributesTest {
     fun `of() populates attributes from version`() {
         val v = createInitialVersion(mapOf("env" to "ci", "run" to "42"))
         val node = HistoryIndexNode.of(v.obj)
-        assertEquals(mapOf("env" to setOf("ci"), "run" to setOf("42")), node.attributes)
+        assertEquals(AttributesAggregation.of(mapOf("env" to "ci", "run" to "42")), node.attributes)
     }
 
     @Test
     fun `of() produces empty attributes when version has none`() {
         val v = createInitialVersion()
         val node = HistoryIndexNode.of(v.obj)
-        assertEquals(emptyMap(), node.attributes)
+        assertEquals(AttributesAggregation.EMPTY, node.attributes)
     }
 
     // --- aggregation through merge/concat ---
@@ -66,8 +68,8 @@ class HistoryIndexNodeAttributesTest {
         val node = HistoryIndexNode.of(v1.obj).asObject(graph)
             .merge(HistoryIndexNode.of(v2.obj).asObject(graph))
             .getBlocking(graph)
-        assertEquals(setOf("staging", "prod"), node.data.attributes["env"])
-        assertEquals(setOf("1"), node.data.attributes["run"])
+        assertEquals(AttributeValuesAggregation.of("staging", "prod"), node.data.attributes.getValues("env"))
+        assertEquals(AttributeValuesAggregation.of("1"), node.data.attributes.getValues("run"))
     }
 
     @Test
@@ -79,8 +81,8 @@ class HistoryIndexNodeAttributesTest {
         val node = HistoryIndexNode.of(v1.obj).asObject(graph)
             .merge(HistoryIndexNode.of(v2.obj).asObject(graph))
             .getBlocking(graph)
-        assertEquals(setOf("a", "b"), node.data.attributes["env"])
-        assertEquals(setOf("1"), node.data.attributes["run"])
+        assertEquals(AttributeValuesAggregation.of("a", "b"), node.data.attributes["env"])
+        assertEquals(AttributeValuesAggregation.of("1"), node.data.attributes["run"])
     }
 
     // --- serialization round-trip ---
@@ -120,7 +122,7 @@ class HistoryIndexNodeAttributesTest {
         val serialized = HistoryIndexNode.of(v.obj).serialize()
         // When attributes are empty, no trailing field is added — deserialization returns empty map
         val restored = HistoryIndexNode.deserialize(serialized, graph)
-        assertEquals(emptyMap(), restored.attributes)
+        assertEquals(AttributesAggregation.EMPTY, restored.attributes)
     }
 
     @Test

--- a/model-datastructure/src/commonTest/kotlin/VersionAttributesTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/VersionAttributesTest.kt
@@ -34,4 +34,30 @@ class VersionAttributesTest {
 
         assertEquals(mapOf(key to value), restoredVersion.getAttributes())
     }
+
+    @Test
+    fun `separator characters in keys and values survive round trip`() {
+        val graph1 = FullyLoadedObjectGraph()
+        val attrs = mapOf(
+            "key/with/slashes" to "val,with,commas",
+            "key=with=equals" to "val;with;semicolons",
+            "key%encoded" to "val%encoded",
+            "unicode-key-\u00e9\u4e2d\u6587" to "unicode-val-\u00e9\u4e2d\u6587",
+        )
+        val originalVersion: IVersion = IVersion.builder()
+            .tree(IModelTree.builder().graph(graph1).build())
+            .also { builder -> attrs.forEach { (k, v) -> builder.attribute(k, v) } }
+            .build()
+
+        assertEquals(attrs, originalVersion.getAttributes())
+
+        val graph2 = FullyLoadedObjectGraph()
+        val restoredVersion = graph2.loadObjects(
+            rootHash = originalVersion.getObjectHash(),
+            rootDeserializer = CPVersion,
+            receivedObjects = originalVersion.asObject().getDescendantsAndSelf().toMap({ it.getHash() }, { it.data.serialize() }).getBlocking(graph1),
+        ).let { CLVersion(it) }
+
+        assertEquals(attrs, restoredVersion.getAttributes())
+    }
 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexIntervalTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexIntervalTest.kt
@@ -4,6 +4,7 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.ktor.test.dispatcher.runTestWithRealTime
 import mu.KotlinLogging
+import org.modelix.datastructures.history.AttributesAggregation
 import org.modelix.datastructures.history.HistoryInterval
 import org.modelix.model.IVersion
 import org.modelix.model.client2.IModelClientV2
@@ -122,7 +123,9 @@ class HistoryIndexIntervalTest {
                     minTime = versions.minOf { it.getTimestamp()!! },
                     maxTime = versions.maxOf { it.getTimestamp()!! },
                     authors = versions.mapNotNull { it.getAuthor() }.toSet(),
-                    attributes = versions.fold(emptyMap()) { acc, v -> mergeAttributes(acc, v.getAttributes()) },
+                    attributes = versions.fold(AttributesAggregation.EMPTY) { acc, v ->
+                        acc + AttributesAggregation.of(v.getAttributes())
+                    },
                 )
             }
             .reversed()

--- a/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexIntervalTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexIntervalTest.kt
@@ -86,13 +86,14 @@ class HistoryIndexIntervalTest {
         val initialVersion = modelClient.initRepository(RepositoryConfig(repositoryId = repositoryId.id, repositoryName = repositoryId.id, modelId = "61bd6cb0-33ff-45d8-9d1b-2149fdb01d16"))
         var currentVersion = initialVersion
 
-        repeat(100) {
+        repeat(100) { i ->
             run {
                 val newVersion = IVersion.builder()
                     .baseVersion(currentVersion)
                     .tree(currentVersion.getModelTree())
                     .author("user1")
                     .time(currentVersion.getTimestamp()!! + rand.nextInt(0, 3).seconds)
+                    .attribute("user", "user1-$i")
                     .build()
                 currentVersion = modelClient.push(branchRef, newVersion, currentVersion)
             }
@@ -102,6 +103,7 @@ class HistoryIndexIntervalTest {
                     .tree(currentVersion.getModelTree())
                     .author("user2")
                     .time(currentVersion.getTimestamp()!! + rand.nextInt(0, 3).seconds)
+                    .attribute("user", "user2-$i")
                     .build()
                 currentVersion = modelClient.push(branchRef, newVersion, currentVersion)
             }
@@ -120,6 +122,7 @@ class HistoryIndexIntervalTest {
                     minTime = versions.minOf { it.getTimestamp()!! },
                     maxTime = versions.maxOf { it.getTimestamp()!! },
                     authors = versions.mapNotNull { it.getAuthor() }.toSet(),
+                    attributes = versions.fold(emptyMap()) { acc, v -> mergeAttributes(acc, v.getAttributes()) },
                 )
             }
             .reversed()

--- a/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexPaginationTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexPaginationTest.kt
@@ -102,6 +102,7 @@ class HistoryIndexPaginationTest {
                     .tree(currentVersion.getModelTree())
                     .author("user1")
                     .time(currentVersion.getTimestamp()!! + rand.nextInt(0, 3).seconds)
+                    .attribute("user", "user1")
                     .build()
                 currentVersion = modelClient.push(branchRef, newVersion, currentVersion)
             }
@@ -111,12 +112,15 @@ class HistoryIndexPaginationTest {
                     .tree(currentVersion.getModelTree())
                     .author("user2")
                     .time(currentVersion.getTimestamp()!! + rand.nextInt(0, 3).seconds)
+                    .attribute("user", "user2")
                     .build()
                 currentVersion = modelClient.push(branchRef, newVersion, currentVersion)
             }
         }
 
-        val expectedOrder = currentVersion.historyAsSequence().map { it.getObjectHash() }.toList()
+        val expectedHistory = currentVersion.historyAsSequence().toList()
+        val expectedOrder = expectedHistory.map { it.getObjectHash() }
+        val expectedAttributes = expectedHistory.map { it.getAttributes() }
 
         val history = modelClient.queryHistory(
             repositoryId = repositoryId,
@@ -126,6 +130,7 @@ class HistoryIndexPaginationTest {
         )
         assertEquals(expectedOrder.drop(skip).take(limit).toSet(), history.map { it.versionHash }.toSet())
         assertEquals(expectedOrder.drop(skip).take(limit), history.map { it.versionHash })
+        assertEquals(expectedAttributes.drop(skip).take(limit), history.map { it.attributes })
     }
 }
 

--- a/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexSessionsTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexSessionsTest.kt
@@ -4,6 +4,7 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.runTestApplication
 import io.ktor.test.dispatcher.runTestWithRealTime
 import mu.KotlinLogging
+import org.modelix.datastructures.history.AttributesAggregation
 import org.modelix.datastructures.history.HistoryInterval
 import org.modelix.model.IVersion
 import org.modelix.model.client2.IModelClientV2
@@ -146,7 +147,7 @@ class HistoryIndexSessionsTest {
                     minTime = version.getTimestamp()!!,
                     maxTime = version.getTimestamp()!!,
                     authors = setOfNotNull(version.getAuthor()),
-                    attributes = mergeAttributes(emptyMap(), version.getAttributes()),
+                    attributes = AttributesAggregation.of(version.getAttributes()),
                 )
             } else {
                 val lastInterval = acc.last()
@@ -157,7 +158,7 @@ class HistoryIndexSessionsTest {
                     minTime = lastInterval.minTime,
                     maxTime = version.getTimestamp()!!,
                     authors = lastInterval.authors + listOfNotNull(version.getAuthor()),
-                    attributes = mergeAttributes(lastInterval.attributes, version.getAttributes()),
+                    attributes = lastInterval.attributes + AttributesAggregation.of(version.getAttributes()),
                 )
             }
         }.reversed().drop(skip).take(limit)

--- a/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexSessionsTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexSessionsTest.kt
@@ -107,6 +107,7 @@ class HistoryIndexSessionsTest {
                         .tree(currentVersion.getModelTree())
                         .author("user1")
                         .time(nextTimestamp)
+                        .attribute("user", "user1")
                         .build()
                     currentVersion = modelClient.push(branchRef, newVersion, currentVersion)
                 }
@@ -117,6 +118,7 @@ class HistoryIndexSessionsTest {
                         .tree(currentVersion.getModelTree())
                         .author("user2")
                         .time(nextTimestamp)
+                        .attribute("user", "user2")
                         .build()
                     currentVersion = modelClient.push(branchRef, newVersion, currentVersion)
                 }
@@ -144,6 +146,7 @@ class HistoryIndexSessionsTest {
                     minTime = version.getTimestamp()!!,
                     maxTime = version.getTimestamp()!!,
                     authors = setOfNotNull(version.getAuthor()),
+                    attributes = mergeAttributes(emptyMap(), version.getAttributes()),
                 )
             } else {
                 val lastInterval = acc.last()
@@ -154,6 +157,7 @@ class HistoryIndexSessionsTest {
                     minTime = lastInterval.minTime,
                     maxTime = version.getTimestamp()!!,
                     authors = lastInterval.authors + listOfNotNull(version.getAuthor()),
+                    attributes = mergeAttributes(lastInterval.attributes, version.getAttributes()),
                 )
             }
         }.reversed().drop(skip).take(limit)

--- a/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedModelTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/ReplicatedModelTest.kt
@@ -5,11 +5,16 @@ import io.ktor.server.testing.testApplication
 import io.ktor.util.reflect.instanceOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertFalse
+import org.modelix.datastructures.model.MutationParameters
 import org.modelix.model.api.ChildLinkReferenceByName
 import org.modelix.model.api.ConceptReference
+import org.modelix.model.api.IPropertyReference
 import org.modelix.model.api.ITree
 import org.modelix.model.api.PBranch
 import org.modelix.model.client2.ModelClientV2
@@ -32,6 +37,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class ReplicatedModelTest {
 
@@ -118,6 +124,83 @@ class ReplicatedModelTest {
             // Step 5: check, eventually we must have 1 "hello" child
             val children = getHelloChildrenOfRootNode(tree)
             assertEquals(1, children.size)
+        }
+    }
+
+    @Test
+    fun versionAttributesAreStoredOnCreatedVersions() = runTest {
+        val client = createModelClient()
+        val repositoryId = RepositoryId(UUID.randomUUID().toString())
+        val branchReference = repositoryId.getBranchReference()
+        client.initRepository(repositoryId)
+
+        val attrs = mapOf("env" to "staging", "pipeline" to "ci-42")
+        val scope = CoroutineScope(Dispatchers.Default)
+        try {
+            ReplicatedModel(
+                client,
+                branchReference,
+                idGenerator = { ModelixIdGenerator(client.getIdGenerator(), it) },
+                providedScope = scope,
+                versionAttributes = { attrs },
+            ).use { replicatedModel ->
+                val tree = replicatedModel.start()
+                tree.runWrite { t ->
+                    t.mutate(MutationParameters.Property(t.tree.getRootNodeId(), IPropertyReference.fromName("test"), "value"))
+                }
+                withTimeout(5000.milliseconds) {
+                    while (replicatedModel.getCurrentVersion().getAttributes() != attrs) {
+                        delay(50.milliseconds)
+                    }
+                }
+                assertEquals(attrs, replicatedModel.getCurrentVersion().getAttributes())
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun versionAttributesCanChangeBetweenVersions() = runTest {
+        val client = createModelClient()
+        val repositoryId = RepositoryId(UUID.randomUUID().toString())
+        val branchReference = repositoryId.getBranchReference()
+        client.initRepository(repositoryId)
+
+        val currentAttrs = mutableMapOf("run" to "1")
+        val scope = CoroutineScope(Dispatchers.Default)
+        try {
+            ReplicatedModel(
+                client,
+                branchReference,
+                idGenerator = { ModelixIdGenerator(client.getIdGenerator(), it) },
+                providedScope = scope,
+                versionAttributes = { currentAttrs.toMap() },
+            ).use { replicatedModel ->
+                val tree = replicatedModel.start()
+
+                // First write — closure returns run=1
+                tree.runWrite { t ->
+                    t.mutate(MutationParameters.Property(t.tree.getRootNodeId(), IPropertyReference.fromName("a"), "1"))
+                }
+                withTimeout(5000) {
+                    while (replicatedModel.getCurrentVersion().getAttributes() != mapOf("run" to "1")) delay(50)
+                }
+                assertEquals(mapOf("run" to "1"), replicatedModel.getCurrentVersion().getAttributes())
+
+                // Mutate the source map — closure now returns run=2
+                currentAttrs["run"] = "2"
+
+                tree.runWrite { t ->
+                    t.mutate(MutationParameters.Property(t.tree.getRootNodeId(), IPropertyReference.fromName("a"), "2"))
+                }
+                withTimeout(5000) {
+                    while (replicatedModel.getCurrentVersion().getAttributes() != mapOf("run" to "2")) delay(50)
+                }
+                assertEquals(mapOf("run" to "2"), replicatedModel.getCurrentVersion().getAttributes())
+            }
+        } finally {
+            scope.cancel()
         }
     }
 

--- a/model-server/src/test/kotlin/org/modelix/model/server/TestAttributeHelpers.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/TestAttributeHelpers.kt
@@ -1,0 +1,9 @@
+package org.modelix.model.server
+
+internal fun mergeAttributes(
+    accumulated: Map<String, Set<String>>,
+    incoming: Map<String, String>,
+): Map<String, Set<String>> =
+    (accumulated.keys + incoming.keys).associateWith { key ->
+        accumulated[key].orEmpty() + setOfNotNull(incoming[key])
+    }


### PR DESCRIPTION
  - `ReplicatedModel` accepts a `versionAttributes` supplier that stamps key-value metadata on every locally created version
  - History queries (sessions, intervals, pagination) aggregate and expose attributes across versions                                                                                                                                                                                                                               
  - JS API gains full parity: supplier is called per commit, not snapshotted at connect time 