### PR TITLE
feat: support MPS 2025.1

### DIFF
--- a/.github/workflows/mps-compatibility.yaml
+++ b/.github/workflows/mps-compatibility.yaml
@@ -23,6 +23,7 @@ jobs:
           - "2023.2"
           - "2023.3"
           - "2024.1"
+          - "2025.1"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/mps-compatibility.yaml
+++ b/.github/workflows/mps-compatibility.yaml
@@ -24,6 +24,12 @@ jobs:
           - "2023.3"
           - "2024.1"
           - "2025.1"
+        include:
+          # mps-git-import only supports MPS 2024.1+ (see sinceBuild in mps-git-import-plugin/build.gradle.kts)
+          - version: "2024.1"
+            additional-tasks: ":mps-git-import:build :mps-git-import-plugin:build"
+          - version: "2025.1"
+            additional-tasks: ":mps-git-import:build :mps-git-import-plugin:build"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -46,6 +52,7 @@ jobs:
           :mps-model-adapters:build
           :mps-model-adapters-plugin:build
           :mps-sync-plugin3:build
+          ${{ matrix.additional-tasks }}
           -Pmps.version.major=${{ matrix.version }}
       - name: Archive test report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
@@ -88,6 +88,63 @@ fun Project.copyMps(): File {
         }
     }
 
+    // The gradle-intellij-plugin 1.x reads the launch information from product-info.json and injects it into the
+    // forked test JVM. Two pieces of that, meant for launching the real IDE, break the test executor on 2025.1+;
+    // MPS <= 2024.1 ships no product-info.json, so the plugin injects neither and the tests pass. Both are sanitized
+    // here, keeping the file present and valid (it also serves as the PathManager marker).
+    val productInfo = mpsHomeDir.get().asFile.resolve("product-info.json")
+    if (productInfo.exists()) {
+        @Suppress("UNCHECKED_CAST")
+        val json = groovy.json.JsonSlurper().parse(productInfo) as MutableMap<String, Any?>
+        val launches = json["launch"] as? List<*> ?: emptyList<Any?>()
+        for (launch in launches.filterIsInstance<MutableMap<String, Any?>>()) {
+            // resolveIdeHomeVariable assumes every additionalJvmArgument is "key=value" and does split("=")[1],
+            // so an argument without "=" (e.g. -XX:+UseCompressedOops) throws IndexOutOfBoundsException while
+            // configuring the test task. Drop them; OpenedPackages provides the --add-opens the platform needs.
+            if (launch.containsKey("additionalJvmArguments")) {
+                launch["additionalJvmArguments"] = emptyList<String>()
+            }
+            // The plugin passes every line of the referenced .vmoptions file to the JVM verbatim, including the
+            // "#Common IntelliJ Platform options:" comment lines. The launcher treats such a token as the main
+            // class, so the -Djava.system.class.loader=com.intellij.util.lang.PathClassLoader it also sets cannot
+            // be resolved (the -cp argfile after the token is ignored) and the VM aborts during initialization.
+            // Strip comment and blank lines, keeping the real options (heap sizes, GC settings, ...).
+            val vmOptionsPath = (launch["vmOptionsFilePath"] as? String)?.removePrefix("../")
+            val vmOptionsFile = vmOptionsPath?.let { mpsHomeDir.get().asFile.resolve(it) }
+            if (vmOptionsFile != null && vmOptionsFile.exists()) {
+                val kept = vmOptionsFile.readLines().filter { it.isNotBlank() && !it.trimStart().startsWith("#") }
+                vmOptionsFile.writeText(kept.joinToString("\n", postfix = "\n"))
+            }
+        }
+
+        // The Maven MPS distribution declares only a Linux/amd64 launch entry. The plugin refuses to
+        // run on a host whose os.arch has no matching launch entry, which blocks running the IDE tests
+        // locally on e.g. Apple Silicon. Add an entry for the current host (cloned from the existing
+        // one, so it inherits the sanitized fields) when none matches. On CI (Linux/amd64) the entry
+        // already exists, so this is a no-op.
+        val mutableLaunches = launches.filterIsInstance<MutableMap<String, Any?>>()
+        if (mutableLaunches.isNotEmpty()) {
+            val osName = System.getProperty("os.name").lowercase()
+            val currentOs = when {
+                osName.contains("win") -> "Windows"
+                osName.contains("mac") || osName.contains("darwin") -> "macOS"
+                else -> "Linux"
+            }
+            val currentArch = System.getProperty("os.arch")
+            val hasMatch = mutableLaunches.any { it["os"] == currentOs && it["arch"] == currentArch }
+            if (!hasMatch) {
+                @Suppress("UNCHECKED_CAST")
+                val launchList = json["launch"] as MutableList<Any?>
+                val hostLaunch = LinkedHashMap(mutableLaunches.first())
+                hostLaunch["os"] = currentOs
+                hostLaunch["arch"] = currentArch
+                launchList.add(hostLaunch)
+            }
+        }
+
+        productInfo.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(json)))
+    }
+
     // The build number of a local IDE is expected to contain a product code, otherwise an exception is thrown.
     val buildTxt = mpsHomeDir.get().asFile.resolve("build.txt")
     val buildNumber = buildTxt.readText()

