### PR TITLE
ci: fixed sarif command line

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Combine SARIF files
         run: |
-          npx @microsoft/sarif-multitool merge --merge-runs --output-file merged.sarif  $(find . -iname '*.sarif*')
+          npx @microsoft/sarif-multitool@5.1.1 merge --output-file merged.sarif  $(find . -iname '*.sarif*')
         env:
           # Disables globalization support.
           # This makes the @microsoft/sarif-multitool work without ICU package installed.

--- a/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexIntervalTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/HistoryIndexIntervalTest.kt
@@ -1,7 +1,7 @@
 package org.modelix.model.server
 
 import io.ktor.server.testing.ApplicationTestBuilder
-import io.ktor.server.testing.testApplication
+import io.ktor.server.testing.runTestApplication
 import io.ktor.test.dispatcher.runTestWithRealTime
 import mu.KotlinLogging
 import org.modelix.datastructures.history.AttributesAggregation
@@ -28,7 +28,7 @@ class HistoryIndexIntervalTest {
     private lateinit var statistics: StoreClientWithStatistics
     private fun runTest(block: suspend ApplicationTestBuilder.() -> Unit) = runTestWithRealTime(timeout = 3.minutes) {
         retryOnTimeout(30.seconds) {
-            testApplication {
+            runTestApplication {
                 application {
                     try {
                         installDefaultServerPlugins()


### PR DESCRIPTION
The `--merge-runs` argument seems to be gone in the latest version and is now the default behavior.