### PR TITLE
fix(mps-sync-plugin): open the primary (writable) repo in "Open in Browser"

### DIFF
--- a/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/OpenFrontendAction.kt
+++ b/mps-sync-plugin3/src/main/kotlin/org/modelix/mps/sync3/ui/OpenFrontendAction.kt
@@ -12,9 +12,17 @@ class OpenFrontendAction() : AnAction("Open in Browser") {
     fun getFrontendUrls(project: Project): List<String> {
         val service = IModelSyncService.getInstance(project)
 
-        return service.getBindings().filter { it.isEnabled() }.map {
-            ModelClientV2.getFrontendUrl(it.getConnection().getUrl(), it.getBranchRef())
-        }
+        // Order the bindings so the primary (writable) repository comes first, ahead of any
+        // read-only dependencies (e.g. a writable TARA followed by the read-only catalogs it
+        // depends on). "Open in Browser" then opens the first entry. This mirrors
+        // ModelSyncStatusWidget, which likewise orders by read-only state to single out the
+        // modifiable binding.
+        return service.getBindings()
+            .filter { it.isEnabled() }
+            .sortedBy { it.isReadonly() }
+            .map {
+                ModelClientV2.getFrontendUrl(it.getConnection().getUrl(), it.getBranchRef())
+            }
     }
 
     override fun update(e: AnActionEvent) {
@@ -22,8 +30,7 @@ class OpenFrontendAction() : AnAction("Open in Browser") {
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-        for (url in getFrontendUrls(e.project ?: return)) {
-            BrowserUtil.open(url)
-        }
+        val url = getFrontendUrls(e.project ?: return).firstOrNull() ?: return
+        BrowserUtil.open(url)
     }
 }

--- a/mps-sync-plugin3/src/test/kotlin/org/modelix/mps/sync3/ProjectSyncTest.kt
+++ b/mps-sync-plugin3/src/test/kotlin/org/modelix/mps/sync3/ProjectSyncTest.kt
@@ -814,6 +814,51 @@ class ProjectSyncTest : ProjectSyncTestBase() {
         assertEquals("http://my-frontend.example.com/sync-test/branchA/overview", URL(urls.single()).toURI().resolve(response.headers["Location"]).toString())
     }
 
+    fun `test open in browser lists the writable binding first`(): Unit = runWithModelServer { port ->
+        // A project with two active bindings: a read-only dependency catalog (listed first) and a
+        // writable TARA (listed second). "Open in Browser" opens the first returned URL, so the
+        // writable repository must be sorted ahead of the read-only one regardless of the order
+        // they were persisted in.
+        openTestProject("initial") { projectDir ->
+            projectDir.resolve(".mps").resolve("modelix.xml").writeText(
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project version="4">
+                  <component name="modelix-sync">
+                    <binding>
+                      <enabled>true</enabled>
+                      <url>http://localhost:$port</url>
+                      <repository>readonly-catalog</repository>
+                      <branch>release</branch>
+                      <readonly>true</readonly>
+                    </binding>
+                    <binding>
+                      <enabled>true</enabled>
+                      <url>http://localhost:$port</url>
+                      <repository>writable-tara</repository>
+                      <branch>main</branch>
+                      <readonly>false</readonly>
+                    </binding>
+                  </component>
+                </project>
+                """.trimIndent(),
+            )
+        }
+
+        val action = OpenFrontendAction()
+        val urls = action.getFrontendUrls(project)
+
+        // The writable repository is first (the one "Open in Browser" opens); the read-only
+        // catalog follows.
+        assertEquals(
+            listOf(
+                "http://localhost:$port/v2/repositories/writable-tara/branches/main/frontend",
+                "http://localhost:$port/v2/repositories/readonly-catalog/branches/release/frontend",
+            ),
+            urls,
+        )
+    }
+
     fun `test loading enabled persisted binding`(): Unit = runPersistedBindingTest(true)
     fun `test loading disabled persisted binding`(): Unit = runPersistedBindingTest(false)
 


### PR DESCRIPTION
## Problem

`OpenFrontendAction` ("Open in Browser") built a frontend URL for **every enabled binding**, so a project that binds a writable repository plus one or more read-only dependency repositories opened a read-only dependency (and one browser tab per binding) instead of the writable repository the user expects.

## Fix

`getFrontendUrls()` now orders enabled bindings writable-first (`sortedBy { it.isReadonly() }`, matching the existing `ModelSyncStatusWidget` ordering) and stays a general accessor; the action opens only the first entry — the primary/writable repo. Also fixes the "opens every binding in its own tab" behavior.

Adds a `ProjectSyncTest` covering one writable + one read-only binding (asserts the writable repo's URL comes first).