### PR TITLE
fix(model-server): index model.repository to speed up repository deletion

### DIFF
--- a/model-server/src/main/kotlin/org/modelix/model/server/SqlUtils.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/SqlUtils.kt
@@ -90,6 +90,48 @@ internal class SqlUtils(private val connection: Connection) {
         return false
     }
 
+    /**
+     * Checks whether an index with the given name exists but is marked INVALID in the catalog.
+     *
+     * An index built with `CREATE INDEX CONCURRENTLY` that is interrupted (e.g. the connection or
+     * pod dies mid-build) is left behind in an INVALID state: it is unusable by the query planner,
+     * yet a later `CREATE INDEX IF NOT EXISTS` — and [isIndexExisting], which via `getIndexInfo`
+     * also reports invalid indexes — would treat the name as taken and never rebuild it. Detecting
+     * the invalid state lets the caller drop and recreate the index instead of skipping it forever.
+     *
+     * Returns `false` when no such index exists (`to_regclass` yields NULL, matching no row).
+     */
+    @Throws(SQLException::class)
+    fun isIndexInvalid(schemaName: String, indexName: String): Boolean {
+        connection.prepareStatement(
+            """
+                SELECT NOT i.indisvalid AS is_invalid
+                FROM pg_index i
+                WHERE i.indexrelid = to_regclass(?)
+            """.trimIndent(),
+        ).use { stmt ->
+            stmt.setString(1, "$schemaName.$indexName")
+            stmt.executeQuery().use { rs ->
+                return rs.next() && rs.getBoolean("is_invalid")
+            }
+        }
+    }
+
+    /**
+     * Ensures the index exists and is valid, (re)building it via the supplied [creationSql].
+     *
+     * The caller is expected to supply a `CREATE INDEX CONCURRENTLY` statement so schema
+     * initialization does not take a table-level `ShareLock` that would block every writer for the
+     * whole (potentially minutes-long, multi-GB) build. `CREATE`/`DROP INDEX CONCURRENTLY` may not
+     * run inside a transaction block, so the connection must be in autocommit mode. The
+     * model-server's `PGPoolingDataSource` hands out autocommit connections and the other `ensure*`
+     * DDL here already relies on that; should autocommit somehow be off we enable it for these
+     * statements and restore the previous value afterwards.
+     *
+     * If a leftover INVALID index (see [isIndexInvalid]) is present it is dropped — also
+     * CONCURRENTLY — before recreating. The operation is idempotent: valid index → no-op, absent →
+     * create, invalid → drop and recreate.
+     */
     @Throws(SQLException::class)
     fun ensureIndexIsPresent(
         schemaName: String,
@@ -97,9 +139,24 @@ internal class SqlUtils(private val connection: Connection) {
         indexName: String,
         creationSql: String,
     ) {
-        if (!isIndexExisting(schemaName, tableName, indexName)) {
-            val stmt = connection.createStatement()
-            stmt.execute(creationSql)
+        val previousAutoCommit = connection.autoCommit
+        if (!previousAutoCommit) {
+            connection.autoCommit = true
+        }
+        try {
+            if (isIndexInvalid(schemaName, indexName)) {
+                LOG.warn("Dropping leftover invalid index $schemaName.$indexName before rebuilding it.")
+                val dropStmt = connection.createStatement()
+                dropStmt.execute("DROP INDEX CONCURRENTLY IF EXISTS $schemaName.$indexName;")
+            }
+            if (!isIndexExisting(schemaName, tableName, indexName)) {
+                val stmt = connection.createStatement()
+                stmt.execute(creationSql)
+            }
+        } finally {
+            if (!previousAutoCommit) {
+                connection.autoCommit = previousAutoCommit
+            }
         }
     }
 
@@ -164,11 +221,17 @@ internal class SqlUtils(private val connection: Connection) {
             // `DELETE FROM model WHERE repository = ?`, which would otherwise degrade to a
             // sequential scan over the entire table (all repositories) and time out for large
             // deployments. A `repository`-leading index makes that DELETE an index scan.
+            //
+            // Build the index CONCURRENTLY so this schema-init step does not take a table-level
+            // ShareLock that blocks all writers for the whole build (on large, multi-GB tables that
+            // build takes long enough to stall a rolling deploy or trip a pod's startup/liveness
+            // probe). CONCURRENTLY requires autocommit and cannot run in a transaction block; the
+            // datasource connection is autocommit, which `ensureIndexIsPresent` also verifies.
             ensureIndexIsPresent(
                 schemaName,
                 "model",
                 "model_repository_idx",
-                "CREATE INDEX IF NOT EXISTS model_repository_idx ON $schemaName.model (repository);",
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS model_repository_idx ON $schemaName.model (repository);",
             )
         } catch (e: SQLException) {
             LOG.error("Failed to initialize the database schema", e)

--- a/model-server/src/main/kotlin/org/modelix/model/server/SqlUtils.kt
+++ b/model-server/src/main/kotlin/org/modelix/model/server/SqlUtils.kt
@@ -79,6 +79,31 @@ internal class SqlUtils(private val connection: Connection) {
     }
 
     @Throws(SQLException::class)
+    fun isIndexExisting(schemaName: String, tableName: String, indexName: String): Boolean {
+        val metadata: DatabaseMetaData = connection.metaData
+        val indexRS: ResultSet = metadata.getIndexInfo(null, schemaName, tableName, false, false)
+        while (indexRS.next()) {
+            if (indexRS.getString("INDEX_NAME") == indexName) {
+                return true
+            }
+        }
+        return false
+    }
+
+    @Throws(SQLException::class)
+    fun ensureIndexIsPresent(
+        schemaName: String,
+        tableName: String,
+        indexName: String,
+        creationSql: String,
+    ) {
+        if (!isIndexExisting(schemaName, tableName, indexName)) {
+            val stmt = connection.createStatement()
+            stmt.execute(creationSql)
+        }
+    }
+
+    @Throws(SQLException::class)
     fun ensureSchemaIsPresent(schemaName: String, username: String) {
         if (!isSchemaExisting(schemaName)) {
             val stmt = connection.createStatement()
@@ -133,6 +158,17 @@ internal class SqlUtils(private val connection: Connection) {
                         add constraint model_pkey
                             primary key (key, repository);
                 """,
+            )
+            // The primary key `(key, repository)` is key-leading, so an equality filter on the
+            // trailing `repository` column cannot use it. Repository deletion runs
+            // `DELETE FROM model WHERE repository = ?`, which would otherwise degrade to a
+            // sequential scan over the entire table (all repositories) and time out for large
+            // deployments. A `repository`-leading index makes that DELETE an index scan.
+            ensureIndexIsPresent(
+                schemaName,
+                "model",
+                "model_repository_idx",
+                "CREATE INDEX IF NOT EXISTS model_repository_idx ON $schemaName.model (repository);",
             )
         } catch (e: SQLException) {
             LOG.error("Failed to initialize the database schema", e)

--- a/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresRepositoryRemovalTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresRepositoryRemovalTest.kt
@@ -131,4 +131,23 @@ class IgnitePostgresRepositoryRemovalTest {
             store.runWrite { store.removeRepositoryObjects(RepositoryId("invalid")) }
         }
     }
+
+    @Test
+    fun `schema initialization creates an index on the repository column`() {
+        // Repository deletion runs `DELETE FROM model WHERE repository = ?`.
+        // Without an index leading with the `repository` column, that DELETE degrades to a
+        // sequential scan over the whole `model` table (all repositories), which times out for
+        // large deployments. Schema initialization must therefore create such an index.
+        dbConnection.prepareStatement(
+            """
+                SELECT 1 FROM pg_indexes
+                WHERE schemaname = 'modelix' AND tablename = 'model' AND indexname = 'model_repository_idx'
+            """.trimIndent(),
+        ).use {
+            val result = it.executeQuery()
+            assertTrue("Expected index `model_repository_idx` on modelix.model to exist after schema init.") {
+                result.isBeforeFirst
+            }
+        }
+    }
 }

--- a/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresRepositoryRemovalTest.kt
+++ b/model-server/src/test/kotlin/org/modelix/model/server/store/IgnitePostgresRepositoryRemovalTest.kt
@@ -150,4 +150,26 @@ class IgnitePostgresRepositoryRemovalTest {
             }
         }
     }
+
+    @Test
+    fun `schema initialization creates a valid repository index`() {
+        // The index is built with `CREATE INDEX CONCURRENTLY`. An interrupted CONCURRENTLY build
+        // leaves an INVALID (planner-unusable) index behind, so it is not enough that the index
+        // exists — it must also be marked valid (`pg_index.indisvalid = true`).
+        dbConnection.prepareStatement(
+            """
+                SELECT i.indisvalid
+                FROM pg_index i
+                WHERE i.indexrelid = to_regclass('modelix.model_repository_idx')
+            """.trimIndent(),
+        ).use {
+            val result = it.executeQuery()
+            assertTrue("Expected index `model_repository_idx` on modelix.model to exist after schema init.") {
+                result.next()
+            }
+            assertTrue("Expected index `model_repository_idx` to be valid (indisvalid) after schema init.") {
+                result.getBoolean("indisvalid")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Deleting a repository (observed with a large TARA repo, `secure-repository-service` → model-server) times out at the client's socket timeout and fails. The delete cost scales with **total server data, not with the repo being deleted**.

## Root cause

`removeRepositoryObjectsFromDatabase` runs `DELETE FROM model WHERE repository = ?` (`IgniteStoreClient.kt:178`). The `model` table's only index is the composite primary key `(key, repository)` — **key-leading** (`SqlUtils.kt`). Postgres cannot range-scan a composite index on its trailing column for an equality on that column alone, so this `DELETE` becomes a **sequential scan of the entire `model` table** (every object of every repository) on every repository delete. On a populated server this exceeds the client socket timeout.

## Fix

Add a `repository`-leading index so the bulk delete uses an index scan:

```sql
CREATE INDEX IF NOT EXISTS model_repository_idx ON <schema>.model (repository);
```

Created during schema init in `SqlUtils.kt` via a new `ensureIndexIsPresent` helper (analogue of the existing `ensureColumnIsPresent`), so existing deployments pick it up on next startup. Doubly idempotent: a `DatabaseMetaData.getIndexInfo` pre-check plus `CREATE INDEX IF NOT EXISTS`.

## Test

`IgnitePostgresRepositoryRemovalTest` gains a case asserting `model_repository_idx` exists in `pg_indexes` after schema init (Testcontainers Postgres).

## Verification status

- ktlint (pre-commit) ✅
- detekt `:model-server:detektMain` + `:model-server:detektTest` ✅
- compile + non-container tests ✅
- ⚠️ The Testcontainers Postgres tests (incl. the new one) could **not** be run in the authoring environment (no Docker daemon). **Please confirm the full `:model-server:jvmTest` passes in CI/a Docker-capable environment before merge.**

## Not in scope (secondary follow-up)

`IgniteStoreClient.removeRepositoryObjects` (`IgniteStoreClient.kt:128-147`) still evicts cache entries via a full-cache `ScanQuery` across all repositories — O(total cached data) per delete. The DB index fixes the dominant timeout cause; partitioning/affinity-keying the cache by repository so eviction is O(repo size) is recommended future work, deliberately left out of this focused fix.

---
_Investigation and fix drafted with AI assistance (Claude)._