### PR TITLE
refactor(mps-sync-plugin): simplify status tooltip — fold read-only and last-change into the status line

### DIFF
--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
@@ -16,15 +16,11 @@ import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.popup.PopupFactoryImpl
 import com.intellij.util.Consumer
 import com.intellij.util.concurrency.EdtExecutorService
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlinx.html.br
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
 import kotlinx.html.table
 import kotlinx.html.td
 import kotlinx.html.tr
-import org.modelix.model.lazy.CLVersion
 import org.modelix.mps.api.ModelixMpsApi
 import org.modelix.mps.sync3.IBinding
 import org.modelix.mps.sync3.IModelSyncService
@@ -142,107 +138,26 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
             }
             for (connection in connections) {
                 div {
-                    div {
-                        styleX = "font-weight: bold; text-decoration: underline;"
-                        +"Connection"
-                    }
-                    div {
-                        styleX = "padding-left: 20px"
-                        table {
-                            tr {
-                                td {
-                                    styleX = "font-weight: bold"
-                                    +"URL: "
-                                }
-                                td {
-                                    +connection.getUrl()
-                                }
+                    table {
+                        tr {
+                            td {
+                                styleX = "font-weight: bold"
+                                +connection.getUrl()
                             }
-                            tr {
-                                td {
-                                    styleX = "font-weight: bold"
-                                    +"Status: "
-                                }
-                                td {
-                                    +connection.getStatus().toString()
-                                }
-                            }
-                            connection.getPendingAuthRequests().forEach { request ->
-                                tr {
-                                    td {
-                                        styleX = "font-weight: bold"
-                                        +"Authorization URL: "
-                                    }
-                                    td {
-                                        +request.getUrl()
-                                    }
-                                }
+                            td {
+                                styleX = "padding-left: 20px"
+                                +connection.getStatus().toString()
                             }
                         }
                         for (binding in connection.getBindings()) {
-                            div {
-                                styleX = "font-weight: bold; text-decoration: underline;"
-                                +"Project Binding"
-                            }
-                            div {
-                                styleX = "padding-left: 20px"
-                                table {
-                                    tr {
-                                        td {
-                                            styleX = "font-weight: bold"
-                                            +"Repository:"
-                                        }
-                                        td {
-                                            +binding.getBranchRef().repositoryId.id
-                                        }
-                                    }
-                                    tr {
-                                        td {
-                                            styleX = "font-weight: bold"
-                                            +"Branch:"
-                                        }
-                                        td {
-                                            +binding.getBranchRef().branchName
-                                        }
-                                    }
-                                    tr {
-                                        td {
-                                            styleX = "font-weight: bold"
-                                            +"Enabled:"
-                                        }
-                                        td {
-                                            +if (binding.isEnabled()) "ENABLED" else "DISABLED"
-                                        }
-                                    }
-                                    tr {
-                                        td {
-                                            styleX = "font-weight: bold"
-                                            +"Access:"
-                                        }
-                                        td {
-                                            +if (binding.isReadonly()) "read-only" else "writable"
-                                        }
-                                    }
-                                    tr {
-                                        td {
-                                            styleX = "font-weight: bold"
-                                            +"Version:"
-                                        }
-                                        td {
-                                            val version = binding.getCurrentVersion()
-                                            if (version != null) {
-                                                +version.getContentHash()
-                                                br()
-                                                +(version as? CLVersion)
-                                                    ?.getTimestamp()
-                                                    ?.toLocalDateTime(TimeZone.currentSystemDefault())
-                                                    ?.toString()
-                                                    .orEmpty()
-                                                br()
-                                                +(version as? CLVersion)?.author.orEmpty()
-                                            }
-                                        }
-                                    }
+                            tr {
+                                td {
+                                    styleX = "padding-left: 20px"
+                                    +"${binding.getBranchRef().repositoryId.id} / ${binding.getBranchRef().branchName}"
+                                }
+                                td {
+                                    styleX = "padding-left: 20px"
+                                    +bindingStatusText(binding)
                                 }
                             }
                         }
@@ -250,6 +165,22 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
                 }
             }
         }.finalize()
+    }
+
+    /**
+     * A compact, single-line sync state for a binding. Read-only bindings are marked with a
+     * `(readonly)` suffix; writable bindings show no suffix (writable is the implicit default).
+     */
+    private fun bindingStatusText(binding: IBinding): String {
+        val status = when (val status = binding.getStatus()) {
+            IBinding.Status.Disabled -> "Disabled"
+            IBinding.Status.Initializing -> "Initializing"
+            is IBinding.Status.Synced -> "Synced ${status.versionHash.take(5)}"
+            is IBinding.Status.Syncing -> "Syncing ${status.progress().orEmpty()}"
+            is IBinding.Status.Error -> "Error: ${status.message.orEmpty()}"
+            is IBinding.Status.NoPermission -> "No permission for ${status.user.orEmpty()}"
+        }
+        return if (binding.isReadonly()) "$status (readonly)" else status
     }
 
     private fun getText(): @NlsContexts.Label String {

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
@@ -16,11 +16,15 @@ import com.intellij.ui.awt.RelativePoint
 import com.intellij.ui.popup.PopupFactoryImpl
 import com.intellij.util.Consumer
 import com.intellij.util.concurrency.EdtExecutorService
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
 import kotlinx.html.table
 import kotlinx.html.td
 import kotlinx.html.tr
+import org.modelix.model.lazy.CLVersion
 import org.modelix.mps.api.ModelixMpsApi
 import org.modelix.mps.sync3.IBinding
 import org.modelix.mps.sync3.IModelSyncService
@@ -168,19 +172,47 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
     }
 
     /**
-     * A compact, single-line sync state for a binding. Read-only bindings are marked with a
-     * `(readonly)` suffix; writable bindings show no suffix (writable is the implicit default).
+     * A compact, single-line sync state for a binding. Extra details are folded into a
+     * parenthesized, comma-joined suffix: the last-change timestamp (only for the `Synced` status,
+     * when available) and `readonly` for read-only bindings. Writable bindings without a timestamp
+     * show no suffix (writable is the implicit default).
      */
     private fun bindingStatusText(binding: IBinding): String {
+        val details = mutableListOf<String>()
         val status = when (val status = binding.getStatus()) {
             IBinding.Status.Disabled -> "Disabled"
             IBinding.Status.Initializing -> "Initializing"
-            is IBinding.Status.Synced -> "Synced ${status.versionHash.take(5)}"
+            is IBinding.Status.Synced -> {
+                formatLastChange(binding)?.let { details.add("last change: $it") }
+                "Synced ${status.versionHash.take(5)}"
+            }
             is IBinding.Status.Syncing -> "Syncing ${status.progress().orEmpty()}"
             is IBinding.Status.Error -> "Error: ${status.message.orEmpty()}"
             is IBinding.Status.NoPermission -> "No permission for ${status.user.orEmpty()}"
         }
-        return if (binding.isReadonly()) "$status (readonly)" else status
+        if (binding.isReadonly()) details.add("readonly")
+        return if (details.isEmpty()) status else "$status (${details.joinToString(", ")})"
+    }
+
+    /**
+     * Formats the current version's timestamp in the system time zone. If the change happened
+     * today, only the time is shown (`HH:mm`), otherwise the full date and time (`dd.MM.yyyy HH:mm`).
+     * Returns `null` when no timestamp is available.
+     */
+    private fun formatLastChange(binding: IBinding): String? {
+        val timestamp = (binding.getCurrentVersion() as? CLVersion)?.getTimestamp() ?: return null
+        val zone = TimeZone.currentSystemDefault()
+        val dateTime = timestamp.toLocalDateTime(zone)
+        val today = Clock.System.now().toLocalDateTime(zone).date
+        val hour = dateTime.hour.toString().padStart(2, '0')
+        val minute = dateTime.minute.toString().padStart(2, '0')
+        val time = "$hour:$minute"
+        if (dateTime.date == today) {
+            return time
+        }
+        val day = dateTime.dayOfMonth.toString().padStart(2, '0')
+        val month = dateTime.monthNumber.toString().padStart(2, '0')
+        return "$day.$month.${dateTime.year} $time"
     }
 
     private fun getText(): @NlsContexts.Label String {

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
@@ -217,6 +217,15 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
                                     tr {
                                         td {
                                             styleX = "font-weight: bold"
+                                            +"Access:"
+                                        }
+                                        td {
+                                            +if (binding.isReadonly()) "read-only" else "writable"
+                                        }
+                                    }
+                                    tr {
+                                        td {
+                                            styleX = "font-weight: bold"
                                             +"Version:"
                                         }
                                         td {

--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/ModelSyncStatusWidget.kt
@@ -40,6 +40,9 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
     companion object {
         private val LOG = mu.KotlinLogging.logger { }
         const val ID = "ModelixSyncStatus"
+
+        /** Number of leading characters of a version hash shown in the status text and tooltip. */
+        private const val VERSION_HASH_DISPLAY_LENGTH = 5
         val ICON: Icon? = runCatching { ModelixMpsApi.loadIcon("org/modelix/mps/sync3/modelix16.svg", this::class.java) }
             .onFailure { LOG.error(it) { "Failed to load icon" } }
             .getOrNull()
@@ -184,7 +187,7 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
             IBinding.Status.Initializing -> "Initializing"
             is IBinding.Status.Synced -> {
                 formatLastChange(binding)?.let { details.add("last change: $it") }
-                "Synced ${status.versionHash.take(5)}"
+                "Synced ${status.versionHash.take(VERSION_HASH_DISPLAY_LENGTH)}"
             }
             is IBinding.Status.Syncing -> "Syncing ${status.progress().orEmpty()}"
             is IBinding.Status.Error -> "Error: ${status.message.orEmpty()}"
@@ -233,7 +236,7 @@ class ModelSyncStatusWidget(val project: Project) : CustomStatusBarWidget, Statu
                 result = when (val status = binding.getStatus()) {
                     IBinding.Status.Disabled -> "Disabled"
                     IBinding.Status.Initializing -> "Initializing"
-                    is IBinding.Status.Synced -> "Synchronized: ${status.versionHash.take(5)}"
+                    is IBinding.Status.Synced -> "Synchronized: ${status.versionHash.take(VERSION_HASH_DISPLAY_LENGTH)}"
                     is IBinding.Status.Syncing -> "Synchronizing: ${status.progress()}"
                     is IBinding.Status.Error -> "Synchronization failed: ${status.message}"
                     is IBinding.Status.NoPermission -> "${status.user} has no permission on ${binding.getBranchRef().repositoryId}"


### PR DESCRIPTION
Simplifies the model-sync status-bar tooltip and enriches the per-binding status line.

## Changes
- **Flatten the layout** — drop the bold "Connection" / "Project Binding" headings and the nested indented tables. Each connection is one header row (URL + status); each binding is one compact line beneath it (`repo / branch` + status).
- **Fold read-only into the status** — read-only bindings get a `(readonly)` suffix; writable is implicit (no suffix).
- **Show the last-change time** — for `Synced` bindings, append the current version's timestamp: `(last change: HH:mm)` if today, `(last change: dd.MM.yyyy HH:mm)` otherwise (system timezone). Combined with read-only → `(last change: …, readonly)`.

Example:
```
https://…/secure.repository            CONNECTED
  2026_06_16_linked / main              Synced hIZha (last change: 15:01)
  2025_06_01_catalog / versions/1.0.0   Synced CT4Wl (last change: 17.05.2026 02:22, readonly)
```

## Dropped vs. the old tooltip (all intentional, for compactness)
- "Connection" / "Project Binding" headings; explicit `URL:` / `Status:` / `Repository:` / `Branch:` labels (now positional)
- `Enabled:` flag — a disabled binding still shows `Disabled` as its status
- Version author; full content hash (now the 5-char prefix, matching the status-bar text)
- The `Authorization URL:` row — clicking the widget still opens the pending auth URL in the browser, so the login flow is unchanged