### PR TITLE
feat!: require Java 17, support MPS 2024.1

### DIFF
--- a/.github/workflows/mps-compatibility.yaml
+++ b/.github/workflows/mps-compatibility.yaml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "2021.3"
           - "2022.2"
           - "2022.3"
           - "2023.2"

--- a/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
@@ -23,10 +23,7 @@ val Project.mpsVersion: String get() {
             requireNotNull(
                 mapOf(
                     // https://artifacts.itemis.cloud/service/rest/repository/browse/maven-mps/com/jetbrains/mps/
-                    "2020.3" to "2020.3.6",
-                    "2021.1" to "2021.1.4",
-                    "2021.2" to "2021.2.6",
-                    "2021.3" to "2021.3.5",
+                    // We only support MPS 2022.2+, which runs on JDK 17. Older versions ran on JDK 11 (see MODELIX_JDK_VERSION).
                     "2022.2" to "2022.2.4",
                     "2022.3" to "2022.3.3",
                     "2023.2" to "2023.2.2",
@@ -41,8 +38,6 @@ val Project.mpsVersion: String get() {
 val Project.mpsPlatformVersion: Int get() {
     return mpsVersion.replace(Regex("""20(\d\d)\.(\d+).*"""), "$1$2").toInt()
 }
-
-val Project.mpsJavaVersion: Int get() = if (mpsPlatformVersion >= 223) 17 else 11
 
 val Project.mpsHomeDir: Provider<Directory> get() {
     if (project != rootProject) return rootProject.mpsHomeDir

--- a/build-logic/src/main/kotlin/org/modelix/LanguageConfig.kt
+++ b/build-logic/src/main/kotlin/org/modelix/LanguageConfig.kt
@@ -3,6 +3,7 @@ package org.modelix
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
-const val MODELIX_JDK_VERSION = 11
-val MODELIX_JVM_TARGET = JvmTarget.JVM_11
+// We only support MPS 2022.2+, which runs on JDK 17. Older MPS versions ran on JDK 11 and can no longer load our artifacts.
+const val MODELIX_JDK_VERSION = 17
+val MODELIX_JVM_TARGET = JvmTarget.JVM_17
 val MODELIX_KOTLIN_API_VERSION = KotlinVersion.KOTLIN_1_8

--- a/bulk-model-sync-gradle-test/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/build.gradle.kts
@@ -24,7 +24,7 @@ val copyTestRepo by tasks.registering(Sync::class) {
 }
 
 mpsBuild {
-    mpsVersion("2021.2.5")
+    mpsVersion("2022.2.4")
 }
 
 modelSync {

--- a/bulk-model-sync-gradle-test/graph-lang-api/build.gradle.kts
+++ b/bulk-model-sync-gradle-test/graph-lang-api/build.gradle.kts
@@ -13,7 +13,7 @@ val mps: Configuration by configurations.creating
 val kotlinGenDir = project.layout.buildDirectory.dir("metamodel/kotlin").get().asFile.apply { mkdirs() }
 
 dependencies {
-    mps("com.jetbrains:mps:2021.2.5")
+    mps("com.jetbrains:mps:2022.2.4")
     api("org.modelix:model-api-gen-runtime")
 }
 

--- a/bulk-model-sync-lib/mps-test/build.gradle.kts
+++ b/bulk-model-sync-lib/mps-test/build.gradle.kts
@@ -41,9 +41,6 @@ tasks {
     test {
         onlyIf {
             !setOf(
-                "2020.3", // incompatible with the intellij plugin
-                "2021.2", // hangs when executed on CI
-                "2021.3", // hangs when executed on CI
                 "2022.2", // hangs when executed on CI
             ).contains(mpsMajorVersion)
         }

--- a/model-api-gen-gradle-test/metamodel-export/build.gradle.kts
+++ b/model-api-gen-gradle-test/metamodel-export/build.gradle.kts
@@ -35,5 +35,5 @@ metamodel {
 }
 
 dependencies {
-    mps("com.jetbrains:mps:2021.1.4")
+    mps("com.jetbrains:mps:2022.2.4")
 }

--- a/model-server/build.gradle.kts
+++ b/model-server/build.gradle.kts
@@ -17,6 +17,39 @@ description = "Model Server offering access to model storage"
 
 defaultTasks.add("build")
 
+// Apache Ignite accesses proprietary JDK APIs that the module system keeps inaccessible by default.
+// These flags open up those APIs and must be passed to every JVM that starts Ignite
+// (tests, `run`, install scripts, container).
+// List taken verbatim from the Ignite documentation:
+// https://ignite.apache.org/docs/latest/quick-start/java#running-ignite-with-java-11-or-later
+val igniteJvmArgs = listOf(
+    "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+    "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+    "--add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED",
+    "--add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
+    "--add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED",
+    "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED",
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.net=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+    "--add-opens=java.base/java.math=ALL-UNNAMED",
+    "--add-opens=java.sql/java.sql=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens=java.base/java.time=ALL-UNNAMED",
+    "--add-opens=java.base/java.text=ALL-UNNAMED",
+    "--add-opens=java.logging/java.util.logging=ALL-UNNAMED",
+    "--add-opens=java.management/sun.management=ALL-UNNAMED",
+    "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED",
+)
+
 val mpsExtensionsVersion: String by project
 
 dependencies {
@@ -111,6 +144,8 @@ tasks.named("assemble") {
 
 application {
     mainClass.set("org.modelix.model.server.Main")
+    // Propagates to the `run` task and the generated start scripts (installDist / distributions).
+    applicationDefaultJvmArgs = igniteJvmArgs
 }
 
 publishing {
@@ -142,13 +177,15 @@ tasks.test {
     // See https://stackoverflow.com/questions/76387714/apache-ignite-failing-on-startup
     environment("IGNITE_OVERRIDE_CONSISTENT_ID", "node00")
     environment("KEYCLOAK_VERSION", libs.versions.keycloak.get())
+    jvmArgs(igniteJvmArgs)
 }
 
 jib {
-    from.image = "registry.access.redhat.com/ubi8/openjdk-11:1.21-1.1736337912"
+    from.image = "registry.access.redhat.com/ubi8/openjdk-17:1.20-2.1729094551"
     to.image = "modelix/model-server:$version"
     to.tags = setOf("test")
     container {
         ports = listOf("28101")
+        jvmFlags = igniteJvmArgs
     }
 }

--- a/mps-model-adapters-plugin/build.gradle.kts
+++ b/mps-model-adapters-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ intellij {
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("211")
+        sinceBuild.set("222")
         untilBuild.set("241.*")
     }
 
@@ -47,9 +47,6 @@ tasks {
     test {
         onlyIf {
             !setOf(
-                "2020.3", // incompatible with the intellij plugin
-                "2021.2", // hangs when executed on CI
-                "2021.3", // hangs when executed on CI
                 "2022.2", // hangs when executed on CI
             ).contains(mpsMajorVersion)
         }

--- a/mps-sync-plugin3/build.gradle.kts
+++ b/mps-sync-plugin3/build.gradle.kts
@@ -121,6 +121,7 @@ tasks {
                 moduleDependency(KnownModuleIds.MPS_IDEA)
                 moduleDependency(KnownModuleIds.MPS_Core)
                 moduleDependency(KnownModuleIds.MPS_Platform)
+                moduleDependency(KnownModuleIds.org_jdom)
             }
         }
     }

--- a/mps-sync-plugin3/build.gradle.kts
+++ b/mps-sync-plugin3/build.gradle.kts
@@ -3,7 +3,6 @@ import org.modelix.buildtools.KnownModuleIds
 import org.modelix.buildtools.buildStubsSolutionJar
 import org.modelix.copyMps
 import org.modelix.mpsHomeDir
-import org.modelix.mpsMajorVersion
 import org.modelix.mpsPlatformVersion
 import kotlin.io.resolve
 import kotlin.jvm.java
@@ -63,7 +62,7 @@ dependencies {
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("213")
+        sinceBuild.set("222")
         untilBuild.set("241.*")
     }
 
@@ -78,11 +77,6 @@ tasks {
     test {
         dependsOn(":model-server:jibDockerBuild")
         jvmArgs("-Dmodelix.model.server.image=modelix/model-server:$version")
-        onlyIf {
-            !setOf(
-                "2020.3", // incompatible with the intellij plugin
-            ).contains(mpsMajorVersion)
-        }
         jvmArgs("-Dintellij.platform.load.app.info.from.resources=true")
         jvmArgs("-Xmx1000m")
 


### PR DESCRIPTION
- Raise the JDK/JVM target to 17, only support MPS 2022.2-2024.1
- Add the Apache Ignite --add-opens JVM flags (per Ignite's docs) to the model-server test, run, install-script, and container JVMs, since Ignite needs proprietary JDK APIs opened up on Java 17.
- Add org.jdom as a dependency for the mps-sync-plugin stubs.