### PR TITLE
fix(model-datastructure,model-client): load older readonly versions via a correct backward delta

### DIFF
--- a/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
+++ b/model-client/src/commonMain/kotlin/org/modelix/model/client2/ModelClientV2.kt
@@ -512,6 +512,19 @@ class ModelClientV2(
         return doLoadVersion(repositoryId, versionHash, baseVersion)
     }
 
+    /**
+     * Loads a version as a delta against [baseVersion] using an explicit [filter]. Used for readonly version
+     * browsing, where only the tree is needed (no history, no operations). See #1042.
+     */
+    suspend fun loadVersion(
+        repositoryId: RepositoryId,
+        versionHash: String,
+        baseVersion: IVersion?,
+        filter: ObjectDeltaFilter,
+    ): IVersion {
+        return doLoadVersion(repositoryId, versionHash, baseVersion, filter)
+    }
+
     override suspend fun lazyLoadVersion(
         repositoryId: RepositoryId,
         versionHash: String,
@@ -530,6 +543,7 @@ class ModelClientV2(
         repositoryId: RepositoryId?,
         versionHash: String,
         baseVersion: IVersion?,
+        filter: ObjectDeltaFilter? = null,
     ): IVersion {
         checkCreatedByThisClient(baseVersion, repositoryId)
         val httpClient = if (repositoryId == null) {
@@ -545,7 +559,10 @@ class ModelClientV2(
                 } else {
                     appendPathSegments("repositories", repositoryId.id, "versions", versionHash)
                 }
-                if (baseVersion != null) {
+                if (filter != null) {
+                    // The filter already carries the known/base versions; it fully describes what to send.
+                    parameters["filter"] = filter.toJson()
+                } else if (baseVersion != null) {
                     parameters["lastKnown"] = (baseVersion as CLVersion).getContentHash()
                 }
             }

--- a/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
+++ b/model-client/src/jsMain/kotlin/org/modelix/model/client2/ClientJS.kt
@@ -16,6 +16,7 @@ import org.modelix.datastructures.model.historyAsMutationParameters
 import org.modelix.datastructures.objects.ObjectHash
 import org.modelix.kotlin.utils.DelicateModelixApi
 import org.modelix.model.IVersion
+import org.modelix.model.ObjectDeltaFilter
 import org.modelix.model.TreeId
 import org.modelix.model.api.INode
 import org.modelix.model.api.INodeReference
@@ -283,7 +284,16 @@ internal class ClientJSImpl(private val modelClient: ModelClientV2) : ClientJS {
     private val lastReadonlyVersion = mutableMapOf<RepositoryId, IVersion>()
 
     private suspend fun loadReadonlyVersionWithDelta(repositoryId: RepositoryId, versionHash: String): IVersion {
-        return modelClient.loadVersion(repositoryId, versionHash, lastReadonlyVersion[repositoryId])
+        val baseVersion = lastReadonlyVersion[repositoryId]
+        // Readonly browsing only needs the tree, not history or operations. Delta against the previously
+        // loaded version so only the changed tree objects are transferred (#1042).
+        val filter = ObjectDeltaFilter(
+            knownVersions = setOfNotNull(baseVersion?.getContentHash()),
+            includeOperations = false,
+            includeHistory = false,
+            includeTrees = true,
+        )
+        return modelClient.loadVersion(repositoryId, versionHash, baseVersion, filter)
             .also { lastReadonlyVersion[repositoryId] = it }
     }
 

--- a/model-client/src/jsTest/kotlin/org/modelix/model/client2/ReadonlyVersionDeltaLoadJsTest.kt
+++ b/model-client/src/jsTest/kotlin/org/modelix/model/client2/ReadonlyVersionDeltaLoadJsTest.kt
@@ -10,27 +10,27 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.await
 import kotlinx.coroutines.promise
+import org.modelix.model.ObjectDeltaFilter
 import org.modelix.model.lazy.CLTree
 import org.modelix.model.lazy.CLVersion
 import org.modelix.model.lazy.RepositoryId
 import org.modelix.model.server.api.v2.VersionDeltaStreamV2
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 /**
- * B2a (#1042): readonly versions should be loaded as a delta against the previously loaded
- * version of the same repository, so the surviving object graph is reused instead of being
- * reloaded in full on every version switch. The presence of the `lastKnown` query parameter is
- * what tells the server to send a delta, so it is the observable signal we assert on.
+ * B2a (#1042): readonly versions are loaded as a delta against the previously loaded version of the same
+ * repository, so only the changed tree objects are transferred on a version switch. The request carries an
+ * [ObjectDeltaFilter] (the observable signal): its `knownVersions` is the delta base, and history/operations
+ * are excluded because readonly browsing only needs the tree.
  */
 class ReadonlyVersionDeltaLoadJsTest {
 
     /** A real, offline version: its root hash plus the serialized objects of its full closure. */
     private class VersionFixture(val versionHash: String, val objects: List<Pair<String, String>>)
 
-    /** A client wired to a [MockEngine] that records the `lastKnown` parameter of every request. */
-    private class RecordingClient(val client: ClientJSImpl, val lastKnownParams: List<String?>)
+    /** A client wired to a [MockEngine] that records the parsed `filter` of every request. */
+    private class RecordingClient(val client: ClientJSImpl, val filters: List<ObjectDeltaFilter?>)
 
     /** Builds a single, real, offline [CLVersion] and serializes its whole object closure. */
     private fun buildVersionFixture(): VersionFixture {
@@ -65,12 +65,12 @@ class ReadonlyVersionDeltaLoadJsTest {
         return sb.toString()
     }
 
-    /** A [ClientJSImpl] whose engine always returns [fixture] and records each `lastKnown` param. */
+    /** A [ClientJSImpl] whose engine always returns [fixture] and records each request's parsed `filter`. */
     private fun recordingClient(fixture: VersionFixture): RecordingClient {
         val deltaBody = encodeDelta(fixture.versionHash, fixture.objects)
-        val lastKnownParams = mutableListOf<String?>()
+        val filters = mutableListOf<ObjectDeltaFilter?>()
         val mockEngine = MockEngine { request ->
-            lastKnownParams.add(request.url.parameters["lastKnown"])
+            filters.add(request.url.parameters["filter"]?.let { ObjectDeltaFilter.fromJson(it) })
             respond(
                 deltaBody,
                 HttpStatusCode.OK,
@@ -81,7 +81,15 @@ class ReadonlyVersionDeltaLoadJsTest {
             .client(HttpClient(mockEngine))
             .url("http://localhost/v2")
             .build()
-        return RecordingClient(ClientJSImpl(modelClient), lastKnownParams)
+        return RecordingClient(ClientJSImpl(modelClient), filters)
+    }
+
+    private fun assertLeanReadonlyFilter(filter: ObjectDeltaFilter?, expectedBase: String?, message: String) {
+        checkNotNull(filter) { "$message: expected a readonly delta filter on the request" }
+        assertEquals(setOfNotNull(expectedBase), filter.knownVersions, "$message: wrong delta base")
+        assertEquals(false, filter.includeHistory, "$message: readonly load must not request history")
+        assertEquals(false, filter.includeOperations, "$message: readonly load must not request operations")
+        assertEquals(true, filter.includeTrees, "$message: readonly load must request the tree")
     }
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -90,18 +98,18 @@ class ReadonlyVersionDeltaLoadJsTest {
         val fixture = buildVersionFixture()
         val recording = recordingClient(fixture)
 
-        // First readonly load of repo1: nothing known yet -> full load.
+        // First readonly load of repo1: nothing known yet -> no delta base.
         recording.client.loadReadonlyVersion("repo1", fixture.versionHash).await()
         // Second readonly load of repo1: the previously loaded version must be the delta base.
         recording.client.loadReadonlyVersion("repo1", fixture.versionHash).await()
-        // A different repo has its own (empty) memo -> full load again.
+        // A different repo has its own (empty) memo -> no delta base.
         recording.client.loadReadonlyVersion("repo2", fixture.versionHash).await()
 
-        val params = recording.lastKnownParams
-        assertEquals(3, params.size, "expected one request per readonly load")
-        assertNull(params[0], "first load of a repo must not send a delta base")
-        assertEquals(fixture.versionHash, params[1], "second load of the same repo must send the previous version as delta base")
-        assertNull(params[2], "first load of a different repo must not send a delta base")
+        val filters = recording.filters
+        assertEquals(3, filters.size, "expected one request per readonly load")
+        assertLeanReadonlyFilter(filters[0], expectedBase = null, message = "first load of a repo")
+        assertLeanReadonlyFilter(filters[1], expectedBase = fixture.versionHash, message = "second load of the same repo")
+        assertLeanReadonlyFilter(filters[2], expectedBase = null, message = "first load of a different repo")
     }
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -124,13 +132,13 @@ class ReadonlyVersionDeltaLoadJsTest {
         // ...then load another readonly version of the same repo via loadReadonlyVersion.
         recording.client.loadReadonlyVersion("repo1", fixture.versionHash).await()
 
-        val params = recording.lastKnownParams
-        assertEquals(2, params.size, "expected one request per readonly load")
-        assertNull(params[0], "first readonly load of a repo must not send a delta base")
-        assertEquals(
-            fixture.versionHash,
-            params[1],
-            "loadReadonlyVersion must reuse the version remembered by startReplicatedModels",
+        val filters = recording.filters
+        assertEquals(2, filters.size, "expected one request per readonly load")
+        assertLeanReadonlyFilter(filters[0], expectedBase = null, message = "first readonly load of a repo")
+        assertLeanReadonlyFilter(
+            filters[1],
+            expectedBase = fixture.versionHash,
+            message = "loadReadonlyVersion must reuse the version remembered by startReplicatedModels",
         )
     }
 }

--- a/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
+++ b/model-datastructure/src/commonMain/kotlin/org/modelix/model/lazy/CLVersion.kt
@@ -367,15 +367,23 @@ class CLVersion(val obj: Object<CPVersion>) : IVersion {
 fun IVersion.diff(knownVersions: List<IVersion>, filter: ObjectDeltaFilter = ObjectDeltaFilter()): IStream.Many<Object<IObjectData>> {
     this as CLVersion
 
-    val unknownHistory: List<CLVersion> = historyDiff(knownVersions).toList().map { it as CLVersion }
+    // Nothing to send if the peer already has the requested version.
+    if (knownVersions.any { it.getObjectHash() == getObjectHash() }) return IStream.empty()
 
-    if (unknownHistory.isEmpty()) return IStream.empty()
+    val unknownHistory: List<CLVersion> = historyDiff(knownVersions).toList().map { it as CLVersion }
 
     val allKnownVersions: MutableMap<ObjectHash, CLVersion> = knownVersions
         .associate { it.getObjectHash() to (it as CLVersion) }
         .toMutableMap()
 
-    val includedVersions = if (filter.includeHistory) unknownHistory else listOf(this)
+    // Always include the requested version itself. Going backward (the requested version is an ancestor of
+    // a known version) [unknownHistory] is empty, yet the requested version's tree still differs from the
+    // known versions and must be diffed and sent. Going forward [this] is already part of [unknownHistory].
+    val includedVersions = when {
+        !filter.includeHistory -> listOf(this)
+        unknownHistory.any { it.getObjectHash() == getObjectHash() } -> unknownHistory
+        else -> unknownHistory + this
+    }
     return IStream.many(includedVersions.reversed()).flatMap { version ->
         var result: IStream.Many<Object<IObjectData>> = IStream.of(version.asObject())
         if (filter.includeTrees) {

--- a/model-datastructure/src/commonTest/kotlin/VersionBackwardDiffTest.kt
+++ b/model-datastructure/src/commonTest/kotlin/VersionBackwardDiffTest.kt
@@ -1,0 +1,73 @@
+import org.modelix.datastructures.objects.getDescendantsAndSelf
+import org.modelix.model.ObjectDeltaFilter
+import org.modelix.model.api.IConceptReference
+import org.modelix.model.api.ITree
+import org.modelix.model.lazy.CLTree
+import org.modelix.model.lazy.CLVersion
+import org.modelix.model.lazy.createObjectStoreCache
+import org.modelix.model.lazy.diff
+import org.modelix.model.persistent.MapBasedStore
+import org.modelix.model.persistent.getTreeObject
+import org.modelix.streams.getBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * #1042: when a peer that already holds a version `B` requests an *older* version `T` (an ancestor of `B`,
+ * i.e. backward navigation between readonly versions), the delta must contain the tree objects that are
+ * unique to `T` so the peer can fully load `T`. Previously `IVersion.diff` short-circuited to an empty
+ * stream whenever `T` added no new history over `B`, which is always true going backward, leaving the
+ * client without `T`'s tree -> "Entry not found".
+ */
+class VersionBackwardDiffTest {
+
+    private val store = createObjectStoreCache(MapBasedStore())
+
+    private fun treeHashes(tree: ITree): Set<String> =
+        tree.getTreeObject().getDescendantsAndSelf().toList().getBlocking(store).map { it.getHashString() }.toSet()
+
+    @Test
+    fun backwardDeltaContainsTargetTreeObjects() {
+        val tree1 = CLTree.builder(store).repositoryId("test").build()
+            .addNewChild(ITree.ROOT_ID, "children", 0, 100, null as IConceptReference?)
+            .addNewChild(ITree.ROOT_ID, "children", 1, 101, null as IConceptReference?)
+        val v1 = CLVersion.createRegularVersion(
+            id = 1L,
+            time = null,
+            author = null,
+            tree = tree1,
+            baseVersion = null,
+            operations = emptyArray(),
+        )
+
+        val tree2 = tree1
+            .setProperty(100, "name", "changed")
+            .addNewChild(ITree.ROOT_ID, "children", 2, 102, null as IConceptReference?)
+        val v2 = CLVersion.createRegularVersion(
+            id = 2L,
+            time = null,
+            author = null,
+            tree = tree2,
+            baseVersion = v1,
+            operations = emptyArray(),
+        )
+
+        val v1TreeHashes = treeHashes(tree1)
+        val v2TreeHashes = treeHashes(tree2)
+
+        // Both the default filter and the lean (readonly) filter must yield a complete backward delta.
+        val filters = listOf(
+            ObjectDeltaFilter(),
+            ObjectDeltaFilter(includeHistory = false, includeOperations = false, includeTrees = true),
+        )
+        for (filter in filters) {
+            // A peer that holds v2's tree asks for the older v1 as a delta against v2.
+            val deltaHashes = v1.diff(listOf(v2), filter).toList().getBlocking(store)
+                .map { it.getHashString() }.toSet()
+
+            // Everything needed to load v1's tree must be available from v2's tree plus the delta.
+            val missing = v1TreeHashes - (v2TreeHashes + deltaHashes)
+            assertEquals(emptySet(), missing, "filter=$filter omitted v1 tree objects: $missing")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Loading an **older** readonly version as a delta against a newer one (backward navigation between readonly versions — added in 19.2.0, #2750) produced an **empty delta**. `IVersion.diff` short-circuited to an empty stream whenever the requested version added no new history over the known base, which is always the case when the target is an *ancestor* of the base. The server then sent only the version object, and the client could not resolve the older version's tree → "An internal error occurred while loading the data from model-server: Entry not found: …".

`IVersion.diff` had only ever been exercised forward (pull tracks a branch head), so the backward case was a latent gap that #2750 was the first to hit.

## Fix

`IVersion.diff` now always includes the requested version itself in `includedVersions` and only early-returns when the requested version is already known to the peer. Going backward it therefore emits the version's tree diff against the closest known base (mirroring the forward case) instead of nothing.

Readonly version loads additionally request a lean filter (`includeHistory=false`, `includeOperations=false`, `includeTrees=true`) via a new `ModelClientV2.loadVersion(…, filter)` overload, since browsing a readonly version only needs the tree.

## Tests

- New `VersionBackwardDiffTest` (model-datastructure): a backward delta must contain every tree object needed to load the older version — verified for both the default and the lean filter. Fails before the fix, passes after.
- `ReadonlyVersionDeltaLoadJsTest` updated to assert the lean readonly filter.
- Full `model-datastructure` suite green (no regression in diff/revert/conflict/merge); `model-client` JS tests green.
- End-to-end on the local docker stack: with this build deployed as the model-server, switching backward through four progressively older readonly versions loads cleanly with no error toast.

Fixes the regression from 19.2.0 (#2750).

🤖 Generated with [Claude Code](https://claude.com/claude-code)