### PR TITLE
ci: fix pre-commit node hooks under Node 24 / pre-commit 4.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,17 +31,25 @@ repos:
           # IMPORTANT: keep in sync with the version configured in build.gradle.kts
           - --ktlint-version=0.50.0
           - --autofix
-  - repo: https://github.com/pre-commit/mirrors-prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
+    # Maintained fork of the now-archived pre-commit/mirrors-prettier.
     # IMPORTANT: keep in sync with the version configured in `vue-model-api/package.json`
-    rev: v3.1.0
+    rev: v3.9.5
     hooks:
       - id: prettier
+        # Node 24's npm refuses pre-commit's `npm install git+file://` hook
+        # bootstrap (EALLOWGIT). Pin this node hook to a Node 22 LTS toolchain
+        # whose npm still permits it; independent of the .nvmrc repo runtime.
+        language_version: "22.22.2"
         files: ^(vue-model-api)|(model-api-gen-gradle-test/vue-integration)|(model-client-js-test/model-client-connection)/
   - repo: "local"
     hooks:
       - id: eslint
         name: ESLint
-        language: node
+        # `language: system` runs the project's own `npm run lint` (deps from
+        # `npm ci`); a `language: node` local hook requires package.json/
+        # additional_dependencies under pre-commit >=4.6 and errors otherwise.
+        language: system
         entry: npm
         args: [ "run", "lint" ]
         types: [ file ]


### PR DESCRIPTION
## Problem

The `pre-commit` (Code linting) check fails on **every** open PR — and for local devs on Node 24. Two distinct `language: node` breakages, the second masked by the first:

1. The **prettier** mirror hook can't install its env:
   ```
   npm install --allow-git=root -g git+file:///.../pre-commit/<repo> prettier@...
   npm error code EALLOWGIT — Refusing to fetch "placeholder_package@git+file:///..."
   ```
   `.nvmrc` pins Node **24.15.0**, whose npm refuses pre-commit's non-root `git+file://` hook bootstrap.

2. Once prettier is fixed, the **local `eslint` hook** then fails:
   ```
   AssertionError: `language: node` must have package.json or additional_dependencies
   ```
   pre-commit **≥ 4.6** (CI runs 4.6.1) always builds an isolated node env for `language: node` hooks, so the local eslint hook — which has no deps and just shells out to `npm run lint` — errors.

## Fix

- **prettier**: pin *only this hook* to Node 22 LTS via `language_version: "22.22.2"`, whose npm permits the `git+file://` bootstrap. Scoped per-hook on purpose — a repo-wide `default_language_version: node` would force a nodeenv on the eslint hook too and re-trigger issue (2).
- **eslint**: change the local hook `language: node` → `language: system`, so it runs the project's own `npm run lint` (eslint from `npm ci`) instead of a pre-commit-managed node env.

Both are independent of the `.nvmrc` repo runtime and fix CI **and** local `pre-commit` runs.

Also bundled (hygiene): migrate the archived `pre-commit/mirrors-prettier@v3.1.0` → maintained fork `rbubley/mirrors-prettier@v3.9.5`, realigning the stale "keep in sync with `vue-model-api/package.json`" pin (package.json is on `3.9.5`).

## Validation

Reproduced CI's toolchain locally (pre-commit 4.6.1): all `pre-commit-hooks`, KTLint, and **prettier Passed**; the eslint AssertionError is gone (it now runs `npm run lint`). Unblocks the `pre-commit` check across all open PRs.

---
_Drafted with AI assistance (Claude)._