### PR TITLE
fix(mps-sync-plugin): use BrowserUtil instead of java.awt.Desktop for login

### DIFF
--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
@@ -1,5 +1,6 @@
 package org.modelix.mps.sync3.ui
 
+import com.intellij.ide.BrowserUtil
 import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionManager
@@ -28,10 +29,8 @@ import org.modelix.mps.api.ModelixMpsApi
 import org.modelix.mps.sync3.IBinding
 import org.modelix.mps.sync3.IModelSyncService
 import org.modelix.mps.sync3.IServerConnection
-import java.awt.Desktop
 import java.awt.Point
 import java.awt.event.MouseEvent
-import java.net.URI
 import java.util.concurrent.TimeUnit
 import javax.swing.Icon
 import javax.swing.JComponent
@@ -64,11 +63,10 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
                 val authRequests = IModelSyncService.getInstance(project).getUsedServerConnections()
                     .flatMap { it.getPendingAuthRequests() }.toSet()
                 if (authRequests.isNotEmpty()) {
-                    val desktop = Desktop.getDesktop()
-                    if (desktop.isSupported(Desktop.Action.BROWSE)) {
-                        for (authRequest in authRequests) {
-                            desktop.browse(URI.create(authRequest.getUrl()))
-                        }
+                    // java.awt.Desktop.BROWSE is unavailable on many Linux setups; BrowserUtil uses it on
+                    // Windows/macOS where it works, and falls back to xdg-open etc. on Linux
+                    for (authRequest in authRequests) {
+                        BrowserUtil.browse(authRequest.getUrl())
                     }
                     return true
                 } else {


### PR DESCRIPTION
## Summary
- The status bar widget's "Click to log in" handler used `java.awt.Desktop.Action.BROWSE` to open the OAuth authorization URL.
- On many Linux desktops (including current Arch/KDE), OpenJDK's `Desktop` peer reports `BROWSE` as unsupported (it depends on the long-obsolete GNOME 2 / gnome-vfs libraries). When unsupported, the click handler silently did nothing and logged nothing, leaving users unable to log in.
- Replaced the `Desktop.browse(...)` call with `com.intellij.ide.BrowserUtil.browse(...)`, which falls back to `xdg-open` and other platform mechanisms that work on modern Linux desktops.
- This is a Linux-specific fix: `Desktop.Action.BROWSE` is natively supported on Windows and macOS, where `BrowserUtil` uses `Desktop.browse` directly, so behavior there is unchanged.

## Test plan
- [x] Verified `Desktop.Action.BROWSE` is unsupported with the bundled JBR 17 and system OpenJDK 11/17/21/26 on Arch Linux/KDE/Wayland.
- [x] Built `mps-sync-plugin3` jar with the patch, swapped it into a local SECURE RCP installation, and confirmed clicking the "Click to log in" status widget now opens the default browser to the OIDC authorization URL.