--- a/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
@@ -31,6 +31,7 @@ val Project.mpsVersion: String get() {
                     "2023.3" to "2023.3.2",
                     "2024.1" to "2024.1.1",
                     "2024.3" to "2024.3",
+                    "2025.1" to "2025.1.2",
                 )[it],
             ) { "Unknown MPS version: $it" }
         }

--- a/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
@@ -14,7 +14,7 @@ val Project.mpsMajorVersion: String get() {
     if (project != rootProject) return rootProject.mpsMajorVersion
     return project.findProperty("mps.version.major")?.toString()?.takeIf { it.isNotEmpty() }
         ?: project.findProperty("mps.version")?.toString()?.takeIf { it.isNotEmpty() }?.replace(Regex("""(20\d\d\.\d+).*"""), "$1")
-        ?: "2024.1"
+        ?: "2025.1"
 }
 
 val Project.mpsVersion: String get() {

--- a/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
+++ b/build-logic/src/main/kotlin/org/modelix/CopyMps.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.exclude
 import java.io.File
@@ -108,4 +109,54 @@ val excludeMPSLibraries: (ModuleDependency).() -> Unit = {
     exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk7")
     exclude("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
     exclude("org.jetbrains", "annotations")
+}
+
+/**
+ * Project-level classpath adjustments for modules whose tests boot MPS via the gradle-intellij-plugin
+ * 1.x (mps-sync-plugin3, mps-model-adapters-plugin, bulk-model-sync-lib/mps-test). Only needed on
+ * MPS 2025.1+ (platform >= 251). Configure the test tasks themselves with [configureMpsTestTask].
+ */
+fun Project.configureMpsTestClasspath() {
+    if (mpsPlatformVersion < 251) return
+
+    // MPS 2025.1+ loads platform services (e.g. SettingsController) from module descriptors in
+    // lib/modules/*.jar. The 1.x plugin doesn't put these on the test classpath, so add them
+    // explicitly; without them the test application fails to boot. Older MPS has no lib/modules.
+    dependencies.add(
+        "testRuntimeOnly",
+        fileTree(mpsHomeDir).matching { include("lib/modules/*.jar") },
+    )
+
+    // MPS bundles JetBrains' coroutines fork (lib/util-8.jar) whose BuildersKt has
+    // runBlockingWithParallelismCompensation, which the platform calls during boot. The vanilla
+    // kotlinx-coroutines-core pulled in transitively lacks that method, so keep it off the test
+    // runtime classpath and let MPS's bundled coroutines win.
+    configurations.named("testRuntimeClasspath").configure {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+    }
+}
+
+/**
+ * Configures a single test task that boots MPS via the gradle-intellij-plugin 1.x. Pair it with
+ * [configureMpsTestClasspath] on the owning project.
+ */
+fun Test.configureMpsTestTask() {
+    // Use a provider to avoid eagerly resolving the MPS home dir
+    jvmArgumentProviders.add {
+        buildList {
+            // JNA's native libraries live under lib/jna/<arch> in the MPS home. Point the test JVM there
+            // so JNA loads the bundled library instead of trying to unpack one from the classpath.
+            // Older MPS versions (2022.2) ship no lib/jna and keep the natives inside the classpath jar,
+            // so the properties must not be set there — jna.noclasspath would leave JNA with no library.
+            val jnaDir = project.mpsHomeDir.get().asFile.resolve("lib/jna/${System.getProperty("os.arch")}")
+            if (jnaDir.exists()) {
+                add("-Djna.boot.library.path=${jnaDir.absolutePath}")
+                add("-Djna.noclasspath=true")
+                add("-Djna.nosys=true")
+            }
+
+            add("-Dintellij.platform.load.app.info.from.resources=true")
+        }
+    }
 }

--- a/bulk-model-sync-lib/mps-test/build.gradle.kts
+++ b/bulk-model-sync-lib/mps-test/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.modelix.configureMpsTestClasspath
+import org.modelix.configureMpsTestTask
 import org.modelix.copyMps
 import org.modelix.excludeMPSLibraries
 import org.modelix.mpsMajorVersion
@@ -25,6 +27,8 @@ dependencies {
     testImplementation(libs.modelix.mpsApi)
 }
 
+configureMpsTestClasspath()
+
 intellij {
     localPath = copyMps().absolutePath
     instrumentCode = false
@@ -39,11 +43,11 @@ tasks {
     }
 
     test {
+        configureMpsTestTask()
         onlyIf {
             !setOf(
                 "2022.2", // hangs when executed on CI
             ).contains(mpsMajorVersion)
         }
-        jvmArgs("-Dintellij.platform.load.app.info.from.resources=true")
     }
 }

--- a/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/MPSBulkSynchronizer.kt
+++ b/bulk-model-sync-mps/src/main/kotlin/org/modelix/mps/model/sync/bulk/MPSBulkSynchronizer.kt
@@ -1,5 +1,6 @@
 package org.modelix.mps.model.sync.bulk
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.project.ProjectManager
 import jetbrains.mps.ide.ThreadUtils
 import jetbrains.mps.ide.project.ProjectHelper
@@ -7,6 +8,8 @@ import jetbrains.mps.smodel.SNodeUtil
 import jetbrains.mps.smodel.StaticReference
 import jetbrains.mps.smodel.adapter.ids.MetaIdHelper
 import jetbrains.mps.smodel.adapter.ids.SConceptId
+import jetbrains.mps.smodel.adapter.ids.SLanguageId
+import jetbrains.mps.smodel.adapter.ids.SPropertyId
 import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory
 import jetbrains.mps.smodel.adapter.structure.concept.SConceptAdapterById
 import jetbrains.mps.smodel.language.ConceptRegistry
@@ -43,33 +46,35 @@ import java.io.File
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 
+@Suppress("MagicNumber")
+private val conceptIdOfINamedConcept = SConceptId(SLanguageId(-0x3154ae6ada15b0deL, -0x646defc46a3573f4L), 0x110396eaaa4L)
+
+@Suppress("MagicNumber")
+private val conceptIdOfIResolveInfo = SConceptId(SLanguageId(-0x3154ae6ada15b0deL, -0x646defc46a3573f4L), 0x116b17c6e46L)
+
 /**
  * Identifier of the `name` property in the `INamedConcept` concept.
  * See https://github.com/JetBrains/MPS/blob/5bb20b8a104c08206490e0f3fad70304fa0e0151/core/kernel/kernelSolution/source_gen/jetbrains/mps/util/SNodeOperations.java#L355
  */
 @Suppress("MagicNumber")
 private val namePropertyOfINamedConceptConcept = MetaAdapterFactory.getProperty(
-    -0x3154ae6ada15b0deL,
-    -0x646defc46a3573f4L,
-    0x110396eaaa4L,
-    0x110396ec041L,
+    SPropertyId(conceptIdOfINamedConcept, 0x110396ec041L),
     "name",
 )
 
 /**
- * Identifier of the `resolveInfo` property in the `IResolveInfoConcept` concept.
- * See https://github.com/JetBrains/MPS/blob/5bb20b8a104c08206490e0f3fad70304fa0e0151/core/kernel/kernelSolution/source_gen/jetbrains/mps/util/SNodeOperations.java#L355
+ * Identifier of the `resolveInfo` property in the `IResolveInfo` concept.
+ * See https://github.com/JetBrains/MPS/blob/5bb20b8a104c08206490e0f3fad70304fa0e0151/core/kernel/kernelSolution/source_gen/jetbrains/mps/util/SNodeOperations.java#L354
  */
 @Suppress("MagicNumber")
 private val resolveInfoPropertyOfIResolveInfoConcept = MetaAdapterFactory.getProperty(
-    -0x3154ae6ada15b0deL,
-    -0x646defc46a3573f4L,
-    0x116b17c6e46L,
-    0x116b17cd415L,
+    SPropertyId(conceptIdOfIResolveInfo, 0x116b17cd415L),
     "resolveInfo",
 )
 
 object MPSBulkSynchronizer {
+
+    private const val MPS_2025_1_BASELINE_VERSION = 251
 
     @JvmStatic
     fun exportRepository() {
@@ -220,7 +225,7 @@ object MPSBulkSynchronizer {
 
     private fun persistChanges(repository: SRepository) = executeCommandWithExceptionHandling(repository) {
         println("Persisting changes...")
-        enableWorkaroundForFilePerRootPersistence(repository)
+        enableWorkaroundForUnloadedConcepts(repository)
         updateUnsetResolveInfo(repository)
         repository.saveAll()
         println("Changes persisted.")
@@ -311,10 +316,7 @@ object MPSBulkSynchronizer {
      * and produce unwanted file changes.
      */
     private fun updateUnsetResolveInfo(repository: SRepository) {
-        val changedModels = repository.modules.asSequence()
-            .flatMap { it.models }
-            .mapNotNull { it as? EditableSModel }
-            .filter { it.isChanged }
+        val changedModels = filterChangedModels(repository)
         val references = changedModels
             .flatMap { org.jetbrains.mps.openapi.model.SNodeUtil.getDescendants(it) }
             .flatMap { it.references }
@@ -340,37 +342,70 @@ object MPSBulkSynchronizer {
     }
 
     /**
-     * Workaround for MPS not being able to read the name property of the node during the save process
-     * in case FilePerRootPersistence is used.
-     * This is because the concept is not properly loaded,
-     * and in the MPS code it checks if the concept is a subconcept of INamedConcept.
-     * Without this workaround, the id of the root node will be used instead of the name, resulting in renamed files.
+     * Registers a dummy [INamedConcept] descriptor for concepts that aren't loaded, so MPS can read a node's name
+     * during save even though the concept's language isn't available. MPS checks for a subconcept of INamedConcept
+     * in two places that matter here:
+     *
+     *  - file-per-root persistence uses the root node's name for the file name (otherwise the node id is used, renaming
+     *    files);
+     *
+     *  - since MPS 2025.1, [org.jetbrains.mps.openapi.model.SModel] save rebuilds the resolve info of every reference
+     *    from its target node (see SaveOptions and ResolveInfoUpdater); for an unloaded target concept this would
+     *    otherwise produce no name and drop the `resolve` attribute.
+     *
+     * The descriptor reports the concept as both INamedConcept and IResolveInfo: the `.mps` file records only which
+     * property a node uses, not the concept's super-concepts, so MPS cannot tell that an unloaded concept implements
+     * either. Reporting both lets the save-time computation read whichever of `name`/`resolveInfo` the node actually
+     * has (the other simply yields nothing).
      */
     @JvmStatic
-    private fun enableWorkaroundForFilePerRootPersistence(repository: SRepository) {
+    private fun enableWorkaroundForUnloadedConcepts(repository: SRepository) {
         val structureRegistry: StructureRegistry = ConceptRegistry.getInstance().readField("myStructureRegistry")
-        val myConceptDescriptorsById: MutableMap<SConceptId, ConceptDescriptor> = structureRegistry.readField("myConceptDescriptorsById")
+        val myConceptDescriptorsById: MutableMap<SConceptId, ConceptDescriptor> =
+            structureRegistry.readField("myConceptDescriptorsById")
 
-        repository.modules
-            .asSequence()
-            .flatMap { it.models }
-            .mapNotNull { it as? EditableSModel }
-            .filter { it.isChanged }
-            .flatMap { it.rootNodes }
-            .mapNotNull { (it.concept as? SConceptAdapterById) }
-            .forEach {
-                myConceptDescriptorsById.putIfAbsent(it.id, DummyNamedConceptDescriptor(it))
+        val changedModels = filterChangedModels(repository)
+
+        val conceptsToRegister = mutableSetOf<SConceptAdapterById>()
+
+        // MPS 2025.1+ rebuilds reference resolve info during save, so there the reference targets' (possibly unloaded)
+        // concepts need a descriptor. On older versions updateUnsetResolveInfo alone sets the resolve info, and
+        // registering target descriptors would make their concepts appear valid, causing updateUnsetResolveInfo to skip
+        // them.
+        val shouldAddReferenceTargets = ApplicationInfo.getInstance().build.baselineVersion >= MPS_2025_1_BASELINE_VERSION
+
+        for (model in changedModels) {
+            for (root in model.rootNodes) {
+                (root.concept as? SConceptAdapterById)?.let { conceptsToRegister.add(it) }
+
+                if (shouldAddReferenceTargets) {
+                    org.jetbrains.mps.openapi.model.SNodeUtil.getDescendants(root).asSequence()
+                        .flatMap { it.references }
+                        .mapNotNullTo(conceptsToRegister) { it.targetNode?.concept as? SConceptAdapterById }
+                }
             }
+        }
+
+        conceptsToRegister.forEach {
+            myConceptDescriptorsById.putIfAbsent(it.id, DummyNamedConceptDescriptor(it))
+        }
     }
+
+    private fun filterChangedModels(repository: SRepository): Sequence<EditableSModel> = repository.modules.asSequence()
+        .flatMap { it.models }
+        .filterIsInstance<EditableSModel>()
+        .filter { it.isChanged }
 
     @Suppress("UNCHECKED_CAST")
     private fun <R> Any.readField(name: String): R {
         return this::class.java.getDeclaredField(name).also { it.isAccessible = true }.get(this) as R
     }
 
-    private class DummyNamedConceptDescriptor(concept: SConceptAdapterById) : ConceptDescriptor by IllegalConceptDescriptor(concept.id, concept.qualifiedName) {
+    private class DummyNamedConceptDescriptor(concept: SConceptAdapterById) :
+        ConceptDescriptor by IllegalConceptDescriptor(concept.id, concept.qualifiedName) {
+
         override fun isAssignableTo(other: SConceptId?): Boolean {
-            return MetaIdHelper.getConcept(SNodeUtil.concept_INamedConcept) == other
+            return other == conceptIdOfINamedConcept || other == conceptIdOfIResolveInfo
         }
 
         override fun getSuperConceptId(): SConceptId {
@@ -378,11 +413,11 @@ object MPSBulkSynchronizer {
         }
 
         override fun getAncestorsIds(): MutableSet<SConceptId> {
-            return mutableSetOf(MetaIdHelper.getConcept(SNodeUtil.concept_INamedConcept))
+            return mutableSetOf(conceptIdOfINamedConcept, conceptIdOfIResolveInfo)
         }
 
         override fun getParentsIds(): MutableList<SConceptId> {
-            return mutableListOf(MetaIdHelper.getConcept(SNodeUtil.concept_INamedConcept))
+            return mutableListOf(conceptIdOfINamedConcept, conceptIdOfIResolveInfo)
         }
     }
 

--- a/mps-git-import-plugin/build.gradle.kts
+++ b/mps-git-import-plugin/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
 tasks {
     patchPluginXml {
         sinceBuild.set("241")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {

--- a/mps-git-import/src/main/java/org/modelix/mps/gitimport/fs/IFileBase.java
+++ b/mps-git-import/src/main/java/org/modelix/mps/gitimport/fs/IFileBase.java
@@ -1,0 +1,15 @@
+package org.modelix.mps.gitimport.fs;
+
+import jetbrains.mps.vfs.IFile;
+
+/**
+ * Implemented in Java instead of Kotlin on purpose: depending on the MPS version,
+ * {@code stepIntoArchive()} is either an abstract member of {@link IFile} or doesn't exist at all.
+ * Kotlin requires the {@code override} modifier in the first case and forbids it in the second,
+ * while a plain Java method compiles against both.
+ */
+public abstract class IFileBase implements IFile {
+    public IFile stepIntoArchive() {
+        throw new UnsupportedOperationException("Not an archive: " + getPath());
+    }
+}

--- a/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/DummyMPSProject.kt
+++ b/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/DummyMPSProject.kt
@@ -5,7 +5,7 @@ import jetbrains.mps.project.persistence.ProjectDescriptorPersistence
 import jetbrains.mps.project.structure.project.ModulePath
 import jetbrains.mps.util.MacrosFactory
 import jetbrains.mps.vfs.IFile
-import jetbrains.mps.vfs.IFileSystem
+import jetbrains.mps.vfs.openapi.FileSystem
 import org.jetbrains.mps.openapi.module.SModule
 import org.jetbrains.mps.openapi.module.SModuleReference
 import org.jetbrains.mps.openapi.module.SRepository
@@ -73,8 +73,8 @@ class DummyMPSProject(
         return moduleEntries.mapNotNull { it.resolve() }
     }
 
-    override fun getFileSystem(): IFileSystem {
-        return projectDir.fs
+    override fun getFileSystem(): FileSystem {
+        return projectDir.fileSystem
     }
 
     override fun getBasePath(): String? {

--- a/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/fs/GitObjectAsVirtualFile.kt
+++ b/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/fs/GitObjectAsVirtualFile.kt
@@ -22,7 +22,7 @@ class GitObjectAsVirtualFile(
     private val isDirectory: Boolean,
     private val objectId: AnyObjectId,
     private val repository: Repository,
-) : IFile {
+) : IFileBase() {
     private val children: Sequence<GitObjectAsVirtualFile> = if (!isDirectory) {
         emptySequence()
     } else {

--- a/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/fs/MutableGitDirectoryOrFile.kt
+++ b/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/fs/MutableGitDirectoryOrFile.kt
@@ -25,7 +25,7 @@ class MutableGitDirectoryOrFile(
     private val gitFS: MutableGitFS,
     private val parent: MutableGitDirectoryOrFile?,
     private val name: String,
-) : IFile {
+) : IFileBase() {
     private var content: Content = NonExisting()
 
     override fun getName() = name

--- a/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/fs/NonExistingFile.kt
+++ b/mps-git-import/src/main/kotlin/org/modelix/mps/gitimport/fs/NonExistingFile.kt
@@ -9,7 +9,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.URL
 
-class NonExistingFile(private val parent: IFile, private val name: String) : IFile {
+class NonExistingFile(private val parent: IFile, private val name: String) : IFileBase() {
     override fun getFileSystem(): FileSystem {
         TODO("Not yet implemented")
     }

--- a/mps-model-adapters-plugin/build.gradle.kts
+++ b/mps-model-adapters-plugin/build.gradle.kts
@@ -36,7 +36,7 @@ intellij {
 tasks {
     patchPluginXml {
         sinceBuild.set("222")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {

--- a/mps-model-adapters-plugin/build.gradle.kts
+++ b/mps-model-adapters-plugin/build.gradle.kts
@@ -1,9 +1,10 @@
 import org.jetbrains.intellij.tasks.PrepareSandboxTask
 import org.modelix.buildtools.KnownModuleIds
 import org.modelix.buildtools.buildStubsSolutionJar
+import org.modelix.configureMpsTestClasspath
+import org.modelix.configureMpsTestTask
 import org.modelix.copyMps
 import org.modelix.excludeMPSLibraries
-import org.modelix.mpsHomeDir
 import org.modelix.mpsMajorVersion
 import kotlin.io.resolve
 import kotlin.jvm.java
@@ -25,6 +26,8 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
+configureMpsTestClasspath()
+
 intellij {
     localPath = copyMps().absolutePath
     instrumentCode = false
@@ -45,19 +48,11 @@ tasks {
     }
 
     test {
+        configureMpsTestTask()
         onlyIf {
             !setOf(
                 "2022.2", // hangs when executed on CI
             ).contains(mpsMajorVersion)
-        }
-        jvmArgs("-Dintellij.platform.load.app.info.from.resources=true")
-
-        val arch = System.getProperty("os.arch")
-        val jnaDir = mpsHomeDir.get().asFile.resolve("lib/jna/$arch")
-        if (jnaDir.exists()) {
-            jvmArgs("-Djna.boot.library.path=${jnaDir.absolutePath}")
-            jvmArgs("-Djna.noclasspath=true")
-            jvmArgs("-Djna.nosys=true")
         }
     }
 

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IMPSProject.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/IMPSProject.kt
@@ -5,7 +5,7 @@ import jetbrains.mps.ide.project.ProjectHelper
 import jetbrains.mps.module.ModuleDeleteHelper
 import jetbrains.mps.project.MPSProject
 import jetbrains.mps.project.ProjectBase
-import jetbrains.mps.vfs.IFileSystem
+import jetbrains.mps.vfs.openapi.FileSystem
 import org.jetbrains.mps.openapi.module.SModule
 import org.jetbrains.mps.openapi.module.SRepository
 import org.jetbrains.mps.openapi.project.Project
@@ -25,7 +25,13 @@ interface IMPSProject {
     fun deleteModule(module: SModule)
     fun getModules(): List<SModule>
 
-    fun getFileSystem(): IFileSystem
+    /**
+     * Returns the project's file system.
+     *
+     * Uses the openapi [FileSystem] interface as the common type across MPS versions: since 2025.1 the
+     * project's file system no longer implements jetbrains.mps.vfs.IFileSystem.
+     */
+    fun getFileSystem(): FileSystem
     fun getBasePath(): String?
 }
 
@@ -71,8 +77,14 @@ data class MPSProjectAdapter(val mpsProject: Project) : IMPSProject {
         )
     }
 
-    override fun getFileSystem(): IFileSystem {
-        return (mpsProject as MPSProject).fileSystem
+    @Suppress("DEPRECATION", "USELESS_CAST")
+    override fun getFileSystem(): FileSystem {
+        // The cast is required for MPS versions where MPSProject.fileSystem is typed as IFileSystem,
+        // which is unrelated to the openapi FileSystem at compile time but always implements it at runtime.
+        val fileSystem = checkNotNull((mpsProject as MPSProject).fileSystem) {
+            "File system of project $mpsProject is null"
+        }
+        return fileSystem as FileSystem
     }
 
     override fun getBasePath(): String? {

--- a/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSWritableNode.kt
+++ b/mps-model-adapters/src/main/kotlin/org/modelix/model/mpsadapters/MPSWritableNode.kt
@@ -151,6 +151,10 @@ data class MPSWritableNode(val node: SNode) : IWritableNode, ISyncTargetNode {
 
     override fun removeChild(child: IWritableNode) {
         require(child is MPSWritableNode) { "child must be an MPSWritableNode" }
+        // A node whose model is already gone (e.g. its containing model was deleted earlier in the
+        // same synchronization) is effectively already removed. On MPS 2025.1+ detaching it would
+        // make its references direct against a null source model and throw an NPE, so skip it.
+        if (child.node.model == null) return
         node.removeChild(child.node)
     }
 

--- a/mps-sync-plugin3/build.gradle.kts
+++ b/mps-sync-plugin3/build.gradle.kts
@@ -67,7 +67,7 @@ configureMpsTestClasspath()
 tasks {
     patchPluginXml {
         sinceBuild.set("222")
-        untilBuild.set("241.*")
+        untilBuild.set("251.*")
     }
 
     buildSearchableOptions {

--- a/mps-sync-plugin3/build.gradle.kts
+++ b/mps-sync-plugin3/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.jetbrains.intellij.tasks.PrepareSandboxTask
 import org.modelix.buildtools.KnownModuleIds
 import org.modelix.buildtools.buildStubsSolutionJar
+import org.modelix.configureMpsTestClasspath
+import org.modelix.configureMpsTestTask
 import org.modelix.copyMps
 import org.modelix.mpsHomeDir
 import org.modelix.mpsPlatformVersion
@@ -60,6 +62,8 @@ dependencies {
     testImplementation(libs.ktor.client.cio, excludeMPSLibraries)
 }
 
+configureMpsTestClasspath()
+
 tasks {
     patchPluginXml {
         sinceBuild.set("222")
@@ -75,18 +79,10 @@ tasks {
     }
 
     test {
+        configureMpsTestTask()
         dependsOn(":model-server:jibDockerBuild")
         jvmArgs("-Dmodelix.model.server.image=modelix/model-server:$version")
-        jvmArgs("-Dintellij.platform.load.app.info.from.resources=true")
         jvmArgs("-Xmx1000m")
-
-        val arch = System.getProperty("os.arch")
-        val jnaDir = mpsHomeDir.get().asFile.resolve("lib/jna/$arch")
-        if (jnaDir.exists()) {
-            jvmArgs("-Djna.boot.library.path=${jnaDir.absolutePath}")
-            jvmArgs("-Djna.noclasspath=true")
-            jvmArgs("-Djna.nosys=true")
-        }
     }
 
     val mpsPluginDir = project.findProperty("mps$mpsPlatformVersion.plugins.dir")?.toString()?.let { file(it) }


### PR DESCRIPTION
Make the necessary changes to support MPS 2022.2..2025.1 from a single codebase.

- mps-model-adapters: use the cross-version supertype `jetbrains.mps.vfs.openapi.FileSystem` for `IMPSProject.getFileSystem()`, since MPS 2024.3+ no longer has `IdeaFileSystem` implement the old `IFileSystem`.
- mps-sync-plugin3: boot the IntelliJ Platform Plugin 1.x test framework on MPS 2025.1 (platform >= 251): add `lib/modules/*.jar` to the test runtime classpath so the platform can register module services such as SettingsController, and keep the vanilla kotlinx-coroutines-core off the test runtime classpath so MPS's bundled coroutines fork is used.
- mps-git-import: implement `IFile.stepIntoArchive()`, which is abstract as of MPS 2025.1, in a Java base class (`IFileBase`). Java methods don't need an override marker, so the same source compiles both against MPS versions where the method exists and where it doesn't.
- ci: add MPS 2025.1 to the mps-compatibility matrix, and build mps-git-import and mps-git-import-plugin in the matrix for MPS 2024.1+ (the versions they support) so incompatibilities with non-default MPS versions are caught on CI.